### PR TITLE
fix(PlanDrawer): enhance metadata validation 

### DIFF
--- a/src/components/molecules/PlanDrawer/PlanDrawer.tsx
+++ b/src/components/molecules/PlanDrawer/PlanDrawer.tsx
@@ -89,7 +89,7 @@ const PlanDrawer: FC<Props> = ({ data, open, onOpenChange, trigger, refetchQuery
 		if (metadataString.trim()) {
 			try {
 				const parsed = JSON.parse(metadataString);
-				if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+				if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
 					newErrors.metadata = 'Metadata must be a JSON object';
 				} else {
 					const allStrings = Object.values(parsed).every((val) => typeof val === 'string');

--- a/src/pages/product-catalog/plans/PlanDetailsPage.tsx
+++ b/src/pages/product-catalog/plans/PlanDetailsPage.tsx
@@ -195,6 +195,8 @@ const PlanDetailsPage = () => {
 	useEffect(() => {
 		if (planData?.metadata) {
 			setMetadata(planData.metadata);
+		} else {
+			setMetadata({});
 		}
 	}, [planData?.metadata]);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance metadata validation in `PlanDrawer` and ensure metadata defaults to an empty object in `PlanDetailsPage`.
> 
>   - **Metadata Validation**:
>     - In `PlanDrawer.tsx`, enhance metadata validation by checking if parsed JSON is `null` in addition to being an object or array.
>   - **Metadata Handling**:
>     - In `PlanDetailsPage.tsx`, set metadata to an empty object if `planData.metadata` is not present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for 1c0c29042b60307bb5741e7478ec5d42a1d489b5. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Correctly validates plan metadata by rejecting null values, ensuring the “Metadata must be a JSON object” error appears when appropriate.
  - Initializes missing plan metadata to an empty object, preventing UI inconsistencies and potential crashes in Plan Details and the Plan Drawer.
  - Improves stability and clarity when viewing or editing plans with empty or malformed metadata, providing more reliable error feedback and consistent defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->