### PR TITLE
Feat/plan overrides

### DIFF
--- a/src/components/organisms/Subscription/PriceOverrideSummary.tsx
+++ b/src/components/organisms/Subscription/PriceOverrideSummary.tsx
@@ -4,6 +4,7 @@ import { SubscriptionLineItemOverrideRequest } from '@/utils/common/price_overri
 import { formatAmount } from '@/components/atoms/Input/Input';
 import { getCurrencySymbol } from '@/utils/common/helper_functions';
 import { CheckCircle } from 'lucide-react';
+import { Card } from '@/components/atoms';
 
 interface Props {
 	overrides: SubscriptionLineItemOverrideRequest[];
@@ -15,12 +16,12 @@ const PriceOverrideSummary: FC<Props> = ({ overrides, prices, className }) => {
 	if (overrides.length === 0) return null;
 
 	return (
-		<div className={`bg-blue-50 border border-blue-200 rounded-lg p-4 ${className}`}>
+		<Card className={`border bg-gray-50 rounded-lg p-4 ${className}`}>
 			<div className='flex items-start gap-3'>
-				<CheckCircle className='w-5 h-5 text-blue-600 mt-0.5' />
-				<div className='flex-1'>
-					<h4 className='font-medium text-blue-900 mb-2'>Price Overrides Applied ({overrides.length})</h4>
-					<div className='space-y-2'>
+				<CheckCircle className='w-5 h-5  mt-0.5 flex-shrink-0' />
+				<div className='flex-1 min-w-0'>
+					<h4 className='font-medium mb-3'>Price Overrides Applied ({overrides.length})</h4>
+					<div className='space-y-3'>
 						{overrides.map((override) => {
 							const price = prices.find((p) => p.id === override.price_id);
 							if (!price) return null;
@@ -30,9 +31,9 @@ const PriceOverrideSummary: FC<Props> = ({ overrides, prices, className }) => {
 							const currencySymbol = getCurrencySymbol(price.currency);
 
 							return (
-								<div key={override.price_id} className='flex items-center justify-between text-sm'>
-									<span className='text-blue-800'>{price.meter?.name || price.description || 'Charge'}</span>
-									<span className='text-blue-700 font-medium'>
+								<div key={override.price_id} className='flex items-center justify-between text-sm text-muted-foreground'>
+									<span className='truncate'>{price.meter?.name || price.description || 'Charge'}</span>
+									<span className='ml-2 flex-shrink-0'>
 										{currencySymbol}
 										{originalAmount} → {currencySymbol}
 										{newAmount}
@@ -43,7 +44,7 @@ const PriceOverrideSummary: FC<Props> = ({ overrides, prices, className }) => {
 					</div>
 				</div>
 			</div>
-		</div>
+		</Card>
 	);
 };
 

--- a/src/components/organisms/Subscription/PriceTable.tsx
+++ b/src/components/organisms/Subscription/PriceTable.tsx
@@ -49,10 +49,6 @@ const PriceTable: FC<Props> = ({ data, billingPeriod, currency, onPriceOverride,
 		setIsDialogOpen(true);
 	};
 
-	const handleDelete = async (priceId: string) => {
-		// This is not used for price overrides, but ActionButton requires it
-	};
-
 	const mappedData: ChargeTableData[] = (filteredPrices ?? []).map((price) => {
 		const isOverridable = price.billing_model === BILLING_MODEL.FLAT_FEE || price.billing_model === BILLING_MODEL.PACKAGE;
 		const isOverridden = overriddenPrices[price.id] !== undefined;
@@ -71,7 +67,7 @@ const PriceTable: FC<Props> = ({ data, billingPeriod, currency, onPriceOverride,
 				<ActionButton
 					editText={'Override Price'}
 					id={price.id}
-					deleteMutationFn={() => handleDelete(price.id)}
+					deleteMutationFn={() => Promise.resolve()}
 					refetchQueryKey='prices'
 					entityName={price.meter?.name || price.description || 'Charge'}
 					isEditDisabled={false}

--- a/src/components/organisms/Subscription/PriceTable.tsx
+++ b/src/components/organisms/Subscription/PriceTable.tsx
@@ -1,8 +1,8 @@
 import { FC, useState, useMemo } from 'react';
 import { ColumnData, FlexpriceTable, PriceOverrideDialog } from '@/components/molecules';
 import { Price, BILLING_MODEL } from '@/models/Price';
-import { ChevronDownIcon, ChevronUpIcon, Edit3 } from 'lucide-react';
-import { FormHeader, Button } from '@/components/atoms';
+import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+import { FormHeader, ActionButton } from '@/components/atoms';
 import { motion } from 'framer-motion';
 import ChargeValueCell from '@/pages/product-catalog/plans/ChargeValueCell';
 import { capitalize } from 'es-toolkit';
@@ -21,6 +21,7 @@ type ChargeTableData = {
 	quantity: string;
 	price: JSX.Element;
 	invoice_cadence: string;
+	actions?: JSX.Element;
 };
 
 const PriceTable: FC<Props> = ({ data, billingPeriod, currency, onPriceOverride, onResetOverride, overriddenPrices = {} }) => {
@@ -43,6 +44,15 @@ const PriceTable: FC<Props> = ({ data, billingPeriod, currency, onPriceOverride,
 		return filtered;
 	}, [data, billingPeriod, currency]);
 
+	const handleOverride = (price: Price) => {
+		setSelectedPrice(price);
+		setIsDialogOpen(true);
+	};
+
+	const handleDelete = async (priceId: string) => {
+		// This is not used for price overrides, but ActionButton requires it
+	};
+
 	const mappedData: ChargeTableData[] = (filteredPrices ?? []).map((price) => {
 		const isOverridable = price.billing_model === BILLING_MODEL.FLAT_FEE || price.billing_model === BILLING_MODEL.PACKAGE;
 		const isOverridden = overriddenPrices[price.id] !== undefined;
@@ -53,23 +63,22 @@ const PriceTable: FC<Props> = ({ data, billingPeriod, currency, onPriceOverride,
 			price: (
 				<ChargeValueCell
 					data={{ ...price, currency: price.currency } as any}
-					overriddenAmount={isOverridden ? overriddenPrices[price.id] : undefined}>
-					{isOverridable && (
-						<Button
-							variant='ghost'
-							size='sm'
-							onClick={() => {
-								setSelectedPrice(price);
-								setIsDialogOpen(true);
-							}}
-							className='ml-2 p-1 h-auto text-xs'>
-							<Edit3 className='w-3 h-3' />
-						</Button>
-					)}
-					{isOverridden && <span className='ml-2 text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded'>Override</span>}
-				</ChargeValueCell>
+					overriddenAmount={isOverridden ? overriddenPrices[price.id] : undefined}
+				/>
 			),
 			invoice_cadence: price.invoice_cadence,
+			actions: isOverridable ? (
+				<ActionButton
+					editText={'Override Price'}
+					id={price.id}
+					deleteMutationFn={() => handleDelete(price.id)}
+					refetchQueryKey='prices'
+					entityName={price.meter?.name || price.description || 'Charge'}
+					isEditDisabled={false}
+					isArchiveDisabled={true}
+					onEdit={() => handleOverride(price)}
+				/>
+			) : undefined,
 		};
 	});
 
@@ -91,6 +100,14 @@ const PriceTable: FC<Props> = ({ data, billingPeriod, currency, onPriceOverride,
 		{
 			fieldName: 'price',
 			title: 'Price',
+		},
+		{
+			fieldName: 'actions',
+			title: '',
+			width: 50,
+			align: 'center',
+			fieldVariant: 'interactive',
+			hideOnEmpty: true,
 		},
 	];
 

--- a/src/components/organisms/Subscription/SubscriptionWithOverrides.tsx
+++ b/src/components/organisms/Subscription/SubscriptionWithOverrides.tsx
@@ -94,7 +94,7 @@ const SubscriptionWithOverrides: FC<Props> = ({ prices, onCreateSubscription, cl
 			{/* Action buttons */}
 			<div className='flex gap-3 pt-4'>
 				<Button variant='outline' onClick={resetAllOverrides} disabled={!hasAnyOverrides()}>
-					Reset All Overrides
+					Reset
 				</Button>
 				<Button onClick={handleCreateSubscription} disabled={isSubmitting} className='flex-1'>
 					{isSubmitting ? 'Creating Subscription...' : 'Create Subscription'}

--- a/src/pages/product-catalog/plans/ChargeValueCell.tsx
+++ b/src/pages/product-catalog/plans/ChargeValueCell.tsx
@@ -7,11 +7,10 @@ import { getCurrencySymbol } from '@/utils/common/helper_functions';
 
 interface Props {
 	data: Price;
-	children?: React.ReactNode;
 	overriddenAmount?: string;
 }
 
-const ChargeValueCell = ({ data, children, overriddenAmount }: Props) => {
+const ChargeValueCell = ({ data, overriddenAmount }: Props) => {
 	// Use overridden amount if provided, otherwise use original price
 	const priceData = overriddenAmount ? { ...data, amount: overriddenAmount } : data;
 	const price = getPriceTableCharge(priceData as any, false);
@@ -35,7 +34,7 @@ const ChargeValueCell = ({ data, children, overriddenAmount }: Props) => {
 
 	return (
 		<div className='flex items-center gap-2'>
-			<div className={overriddenAmount ? 'text-blue-600 font-medium' : ''}>{price}</div>
+			<div className={overriddenAmount ? '' : ''}>{price}</div>
 			{isTiered && (
 				<TooltipProvider delayDuration={0}>
 					<Tooltip>
@@ -74,7 +73,6 @@ const ChargeValueCell = ({ data, children, overriddenAmount }: Props) => {
 					</Tooltip>
 				</TooltipProvider>
 			)}
-			{children && <span>{children}</span>}
 		</div>
 	);
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds price override functionality to subscription components with UI updates and new actions for managing overrides.
> 
>   - **Behavior**:
>     - Adds price override functionality to `PriceTable` and `SubscriptionWithOverrides`.
>     - Introduces `ActionButton` for overriding prices in `PriceTable`.
>     - Updates `PriceOverrideSummary` to use `Card` component for UI consistency.
>   - **UI Components**:
>     - Replaces `Button` with `ActionButton` in `PriceTable` for override actions.
>     - Modifies `ChargeValueCell` to remove children prop and adjust styling.
>     - Updates `SubscriptionWithOverrides` to include override summary and reset functionality.
>   - **Misc**:
>     - Minor UI adjustments in `PriceOverrideSummary` and `SubscriptionWithOverrides` for better layout and styling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for bf7bb5112592719fdb0e326d9ccf9e239d3a486d. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->