### PR TITLE
fix(IntercomMessenger): Update inactivity timeout to 15 minutes for intercom popup

### DIFF
--- a/src/core/services/intercom/IntercomMessenger.tsx
+++ b/src/core/services/intercom/IntercomMessenger.tsx
@@ -8,7 +8,8 @@ import { useQuery } from '@tanstack/react-query';
 import TenantApi from '@/api/TenantApi';
 import { TenantMetadataKey } from '@/models/Tenant';
 
-const INACTIVITY_TIMEOUT = 300_000; // 5 minutes
+// mseconds * seconds * minutes
+const INACTIVITY_TIMEOUT = 1000 * 60 * 15; // 15 minutes
 
 const IntercomMessenger = () => {
 	const { user } = useUser();

--- a/src/pages/auth/LandingSection.tsx
+++ b/src/pages/auth/LandingSection.tsx
@@ -58,7 +58,7 @@ const customerLogos = [
 	'/assets/svg/supervity_logo.svg',
 ];
 
-const ANIMATION_DURATION = 18; // seconds for one full loop
+const ANIMATION_DURATION = 35; // seconds for one full loop
 
 const LandingSection = () => {
 	const scrollRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update inactivity timeout for Intercom popup to 15 minutes and animation duration for customer logos to 35 seconds.
> 
>   - **Behavior**:
>     - Update `INACTIVITY_TIMEOUT` in `IntercomMessenger.tsx` to 15 minutes (from 5 minutes) for Intercom popup.
>     - Update `ANIMATION_DURATION` in `LandingSection.tsx` to 35 seconds (from 18 seconds) for customer logos animation loop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for 848ec5b6eb7dc6849ecb8b0f8ebc65347047cf1f. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->