### PR TITLE
feat(plan): add published filter in pricing widget

### DIFF
--- a/src/pages/product-catalog/plans/Pricing.tsx
+++ b/src/pages/product-catalog/plans/Pricing.tsx
@@ -150,7 +150,7 @@ const PricingPage = () => {
 	const navigate = useNavigate();
 
 	const fetchPlans = async () => {
-		return await PlanApi.getAllPlans({
+		return await PlanApi.getAllActivePlans({
 			limit,
 			offset,
 		});

--- a/src/utils/api_requests/PlanApi.ts
+++ b/src/utils/api_requests/PlanApi.ts
@@ -20,8 +20,10 @@ export class PlanApi {
 			`${this.baseUrl}?limit=${limit}&offset=${offset}&expand=entitlements%2Cprices%2Cmeters%2Cfeatures`,
 		);
 	}
-	public static async getAllActivePlans() {
-		return await AxiosClient.get<GetAllPlansResponse>(`${this.baseUrl}?status=published`);
+	public static async getAllActivePlans({ limit, offset }: PaginationType) {
+		return await AxiosClient.get<GetAllPlansResponse>(
+			`${this.baseUrl}?status=published&limit=${limit}&offset=${offset}&expand=entitlements%2Cprices%2Cmeters%2Cfeatures`,
+		);
 	}
 
 	public static async getExpandedPlan() {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add published filter to pricing widget by fetching only active plans with pagination in `Pricing.tsx`.
> 
>   - **Behavior**:
>     - `fetchPlans` in `Pricing.tsx` now uses `PlanApi.getAllActivePlans` to fetch only published plans.
>     - `getAllActivePlans` in `PlanApi.ts` updated to accept `limit` and `offset` for pagination.
>   - **API**:
>     - `getAllActivePlans` in `PlanApi.ts` now includes pagination parameters in the request URL.
>   - **Misc**:
>     - Renames `getAllPlans` to `getAllActivePlans` in `Pricing.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for 00421561b00a01548325f159c32792f1a2781cb2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->