### PR TITLE
feat(subscription): add SUBSCRIPTION_CANCELLATION_TYPE enum and updat…

### DIFF
--- a/src/components/organisms/Subscription/SubscriptionActionButton.tsx
+++ b/src/components/organisms/Subscription/SubscriptionActionButton.tsx
@@ -1,4 +1,4 @@
-import { BILLING_CYCLE, Subscription, SubscriptionPhase, SUBSCRIPTION_PRORATION_BEHAVIOR } from '@/models/Subscription';
+import { BILLING_CYCLE, Subscription, SubscriptionPhase, SUBSCRIPTION_PRORATION_BEHAVIOR, SUBSCRIPTION_CANCELLATION_TYPE } from '@/models/Subscription';
 import { SUBSCRIPTION_PRORATION_ACTION } from '@/models/Subscription';
 import { useMutation } from '@tanstack/react-query';
 import { CirclePause, CirclePlay, X, Plus } from 'lucide-react';
@@ -72,7 +72,7 @@ const SubscriptionActionButton: React.FC<Props> = ({ subscription }) => {
 		mutationFn: (id: string) =>
 			SubscriptionApi.cancelSubscription(id, {
 				proration_behavior: SUBSCRIPTION_PRORATION_BEHAVIOR.NONE,
-				cancellation_type: SUBSCRIPTION_PRORATION_ACTION.CANCELLATION,
+				cancellation_type: SUBSCRIPTION_CANCELLATION_TYPE.IMMEDIATE,
 			}),
 		onSuccess: async () => {
 			setState((prev) => ({ ...prev, isCancelModalOpen: false }));
@@ -92,29 +92,29 @@ const SubscriptionActionButton: React.FC<Props> = ({ subscription }) => {
 	const menuOptions: DropdownMenuOption[] = [
 		...(!isPaused && !isCancelled
 			? [
-					{
-						label: 'Pause Subscription',
-						icon: <CirclePause className='h-4 w-4' />,
-						onSelect: () => setState((prev) => ({ ...prev, isPauseModalOpen: true })),
-						disabled: isPaused || isCancelled,
-					},
-					{
-						label: 'Add Subscription Phase',
-						icon: <Plus className='h-4 w-4' />,
-						onSelect: () => setState((prev) => ({ ...prev, isAddPhaseModalOpen: true })),
-						disabled: isPaused || isCancelled,
-					},
-				]
+				{
+					label: 'Pause Subscription',
+					icon: <CirclePause className='h-4 w-4' />,
+					onSelect: () => setState((prev) => ({ ...prev, isPauseModalOpen: true })),
+					disabled: isPaused || isCancelled,
+				},
+				{
+					label: 'Add Subscription Phase',
+					icon: <Plus className='h-4 w-4' />,
+					onSelect: () => setState((prev) => ({ ...prev, isAddPhaseModalOpen: true })),
+					disabled: isPaused || isCancelled,
+				},
+			]
 			: []),
 		...(isPaused && !isCancelled
 			? [
-					{
-						label: 'Resume Subscription',
-						icon: <CirclePlay className='h-4 w-4' />,
-						onSelect: () => setState((prev) => ({ ...prev, isResumeModalOpen: true })),
-						disabled: isCancelled,
-					},
-				]
+				{
+					label: 'Resume Subscription',
+					icon: <CirclePlay className='h-4 w-4' />,
+					onSelect: () => setState((prev) => ({ ...prev, isResumeModalOpen: true })),
+					disabled: isCancelled,
+				},
+			]
 			: []),
 		{
 			label: 'Cancel Subscription',

--- a/src/models/Subscription.ts
+++ b/src/models/Subscription.ts
@@ -175,7 +175,8 @@ export enum RESUME_MODE {
 /**
  * ProrationAction defines the type of change triggering proration.
  */
-export enum SUBSCRIPTION_PRORATION_ACTION {
+export enum
+	SUBSCRIPTION_PRORATION_ACTION {
 	UPGRADE = 'upgrade',
 	DOWNGRADE = 'downgrade',
 	QUANTITY_CHANGE = 'quantity_change',
@@ -198,4 +199,11 @@ export enum SUBSCRIPTION_PRORATION_STRATEGY {
 export enum SUBSCRIPTION_PRORATION_BEHAVIOR {
 	CREATE_PRORATIONS = 'create_prorations', // Default: Create credits/charges on invoice
 	NONE = 'none', // Calculate but don't apply (e.g., for previews)
+}
+
+
+
+export enum SUBSCRIPTION_CANCELLATION_TYPE {
+	IMMEDIATE = "immediate",
+	END_OF_PERIOD = "end_of_period"
 }

--- a/src/types/dto/Subscription.ts
+++ b/src/types/dto/Subscription.ts
@@ -3,8 +3,8 @@ import {
 	BILLING_CYCLE,
 	SUBSCRIPTION_STATUS,
 	SubscriptionPhase,
-	SUBSCRIPTION_PRORATION_ACTION,
 	SUBSCRIPTION_PRORATION_BEHAVIOR,
+	SUBSCRIPTION_CANCELLATION_TYPE,
 } from '@/models/Subscription';
 import { CreditGrant } from '@/models/CreditGrant';
 import { BILLING_PERIOD } from '@/constants/constants';
@@ -171,6 +171,8 @@ export interface SubscriptionLineItemOverrideRequest {
 
 export interface CancelSubscriptionPayload {
 	proration_behavior?: SUBSCRIPTION_PRORATION_BEHAVIOR;
-	cancellation_type?: SUBSCRIPTION_PRORATION_ACTION;
+	cancellation_type?: SUBSCRIPTION_CANCELLATION_TYPE;
 	reason?: string;
 }
+
+


### PR DESCRIPTION
…e cancelSubscription logic
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `SUBSCRIPTION_CANCELLATION_TYPE` enum and updates cancellation logic to use it in `SubscriptionActionButton.tsx`.
> 
>   - **Behavior**:
>     - Introduces `SUBSCRIPTION_CANCELLATION_TYPE` enum in `Subscription.ts` with values `IMMEDIATE` and `END_OF_PERIOD`.
>     - Updates `cancelSubscription` logic in `SubscriptionActionButton.tsx` to use `SUBSCRIPTION_CANCELLATION_TYPE.IMMEDIATE`.
>   - **Models**:
>     - Replaces `cancellation_type` from `SUBSCRIPTION_PRORATION_ACTION` to `SUBSCRIPTION_CANCELLATION_TYPE` in `CancelSubscriptionPayload` in `Subscription.ts` and `Subscription.tsx`.
>   - **Imports**:
>     - Adds `SUBSCRIPTION_CANCELLATION_TYPE` import in `SubscriptionActionButton.tsx` and `Subscription.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for 8d86803ce2c9770438cca13518a872637d995f44. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->