### PR TITLE
Fix(AddFeature): decimal input handling for Aggregation Multiplier

### DIFF
--- a/src/pages/product-catalog/features/AddFeature.tsx
+++ b/src/pages/product-catalog/features/AddFeature.tsx
@@ -462,15 +462,23 @@ const AggregationSection = ({
 		[onUpdateMeter],
 	);
 
+	const [multiplierInput, setMultiplierInput] = useState(meter.aggregation?.multiplier?.toString() || '');
+
 	const handleMultiplierChange = useCallback(
-		(multiplierStr: string) => {
-			onUpdateMeter((prev) => ({
-				...prev,
-				aggregation: {
-					...prev.aggregation!,
-					multiplier: multiplierStr ? Number(multiplierStr) : undefined,
-				},
-			}));
+		(value: string) => {
+			// Allow empty string or valid decimal numbers
+			if (/^\d*\.?\d*$/.test(value)) {
+				setMultiplierInput(value);
+
+				const num = parseFloat(value);
+				onUpdateMeter((prev) => ({
+					...prev,
+					aggregation: {
+						...prev.aggregation!,
+						multiplier: !isNaN(num) ? num : undefined,
+					},
+				}));
+			}
 		},
 		[onUpdateMeter],
 	);
@@ -527,7 +535,7 @@ const AggregationSection = ({
 
 				{showMultiplierInput && (
 					<Input
-						value={meter.aggregation?.multiplier?.toString() || ''}
+						value={multiplierInput}
 						onChange={handleMultiplierChange}
 						label='Aggregation Multiplier'
 						placeholder='1'


### PR DESCRIPTION
fix: #381 

Updated the Aggregation Multiplier input to allow users to type decimal and non-decimal numbers without breaking the input. The input now temporarily stores the value as a string to support partial decimals (e.g 1. or 0.25) while keeping the stored `Meter.aggregation.multiplier` as a number. TypeScript type safety is maintained, and invalid characters are prevented