### PR TITLE
feat(events): copy complete object

### DIFF
--- a/src/components/molecules/Events/EventPropertiesDrawer.tsx
+++ b/src/components/molecules/Events/EventPropertiesDrawer.tsx
@@ -14,7 +14,7 @@ interface Props {
 const EventPropertiesDrawer: FC<Props> = ({ isOpen, onOpenChange, event }) => {
 	const handleCopyCode = () => {
 		if (!event) return;
-		navigator.clipboard.writeText(JSON.stringify(event.properties, null, 2));
+		navigator.clipboard.writeText(JSON.stringify(event, null, 2));
 		toast.success('Properties copied to clipboard!');
 	};
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `handleCopyCode` in `EventPropertiesDrawer.tsx` now copies the entire `event` object to the clipboard.
> 
>   - **Behavior**:
>     - In `EventPropertiesDrawer.tsx`, `handleCopyCode` now copies the entire `event` object instead of just `event.properties` to the clipboard.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for 61f508e7c147be207c693e5b650290ad880c71f3. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->