### PR TITLE
chore: add decimal.js dependency to package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "cmdk": "^1.0.0",
         "country-state-city": "^3.2.1",
         "date-fns": "^3.6.0",
+        "decimal.js": "^10.6.0",
         "es-toolkit": "^1.37.2",
         "framer-motion": "^12.4.2",
         "html2canvas": "^1.4.1",
@@ -6376,7 +6377,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "cmdk": "^1.0.0",
     "country-state-city": "^3.2.1",
     "date-fns": "^3.6.0",
+    "decimal.js": "^10.6.0",
     "es-toolkit": "^1.37.2",
     "framer-motion": "^12.4.2",
     "html2canvas": "^1.4.1",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `decimal.js` dependency to `package.json`.
> 
>   - **Dependencies**:
>     - Add `decimal.js` version `^10.6.0` to `dependencies` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for 71bba0902b2ec1be47c91beb9baaf8c5de50caa4. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->