### PR TITLE
fix: Adjust event count display in DebugMenu

### DIFF
--- a/src/components/molecules/DebugMenu/DebugMenu.tsx
+++ b/src/components/molecules/DebugMenu/DebugMenu.tsx
@@ -152,7 +152,7 @@ const DebugMenu = () => {
 							{eventsCompleted ? (
 								<>
 									<p className='text-sm text-muted-foreground mb-4'>
-										{eventCount} events have been fired for
+										{eventCount * 5} events have been fired for
 										<Link to={`${RouteNames.customers}/${customerData?.items[0]?.id}`} className='text-blue-500'>
 											{` ${customerData?.items[0]?.name} `}
 										</Link>


### PR DESCRIPTION
- Multiply event count by 5 to reflect total simulated events
- Maintain link to customer details with updated event count