### PR TITLE
feat(PriceApi): add terminate option for prices

### DIFF
--- a/src/api/PriceApi.ts
+++ b/src/api/PriceApi.ts
@@ -32,6 +32,6 @@ export class PriceApi {
 	}
 
 	public static async DeletePrice(id: string) {
-		return await AxiosClient.delete(`${this.baseUrl}/${id}`);
+		return await AxiosClient.delete<void>(`${this.baseUrl}/${id}`, {});
 	}
 }

--- a/src/core/axios/verbs.ts
+++ b/src/core/axios/verbs.ts
@@ -39,8 +39,9 @@ export class AxiosClient {
 		return response as T;
 	}
 
-	public static async delete<T>(url: string): Promise<T> {
-		const response: AxiosResponse<T> = await axiosClient.delete(url);
+	public static async delete<T, D extends DataObject = any>(url: string, data?: D): Promise<T> {
+		const sanitizedData = sanitizeData(data);
+		const response: AxiosResponse<T> = await axiosClient.delete(url, { data: sanitizedData });
 		return response as T;
 	}
 }

--- a/src/pages/product-catalog/plans/PlanDetailsPage.tsx
+++ b/src/pages/product-catalog/plans/PlanDetailsPage.tsx
@@ -15,6 +15,7 @@ import { FEATURE_TYPE } from '@/models/Feature';
 import { useBreadcrumbsStore } from '@/store/useBreadcrumbsStore';
 import EntitlementApi from '@/api/EntitlementApi';
 import { PlanApi } from '@/api/PlanApi';
+import { PriceApi } from '@/api/PriceApi';
 import formatDate from '@/utils/common/format_date';
 import { getPriceTypeLabel } from '@/utils/common/helper_functions';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -134,6 +135,27 @@ const chargeColumns: ColumnData<Price>[] = [
 		title: 'Value',
 		render(rowData) {
 			return <ChargeValueCell data={rowData} />;
+		},
+	},
+	{
+		fieldVariant: 'interactive',
+		width: '30px',
+		hideOnEmpty: true,
+		render(row) {
+			return (
+				<ActionButton
+					deleteMutationFn={async () => {
+						await PriceApi.DeletePrice(row.id);
+					}}
+					archiveIcon={<Trash2 />}
+					archiveText='Terminate'
+					id={row.id}
+					isEditDisabled={true}
+					isArchiveDisabled={false}
+					refetchQueryKey={'fetchPlan'}
+					entityName='charge'
+				/>
+			);
 		},
 	},
 ];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add terminate option for prices in `PriceApi` and update `PlanDetailsPage` to include a termination button.
> 
>   - **Behavior**:
>     - `PriceApi.DeletePrice` now accepts an optional data parameter, allowing for more flexible DELETE requests.
>     - `PlanDetailsPage` adds a new column with an `ActionButton` to terminate prices using `PriceApi.DeletePrice`.
>   - **AxiosClient**:
>     - `delete<T, D>` method updated to accept and sanitize optional data parameter in `verbs.ts`.
>   - **UI**:
>     - Adds a "Terminate" button in `PlanDetailsPage` to allow users to terminate prices directly from the UI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for cb701c0756a93a26eb8bbacfd01505650921a8c5. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->