### PR TITLE
feat(RecordPaymentTopup): add recorded_at field

### DIFF
--- a/src/types/dto/Payment.ts
+++ b/src/types/dto/Payment.ts
@@ -36,4 +36,5 @@ export interface RecordPaymentPayload {
 	payment_method_type: PAYMENT_METHOD_TYPE;
 	payment_gateway?: string;
 	process_payment?: boolean;
+	recorded_at?: Date;
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `recorded_at` field to `RecordPaymentTopup.tsx` and `RecordPaymentPayload` for offline payments, with validation to prevent future dates.
> 
>   - **Behavior**:
>     - Add `recorded_at` field to `RecordPaymentTopup.tsx` for offline payments, allowing users to optionally set the date when the payment was recorded.
>     - Validates `recorded_at` to ensure it is not set in the future.
>   - **Components**:
>     - Add `DatePicker` to `RecordPaymentTopup.tsx` for selecting `recorded_at` date.
>     - Update form reset logic in `RecordPaymentTopup.tsx` to include `recorded_at`.
>   - **Types**:
>     - Add `recorded_at` field to `RecordPaymentPayload` in `Payment.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for 7725d0964520cb9759851b9cedae1c8b316ea23c. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->