### PR TITLE
feat(BreadCrumbs): add search trigger component to breadcrumbs for enhanced navigation; remove sidebar search trigger

### DIFF
--- a/src/components/molecules/BreadCrumbs/BreadCrumbs.tsx
+++ b/src/components/molecules/BreadCrumbs/BreadCrumbs.tsx
@@ -6,6 +6,31 @@ import { useBreadcrumbs } from '@/hooks/useBreadcrumbs';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import ApiDocs from '../ApiDocs';
 import IntercomMessenger from '@/core/services/intercom/IntercomMessenger';
+import { Search } from 'lucide-react';
+import { Button } from '@/components/atoms';
+
+const COMMAND_PALETTE_EVENT = 'open-command-palette';
+
+const BreadCrumbsSearchTrigger: React.FC = () => {
+	const handleClick = () => window.dispatchEvent(new CustomEvent(COMMAND_PALETTE_EVENT));
+
+	return (
+		<Button
+			type='button'
+			onClick={handleClick}
+			variant='outline'
+			size='sm'
+			className='flex items-center gap-2'
+			aria-label='Search or run a command (⌘K)'>
+			<Search className='h-4 w-4 shrink-0 opacity-70' />
+			<span className='flex-1 truncate'>Search...</span>
+			<kbd className='pointer-events-none hidden h-5 select-none items-center gap-0.5 rounded border border-border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground sm:inline-flex'>
+				⌘ K
+			</kbd>
+		</Button>
+	);
+};
+
 const BreadCrumbs: FC = () => {
 	useBreadcrumbs();
 	const { breadcrumbs, isLoading } = useBreadcrumbsStore();
@@ -57,6 +82,7 @@ const BreadCrumbs: FC = () => {
 					))}
 				</nav>
 				<div className='flex items-center gap-4'>
+					<BreadCrumbsSearchTrigger />
 					<IntercomMessenger />
 					<ApiDocs />
 				</div>

--- a/src/components/molecules/Sidebar/Sidebar.tsx
+++ b/src/components/molecules/Sidebar/Sidebar.tsx
@@ -4,36 +4,8 @@ import SidebarNav, { NavItem } from './SidebarMenu';
 import FlexpriceSidebarFooter from './SidebarFooter';
 import { RouteNames } from '@/core/routes/Routes';
 import { EnvironmentSelector } from '@/components/molecules';
-import { Settings, Landmark, Layers2, CodeXml, Puzzle, GalleryHorizontalEnd, Home, Search } from 'lucide-react';
+import { Settings, Landmark, Layers2, CodeXml, Puzzle, GalleryHorizontalEnd, Home } from 'lucide-react';
 import { cn } from '@/lib/utils';
-
-const COMMAND_PALETTE_EVENT = 'open-command-palette';
-
-function SidebarSearchTrigger() {
-	const { open: sidebarOpen } = useSidebar();
-	const handleClick = () => window.dispatchEvent(new CustomEvent(COMMAND_PALETTE_EVENT));
-
-	return (
-		<button
-			type='button'
-			onClick={handleClick}
-			className={cn(
-				'flex h-8 w-full items-center gap-2 rounded-md border border-input bg-background px-2.5 text-left text-sm text-muted-foreground shadow-none transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring',
-				!sidebarOpen && 'justify-center px-2',
-			)}
-			aria-label='Search or run a command (⌘K)'>
-			<Search className='h-4 w-4 shrink-0 opacity-70' />
-			{sidebarOpen && (
-				<>
-					<span className='flex-1 truncate'>Search...</span>
-					<kbd className='pointer-events-none hidden h-5 select-none items-center gap-0.5 rounded border border-border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground sm:inline-flex'>
-						⌘ K
-					</kbd>
-				</>
-			)}
-		</button>
-	);
-}
 
 const AppSidebar: React.FC<React.ComponentProps<typeof Sidebar>> = ({ ...props }) => {
 	const { open: sidebarOpen } = useSidebar();
@@ -166,7 +138,6 @@ const AppSidebar: React.FC<React.ComponentProps<typeof Sidebar>> = ({ ...props }
 			className={cn('border-none px-3 py-1 shadow-md  bg-[#f9f9f9]', sidebarOpen ? 'px-3' : 'pr-0 pl-2')}>
 			<SidebarHeader>
 				<EnvironmentSelector />
-				<SidebarSearchTrigger />
 			</SidebarHeader>
 			<SidebarContent className='gap-0 mt-1'>
 				<SidebarNav items={navMain} />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `BreadCrumbsSearchTrigger` to `BreadCrumbs` and removes `SidebarSearchTrigger` from `Sidebar` for improved navigation.
> 
>   - **Behavior**:
>     - Adds `BreadCrumbsSearchTrigger` component to `BreadCrumbs.tsx` for enhanced navigation.
>     - Removes `SidebarSearchTrigger` from `Sidebar.tsx`.
>   - **Components**:
>     - `BreadCrumbsSearchTrigger` dispatches `COMMAND_PALETTE_EVENT` on click.
>     - `Button` with `Search` icon and `⌘K` shortcut hint added to `BreadCrumbs`.
>   - **Imports**:
>     - Removes `Search` import from `Sidebar.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice-front&utm_source=github&utm_medium=referral)<sup> for 6954325c922b5b2c32b0464ee00d1c641cccd519. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Relocated the search trigger from the sidebar to the breadcrumbs header section. The search button is now positioned in the header's right-side control area alongside other interface elements. Keyboard shortcut hints continue to be available with the search button for both button interaction and keyboard-based access to search features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->