### PR TITLE
fix(invoice): remove price_id for invoice creation

### DIFF
--- a/src/pages/customer/invoices/CreateInvoice.tsx
+++ b/src/pages/customer/invoices/CreateInvoice.tsx
@@ -86,14 +86,12 @@ const CreateInvoicePage: FC = () => {
 				customer_id: customerId!,
 				invoice_type: 'ONE_OFF',
 				currency,
-				price_id: 'usd',
 				amount_due: calculateSubtotal().toString(),
 				period_start: today.toISOString(),
 				line_items: lineItems.map((item) => ({
 					display_name: item.display_name,
 					quantity: item.quantity,
 					amount: parseFloat(item.amount || '0') * parseFloat(item.quantity || '0'),
-					price_id: 'usd',
 				})),
 			});
 		},

--- a/src/utils/api_requests/InvoiceApi.ts
+++ b/src/utils/api_requests/InvoiceApi.ts
@@ -39,7 +39,6 @@ interface GetInvoicePreviewPayload {
 
 interface CreateOneOffInvoicePayload {
 	customer_id: string;
-	price_id: string;
 	invoice_type: 'ONE_OFF';
 	currency: string;
 	amount_due: string;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `price_id` from invoice creation payload in `CreateInvoice.tsx` and `InvoiceApi.ts`.
> 
>   - **Behavior**:
>     - Remove `price_id` from invoice creation payload in `CreateInvoice.tsx` and `InvoiceApi.ts`.
>     - Invoice creation now only requires `customer_id`, `invoice_type`, `currency`, `amount_due`, `period_start`, and `line_items`.
>   - **Misc**:
>     - Update `CreateOneOffInvoicePayload` interface in `InvoiceApi.ts` to remove `price_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for 5764cd6b36dbc55f0ab5eabe1901f460fb5a5578. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->