### PR TITLE
fix(onboarding): update 'Getting Started' tutorial link

### DIFF
--- a/src/pages/onboarding/OnboardingTenant.tsx
+++ b/src/pages/onboarding/OnboardingTenant.tsx
@@ -24,7 +24,7 @@ const exploreTutorials: TutorialItem[] = [
 		title: 'Getting Started',
 		description: 'Learn the basics of Flexprice in 5 minutes',
 		icon: <Globe className='w-5 h-5 text-[#3293D9]' />,
-		onClick: () => window.open('https://docs.flexprice.io/guides/getting-started/video', '_blank', 'noopener,noreferrer'),
+		onClick: () => window.open('https://docs.flexprice.io', '_blank', 'noopener,noreferrer'),
 	},
 	{
 		title: 'Define Usage Metering',


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update 'Getting Started' tutorial link in `OnboardingTenant.tsx` to point to the main documentation page.
> 
>   - **Behavior**:
>     - Updates 'Getting Started' tutorial link in `OnboardingTenant.tsx` to point to `https://docs.flexprice.io` instead of `https://docs.flexprice.io/guides/getting-started/video`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for e2b91a42d43b9071837f856a757ca55922a97dfa. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->