### PR TITLE
fix(onboarding): update link for 'Getting Started' tutorial

### DIFF
--- a/src/pages/onboarding/onboarding.tsx
+++ b/src/pages/onboarding/onboarding.tsx
@@ -16,7 +16,7 @@ const tutorials: TutorialItem[] = [
 	{
 		title: 'Getting Started',
 		description: 'Learn the basics of Flexprice in 5 minutes',
-		onClick: () => window.open('https://docs.flexprice.io/guides/getting-started/video', '_blank'),
+		onClick: () => window.open('https://docs.flexprice.io', '_blank'),
 	},
 	{
 		title: 'Set Up Pricing Plans',


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update 'Getting Started' tutorial link in `onboarding.tsx` to point to the main documentation page.
> 
>   - **Behavior**:
>     - Update 'Getting Started' tutorial link in `onboarding.tsx` to `https://docs.flexprice.io` from `https://docs.flexprice.io/guides/getting-started/video`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for 216ee7bba0c9af7cda433c1414f1325da6e180c2. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->