### PR TITLE
refactor: Replace BaseEntityStatus with ENTITY_STATUS 

### DIFF
--- a/src/pages/product-catalog/plans/PlanDetailsPage.tsx
+++ b/src/pages/product-catalog/plans/PlanDetailsPage.tsx
@@ -90,7 +90,7 @@ const formatBillingPeriod = (billingPeriod: string) => {
 	}
 };
 
-const formatInvoiceCadence = (cadence: string): string => {
+export const formatInvoiceCadence = (cadence: string): string => {
 	switch (cadence.toUpperCase()) {
 		case 'ADVANCE':
 			return 'Advance';

--- a/src/types/dto/Price.ts
+++ b/src/types/dto/Price.ts
@@ -6,16 +6,14 @@ import Addon from '@/models/Addon';
 import Feature from '@/models/Feature';
 import { Meter } from '@/models/Meter';
 import { QueryFilter, TimeRangeFilter } from './base';
+import { Pagination } from '@/models/Pagination';
 
 export interface CreateBulkPriceRequest {
 	items: CreatePriceRequest[];
 }
 
-export interface GetAllPricesResponse {
-	prices: Price[];
-	total: number;
-	offset: number;
-	limit: number;
+export interface GetAllPricesResponse extends Pagination {
+	items: Price[];
 }
 
 export interface PriceFilter extends QueryFilter, TimeRangeFilter {
@@ -24,6 +22,7 @@ export interface PriceFilter extends QueryFilter, TimeRangeFilter {
 	entity_ids?: string[];
 	subscription_id?: string;
 	parent_price_id?: string;
+	meter_ids?: string[];
 }
 
 export interface CreatePriceRequest {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `BaseEntityStatus` with `ENTITY_STATUS` and enhance feature details to display linked prices for metered features.
> 
>   - **Behavior**:
>     - Replace `BaseEntityStatus` with `ENTITY_STATUS` in `FeatureDetails.tsx`.
>     - Display linked prices for metered features in `FeatureDetails.tsx`.
>   - **Data Models**:
>     - Extend `GetAllPricesResponse` with `Pagination` in `Price.ts`.
>     - Add `meter_ids` to `PriceFilter` in `Price.ts`.
>   - **Functions**:
>     - Export `formatInvoiceCadence` from `PlanDetailsPage.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for d3499eaeb1d1e849994755f4eda5f8b2b7b06c37. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->