### PR TITLE
feat(org-setting-dashboard): add custom setting chnages dashboard for user

### DIFF
--- a/src/core/routes/Routes.tsx
+++ b/src/core/routes/Routes.tsx
@@ -75,6 +75,7 @@ import {
 	// Settings pages
 	Billing as BillingPage,
 	SettingsDashboard,
+	OrgSettingsPage,
 	// Insights tools pages
 	Integrations,
 	IntegrationDetails,
@@ -179,6 +180,7 @@ export const RouteNames = {
 	// footer
 	onboarding: '/onboarding',
 	settings: '/settings',
+	orgSettings: '/settings/org',
 	customerBilling: '/settings/billing',
 };
 
@@ -556,6 +558,10 @@ export const MainRouter = createBrowserRouter([
 			{
 				path: RouteNames.settings,
 				element: <SettingsDashboard />,
+			},
+			{
+				path: RouteNames.orgSettings,
+				element: <OrgSettingsPage />,
 			},
 			{
 				path: RouteNames.customerBilling,

--- a/src/hooks/useJsonEditor.ts
+++ b/src/hooks/useJsonEditor.ts
@@ -1,0 +1,107 @@
+import { useState, useRef, useEffect } from 'react';
+import toast from 'react-hot-toast';
+
+export interface UseJsonEditorOptions<T> {
+	initialValue: T;
+	onSave?: (changedValues: Partial<T> | T) => void;
+	validate?: (value: T) => string | null;
+	sendCompleteConfig?: boolean; // New option to control whether to send complete config or just changes
+}
+
+export function useJsonEditor<T>({ initialValue, onSave, validate, sendCompleteConfig = false }: UseJsonEditorOptions<T>) {
+	const [showJsonEditor, setShowJsonEditor] = useState(false);
+	const [jsonValue, setJsonValue] = useState('');
+	const [jsonError, setJsonError] = useState('');
+	const originalValueRef = useRef<T | null>(null);
+
+	// Store original value for comparison
+	useEffect(() => {
+		originalValueRef.current = initialValue;
+	}, [initialValue]);
+
+	// Update JSON editor content when form value changes
+	useEffect(() => {
+		if (showJsonEditor) {
+			setJsonValue(JSON.stringify(initialValue, null, 2));
+		}
+	}, [initialValue, showJsonEditor]);
+
+	const getChangedValues = (original: T, updated: T): Partial<T> => {
+		const changes: Partial<T> = {};
+
+		for (const key in updated) {
+			const typedKey = key as keyof T;
+			if (JSON.stringify(original[typedKey]) !== JSON.stringify(updated[typedKey])) {
+				(changes as any)[typedKey] = updated[typedKey];
+			}
+		}
+
+		return changes;
+	};
+
+	const validateJson = (): boolean => {
+		try {
+			JSON.parse(jsonValue);
+			setJsonError('');
+			return true;
+		} catch (err) {
+			setJsonError(err instanceof Error ? err.message : 'Invalid JSON');
+			return false;
+		}
+	};
+
+	const handleJsonSave = () => {
+		if (!validateJson()) return;
+
+		try {
+			const parsedValue = JSON.parse(jsonValue) as T;
+
+			// Run custom validation if provided
+			if (validate) {
+				const validationError = validate(parsedValue);
+				if (validationError) {
+					setJsonError(validationError);
+					return;
+				}
+			}
+
+			// Get only changed values for comparison
+			const originalValue = originalValueRef.current || initialValue;
+			const changedValues = getChangedValues(originalValue, parsedValue);
+
+			// If no changes, show message
+			if (Object.keys(changedValues).length === 0) {
+				toast('No changes detected');
+				return;
+			}
+
+			// Send complete config or just changes based on the flag
+			const dataToSend = sendCompleteConfig ? parsedValue : changedValues;
+
+			// Call custom save handler
+			if (onSave) {
+				onSave(dataToSend);
+			}
+
+			return dataToSend;
+		} catch (err) {
+			setJsonError('Failed to parse JSON configuration');
+			return null;
+		}
+	};
+
+	const toggleEditor = () => {
+		setShowJsonEditor(!showJsonEditor);
+		setJsonError('');
+	};
+
+	return {
+		showJsonEditor,
+		jsonValue,
+		setJsonValue,
+		jsonError,
+		toggleEditor,
+		handleJsonSave,
+		validateJson,
+	};
+}

--- a/src/hooks/useSettingSection.ts
+++ b/src/hooks/useSettingSection.ts
@@ -1,0 +1,108 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import SettingsApi from '@/api/SettingsApi';
+import type { Setting } from '@/api/SettingsApi';
+import type { ServerError } from '@/core/axios/types';
+
+const SETTINGS_QUERY_KEY = 'settings';
+
+export interface UseSettingSectionOptions<T> {
+	key: string;
+	defaultValue: T;
+	/** Merge API value with defaults (for partial responses). If not provided, form is set to (data?.value ?? defaultValue). */
+	mergeWithDefaults?: (apiValue: unknown, defaultValue: T) => T;
+}
+
+export interface UseSettingSectionResult<T> {
+	data: Setting | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	refetch: () => void;
+	formValue: T;
+	setFormValue: React.Dispatch<React.SetStateAction<T>>;
+	saveMutation: ReturnType<typeof useMutation<Setting, ServerError, T>>;
+	resetMutation: ReturnType<typeof useMutation<void, ServerError, void>>;
+	/** Field-level errors from last failed PUT (e.g. { 'value.prefix': 'must be at least 1 character' }) */
+	backendDetails: Record<string, string>;
+	/** Sync form from API data (e.g. after load or refetch). */
+	syncFormFromData: () => void;
+}
+
+export function useSettingSection<T>({ key, defaultValue, mergeWithDefaults }: UseSettingSectionOptions<T>): UseSettingSectionResult<T> {
+	const queryClient = useQueryClient();
+	const [formValue, setFormValue] = useState<T>(defaultValue);
+	const [backendDetails, setBackendDetails] = useState<Record<string, string>>({});
+
+	const { data, isLoading, isError, refetch } = useQuery({
+		queryKey: [SETTINGS_QUERY_KEY, key],
+		queryFn: () => SettingsApi.getSettingByKey(key),
+	});
+
+	const syncFormFromData = useCallback(() => {
+		if (!data?.value) {
+			setFormValue(defaultValue);
+			return;
+		}
+		if (mergeWithDefaults) {
+			setFormValue(mergeWithDefaults(data.value, defaultValue));
+		} else {
+			setFormValue({ ...defaultValue, ...(data.value as Partial<T>) } as T);
+		}
+	}, [data?.value, defaultValue, mergeWithDefaults]);
+
+	useEffect(() => {
+		if (data === undefined) return;
+		if (!data?.value) {
+			setFormValue(defaultValue);
+			return;
+		}
+		if (mergeWithDefaults) {
+			setFormValue(mergeWithDefaults(data.value, defaultValue));
+		} else {
+			setFormValue({ ...defaultValue, ...(data.value as Partial<T>) } as T);
+		}
+	}, [data, defaultValue, mergeWithDefaults]);
+
+	const saveMutation = useMutation<Setting, ServerError, T>({
+		mutationFn: (value) => SettingsApi.updateSettingByKey(key, { value: value as Record<string, unknown> }),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: [SETTINGS_QUERY_KEY, key] });
+			setBackendDetails({});
+			toast.success('Settings saved');
+		},
+		onError: (err: ServerError) => {
+			const message = err?.error?.message || 'Failed to save settings';
+			toast.error(message);
+			setBackendDetails(err?.error?.details ?? {});
+		},
+	});
+
+	const resetMutation = useMutation<void, ServerError, void>({
+		mutationFn: () => SettingsApi.deleteSettingByKey(key),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: [SETTINGS_QUERY_KEY, key] });
+			setFormValue(defaultValue);
+			setBackendDetails({});
+			toast.success('Reset to default');
+		},
+		onError: (err: ServerError) => {
+			const message = err?.error?.message || 'Failed to reset settings';
+			toast.error(message);
+			setBackendDetails(err?.error?.details ?? {});
+		},
+	});
+
+	return {
+		data,
+		isLoading,
+		isError,
+		refetch,
+		formValue,
+		setFormValue,
+		saveMutation,
+		resetMutation,
+		backendDetails,
+		syncFormFromData,
+	};
+}

--- a/src/pages/settings/OrgSettingsPage.tsx
+++ b/src/pages/settings/OrgSettingsPage.tsx
@@ -1,0 +1,37 @@
+import { Page } from '@/components/atoms';
+import { FlatTabs } from '@/components/molecules';
+import { InvoiceConfigSection } from './org/InvoiceConfigSection';
+import { SubscriptionConfigSection } from './org/SubscriptionConfigSection';
+import { InvoicePdfConfigSection } from './org/InvoicePdfConfigSection';
+import { CustomerOnboardingSection } from './org/CustomerOnboardingSection';
+import { WalletBalanceAlertConfigSection } from './org/WalletBalanceAlertConfigSection';
+import { PrepareProcessedEventsConfigSection } from './org/PrepareProcessedEventsConfigSection';
+import { CustomAnalyticsConfigSection } from './org/CustomAnalyticsConfigSection';
+import { CustomerPortalConfigSection } from './org/CustomerPortalConfigSection';
+
+const OrgSettingsPage = () => {
+	return (
+		<Page heading='Org Settings' documentTitle='Org Settings' headingClassName='font-semibold text-2xl text-zinc-900'>
+			<FlatTabs
+				className='[&_.border-b]:border-gray-200'
+				defaultValue='invoice_config'
+				tabs={[
+					{ value: 'invoice_config', label: 'Invoice', content: <InvoiceConfigSection /> },
+					{ value: 'subscription_config', label: 'Subscriptions', content: <SubscriptionConfigSection /> },
+					{ value: 'invoice_pdf_config', label: 'Invoice PDF', content: <InvoicePdfConfigSection /> },
+					{ value: 'customer_onboarding', label: 'Customer onboarding', content: <CustomerOnboardingSection /> },
+					{ value: 'wallet_balance_alert_config', label: 'Wallet alerts', content: <WalletBalanceAlertConfigSection /> },
+					{
+						value: 'prepare_processed_events_config',
+						label: 'Prepare processed events',
+						content: <PrepareProcessedEventsConfigSection />,
+					},
+					{ value: 'custom_analytics_config', label: 'Custom analytics', content: <CustomAnalyticsConfigSection /> },
+					{ value: 'customer_portal_config', label: 'Customer portal', content: <CustomerPortalConfigSection /> },
+				]}
+			/>
+		</Page>
+	);
+};
+
+export default OrgSettingsPage;

--- a/src/pages/settings/OrgSettingsPage.tsx
+++ b/src/pages/settings/OrgSettingsPage.tsx
@@ -1,4 +1,3 @@
-import { Page } from '@/components/atoms';
 import { FlatTabs } from '@/components/molecules';
 import { InvoiceConfigSection } from './org/InvoiceConfigSection';
 import { CustomerOnboardingSection } from './org/CustomerOnboardingSection';
@@ -8,26 +7,24 @@ import { CustomerPortalConfigSection } from './org/CustomerPortalConfigSection';
 
 const OrgSettingsPage = () => {
 	return (
-		<Page heading='Org Settings' documentTitle='Org Settings' headingClassName='font-semibold text-2xl text-zinc-900'>
-			<FlatTabs
-				className='[&_.border-b]:border-gray-200'
-				defaultValue='invoice_config'
-				tabs={[
-					{ value: 'invoice_config', label: 'Invoice', content: <InvoiceConfigSection /> },
-					// { value: 'subscription_config', label: 'Subscriptions', content: <SubscriptionConfigSection /> },
-					// { value: 'invoice_pdf_config', label: 'Invoice PDF', content: <InvoicePdfConfigSection /> },
-					{ value: 'customer_onboarding', label: 'Customer onboarding', content: <CustomerOnboardingSection /> },
-					{ value: 'wallet_balance_alert_config', label: 'Wallet alerts', content: <WalletBalanceAlertConfigSection /> },
-					// {
-					// 	value: 'prepare_processed_events_config',
-					// 	label: 'Prepare processed events',
-					// 	content: <PrepareProcessedEventsConfigSection />,
-					// },
-					{ value: 'custom_analytics_config', label: 'Custom analytics', content: <CustomAnalyticsConfigSection /> },
-					{ value: 'customer_portal_config', label: 'Customer portal', content: <CustomerPortalConfigSection /> },
-				]}
-			/>
-		</Page>
+		<FlatTabs
+			className='[&_.border-b]:border-gray-200'
+			defaultValue='invoice_config'
+			tabs={[
+				{ value: 'invoice_config', label: 'Invoice', content: <InvoiceConfigSection /> },
+				// { value: 'subscription_config', label: 'Subscriptions', content: <SubscriptionConfigSection /> },
+				// { value: 'invoice_pdf_config', label: 'Invoice PDF', content: <InvoicePdfConfigSection /> },
+				{ value: 'customer_onboarding', label: 'Customer onboarding', content: <CustomerOnboardingSection /> },
+				{ value: 'wallet_balance_alert_config', label: 'Wallet alerts', content: <WalletBalanceAlertConfigSection /> },
+				// {
+				// 	value: 'prepare_processed_events_config',
+				// 	label: 'Prepare processed events',
+				// 	content: <PrepareProcessedEventsConfigSection />,
+				// },
+				{ value: 'custom_analytics_config', label: 'Custom analytics', content: <CustomAnalyticsConfigSection /> },
+				{ value: 'customer_portal_config', label: 'Customer portal', content: <CustomerPortalConfigSection /> },
+			]}
+		/>
 	);
 };
 

--- a/src/pages/settings/OrgSettingsPage.tsx
+++ b/src/pages/settings/OrgSettingsPage.tsx
@@ -1,11 +1,8 @@
 import { Page } from '@/components/atoms';
 import { FlatTabs } from '@/components/molecules';
 import { InvoiceConfigSection } from './org/InvoiceConfigSection';
-import { SubscriptionConfigSection } from './org/SubscriptionConfigSection';
-import { InvoicePdfConfigSection } from './org/InvoicePdfConfigSection';
 import { CustomerOnboardingSection } from './org/CustomerOnboardingSection';
 import { WalletBalanceAlertConfigSection } from './org/WalletBalanceAlertConfigSection';
-import { PrepareProcessedEventsConfigSection } from './org/PrepareProcessedEventsConfigSection';
 import { CustomAnalyticsConfigSection } from './org/CustomAnalyticsConfigSection';
 import { CustomerPortalConfigSection } from './org/CustomerPortalConfigSection';
 
@@ -17,15 +14,15 @@ const OrgSettingsPage = () => {
 				defaultValue='invoice_config'
 				tabs={[
 					{ value: 'invoice_config', label: 'Invoice', content: <InvoiceConfigSection /> },
-					{ value: 'subscription_config', label: 'Subscriptions', content: <SubscriptionConfigSection /> },
-					{ value: 'invoice_pdf_config', label: 'Invoice PDF', content: <InvoicePdfConfigSection /> },
+					// { value: 'subscription_config', label: 'Subscriptions', content: <SubscriptionConfigSection /> },
+					// { value: 'invoice_pdf_config', label: 'Invoice PDF', content: <InvoicePdfConfigSection /> },
 					{ value: 'customer_onboarding', label: 'Customer onboarding', content: <CustomerOnboardingSection /> },
 					{ value: 'wallet_balance_alert_config', label: 'Wallet alerts', content: <WalletBalanceAlertConfigSection /> },
-					{
-						value: 'prepare_processed_events_config',
-						label: 'Prepare processed events',
-						content: <PrepareProcessedEventsConfigSection />,
-					},
+					// {
+					// 	value: 'prepare_processed_events_config',
+					// 	label: 'Prepare processed events',
+					// 	content: <PrepareProcessedEventsConfigSection />,
+					// },
 					{ value: 'custom_analytics_config', label: 'Custom analytics', content: <CustomAnalyticsConfigSection /> },
 					{ value: 'customer_portal_config', label: 'Customer portal', content: <CustomerPortalConfigSection /> },
 				]}

--- a/src/pages/settings/SettingsDashboard.tsx
+++ b/src/pages/settings/SettingsDashboard.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
 import { Page, AddButton, Card, CardHeader, Loader, Button, Input, ShortPagination, Dialog } from '@/components/atoms';
 import { FlatTabs, FlexpriceTable } from '@/components/molecules';
 import { UserApi } from '@/api/UserApi';
 import { User } from '@/models';
 import toast from 'react-hot-toast';
 import { ColumnData } from '@/components/molecules/Table/Table';
-import { AlertTriangle, Copy, Download, Eye, EyeOff, Info, Link2, Lock, Mail } from 'lucide-react';
+import { AlertTriangle, Copy, Download, Eye, EyeOff, Info, Link2, Lock, Mail, Building2 } from 'lucide-react';
 import { RouteNames } from '@/core/routes/Routes';
 import { refetchQueries } from '@/core/services/tanstack/ReactQueryProvider';
 import usePagination, { PAGINATION_PREFIX } from '@/hooks/usePagination';
@@ -369,6 +370,24 @@ function MembersSection() {
 	);
 }
 
+function OrganizationSection() {
+	const navigate = useNavigate();
+	return (
+		<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+			<div className='p-6'>
+				<p className='text-sm text-zinc-600 mb-4'>
+					Manage environment-level settings such as invoice format, subscription grace period, customer onboarding workflow, wallet alerts,
+					and customer portal theme.
+				</p>
+				<Button onClick={() => navigate(RouteNames.orgSettings)}>
+					<Building2 className='h-4 w-4 mr-2' />
+					Open Org Settings
+				</Button>
+			</div>
+		</Card>
+	);
+}
+
 const SettingsDashboard = () => {
 	return (
 		<Page heading='Settings' documentTitle='Settings' headingClassName='font-semibold text-2xl text-zinc-900'>
@@ -379,6 +398,11 @@ const SettingsDashboard = () => {
 						value: 'team',
 						label: 'Team',
 						content: <MembersSection />,
+					},
+					{
+						value: 'organization',
+						label: 'Organization',
+						content: <OrganizationSection />,
 					},
 				]}
 				defaultValue='team'

--- a/src/pages/settings/index.ts
+++ b/src/pages/settings/index.ts
@@ -1,2 +1,3 @@
 export { default as Billing } from './Billing';
 export { default as SettingsDashboard } from './SettingsDashboard';
+export { default as OrgSettingsPage } from './OrgSettingsPage';

--- a/src/pages/settings/org/CustomAnalyticsConfigSection.tsx
+++ b/src/pages/settings/org/CustomAnalyticsConfigSection.tsx
@@ -1,5 +1,6 @@
-import { Card, CardHeader, Button, Input, Loader, Select, type SelectOption } from '@/components/atoms';
+import { Card, CardHeader, Button, Input, Loader, Select, Textarea, type SelectOption } from '@/components/atoms';
 import { useSettingSection } from '@/hooks/useSettingSection';
+import { useJsonEditor } from '@/hooks/useJsonEditor';
 import {
 	DEFAULT_CUSTOM_ANALYTICS_CONFIG,
 	type CustomAnalyticsConfig,
@@ -26,6 +27,15 @@ export function CustomAnalyticsConfigSection() {
 			key: SETTING_KEY,
 			defaultValue: DEFAULT_CUSTOM_ANALYTICS_CONFIG,
 		});
+
+	const jsonEditor = useJsonEditor({
+		initialValue: formValue,
+		sendCompleteConfig: true,
+		onSave: (data) => {
+			saveMutation.mutate(data as CustomAnalyticsConfig);
+			setFormValue((prev) => ({ ...prev, ...(data as CustomAnalyticsConfig) }));
+		},
+	});
 
 	const handleSave = () => {
 		saveMutation.mutate(formValue);
@@ -77,57 +87,97 @@ export function CustomAnalyticsConfigSection() {
 						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
 							Reset to default
 						</Button>
-						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+						<Button variant='outline' size='sm' onClick={jsonEditor.toggleEditor}>
+							{jsonEditor.showJsonEditor ? 'Form View' : 'JSON Editor'}
+						</Button>
+						<Button
+							size='sm'
+							onClick={jsonEditor.showJsonEditor ? jsonEditor.handleJsonSave : handleSave}
+							disabled={saveMutation.isPending}
+							isLoading={saveMutation.isPending}>
 							Save
 						</Button>
 					</div>
 				}
 			/>
 			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
-				{isError && (
-					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
-						Failed to load settings.{' '}
-						<button type='button' onClick={() => refetch()} className='underline font-medium'>
-							Retry
-						</button>
-					</div>
-				)}
-				<div className='flex items-center justify-between'>
-					<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Rules</label>
-					<Button type='button' variant='outline' size='sm' onClick={addRule}>
-						<Plus className='h-3.5 w-3.5 mr-1' />
-						Add rule
-					</Button>
-				</div>
-				<div className='space-y-2'>
-					{formValue.rules.length === 0 ? (
-						<p className='text-sm text-zinc-500'>No rules. Add rules to target feature, meter, or event_name.</p>
-					) : (
-						formValue.rules.map((rule, index) => (
-							<div key={rule.id} className='flex flex-wrap items-center gap-2 p-3 rounded-lg border border-gray-100 bg-gray-50/50'>
-								<Select
-									options={TARGET_TYPE_OPTIONS}
-									value={rule.target_type}
-									onChange={(v) => updateRule(index, { target_type: v as CustomAnalyticsTargetType })}
-									className='w-36'
-								/>
-								<Input
-									placeholder='Target ID'
-									value={rule.target_id}
-									onChange={(v) => updateRule(index, { target_id: v })}
-									className='flex-1 min-w-[120px]'
-								/>
-								<Button type='button' variant='outline' size='sm' onClick={() => removeRule(index)} aria-label='Remove rule'>
-									<Trash2 className='h-4 w-4' />
-								</Button>
+				{!jsonEditor.showJsonEditor ? (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
 							</div>
-						))
-					)}
-				</div>
-				{getFieldError(backendDetails, 'rules') && (
-					<p className='text-sm text-red-600' role='alert'>
-						{getFieldError(backendDetails, 'rules')}
-					</p>
+						)}
+						<div className='flex items-center justify-between'>
+							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Rules</label>
+							<Button type='button' variant='outline' size='sm' onClick={addRule}>
+								<Plus className='h-3.5 w-3.5 mr-1' />
+								Add rule
+							</Button>
+						</div>
+						<div className='space-y-2'>
+							{formValue.rules.length === 0 ? (
+								<p className='text-sm text-zinc-500'>No rules. Add rules to target feature, meter, or event_name.</p>
+							) : (
+								formValue.rules.map((rule, index) => (
+									<div key={rule.id} className='flex flex-wrap items-center gap-2 p-3 rounded-lg border border-gray-100 bg-gray-50/50'>
+										<Select
+											options={TARGET_TYPE_OPTIONS}
+											value={rule.target_type}
+											onChange={(v) => updateRule(index, { target_type: v as CustomAnalyticsTargetType })}
+											className='w-36'
+										/>
+										<Input
+											placeholder='Target ID'
+											value={rule.target_id}
+											onChange={(v) => updateRule(index, { target_id: v })}
+											className='flex-1 min-w-[120px]'
+										/>
+										<Button type='button' variant='outline' size='sm' onClick={() => removeRule(index)} aria-label='Remove rule'>
+											<Trash2 className='h-4 w-4' />
+										</Button>
+									</div>
+								))
+							)}
+						</div>
+						{getFieldError(backendDetails, 'rules') && (
+							<p className='text-sm text-red-600' role='alert'>
+								{getFieldError(backendDetails, 'rules')}
+							</p>
+						)}
+					</div>
+				) : (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
+						<div>
+							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								JSON Configuration (Developer Mode)
+							</label>
+							<Textarea
+								value={jsonEditor.jsonValue}
+								onChange={jsonEditor.setJsonValue}
+								placeholder='Paste or edit JSON configuration here...'
+								error={jsonEditor.jsonError}
+								description='Edit the custom analytics configuration directly in JSON format. Only changed values will be saved.'
+								textAreaClassName='min-h-[400px] font-mono text-sm'
+							/>
+							{jsonEditor.jsonError && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{jsonEditor.jsonError}
+								</p>
+							)}
+						</div>
+					</div>
 				)}
 			</div>
 		</Card>

--- a/src/pages/settings/org/CustomAnalyticsConfigSection.tsx
+++ b/src/pages/settings/org/CustomAnalyticsConfigSection.tsx
@@ -1,0 +1,135 @@
+import { Card, CardHeader, Button, Input, Loader, Select, type SelectOption } from '@/components/atoms';
+import { useSettingSection } from '@/hooks/useSettingSection';
+import {
+	DEFAULT_CUSTOM_ANALYTICS_CONFIG,
+	type CustomAnalyticsConfig,
+	type CustomAnalyticsRule,
+	type CustomAnalyticsTargetType,
+} from '@/types/dto/OrgSettings';
+import { Plus, Trash2 } from 'lucide-react';
+
+const SETTING_KEY = 'custom_analytics_config';
+
+const TARGET_TYPE_OPTIONS: SelectOption[] = [
+	{ value: 'feature', label: 'Feature' },
+	{ value: 'meter', label: 'Meter' },
+	{ value: 'event_name', label: 'Event name' },
+];
+
+function getFieldError(details: Record<string, string>, field: string): string | undefined {
+	return details[`value.${field}`] ?? details[field];
+}
+
+export function CustomAnalyticsConfigSection() {
+	const { isLoading, isError, formValue, setFormValue, saveMutation, resetMutation, backendDetails, refetch } =
+		useSettingSection<CustomAnalyticsConfig>({
+			key: SETTING_KEY,
+			defaultValue: DEFAULT_CUSTOM_ANALYTICS_CONFIG,
+		});
+
+	const handleSave = () => {
+		saveMutation.mutate(formValue);
+	};
+
+	const handleReset = () => {
+		resetMutation.mutate(undefined);
+	};
+
+	const addRule = () => {
+		setFormValue((prev) => ({
+			...prev,
+			rules: [...prev.rules, { id: `rule-${Date.now()}`, target_type: 'feature', target_id: '' }],
+		}));
+	};
+
+	const updateRule = (index: number, patch: Partial<CustomAnalyticsRule>) => {
+		setFormValue((prev) => {
+			const next = [...prev.rules];
+			next[index] = { ...next[index], ...patch };
+			return { ...prev, rules: next };
+		});
+	};
+
+	const removeRule = (index: number) => {
+		setFormValue((prev) => ({
+			...prev,
+			rules: prev.rules.filter((_, i) => i !== index),
+		}));
+	};
+
+	if (isLoading) {
+		return (
+			<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+				<div className='p-6'>
+					<Loader />
+				</div>
+			</Card>
+		);
+	}
+
+	return (
+		<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+			<CardHeader
+				title='Custom analytics rules'
+				titleClassName='text-lg font-medium text-zinc-800'
+				cta={
+					<div className='flex items-center gap-2'>
+						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
+							Reset to default
+						</Button>
+						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+							Save
+						</Button>
+					</div>
+				}
+			/>
+			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
+				{isError && (
+					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+						Failed to load settings.{' '}
+						<button type='button' onClick={() => refetch()} className='underline font-medium'>
+							Retry
+						</button>
+					</div>
+				)}
+				<div className='flex items-center justify-between'>
+					<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Rules</label>
+					<Button type='button' variant='outline' size='sm' onClick={addRule}>
+						<Plus className='h-3.5 w-3.5 mr-1' />
+						Add rule
+					</Button>
+				</div>
+				<div className='space-y-2'>
+					{formValue.rules.length === 0 ? (
+						<p className='text-sm text-zinc-500'>No rules. Add rules to target feature, meter, or event_name.</p>
+					) : (
+						formValue.rules.map((rule, index) => (
+							<div key={rule.id} className='flex flex-wrap items-center gap-2 p-3 rounded-lg border border-gray-100 bg-gray-50/50'>
+								<Select
+									options={TARGET_TYPE_OPTIONS}
+									value={rule.target_type}
+									onChange={(v) => updateRule(index, { target_type: v as CustomAnalyticsTargetType })}
+									className='w-36'
+								/>
+								<Input
+									placeholder='Target ID'
+									value={rule.target_id}
+									onChange={(v) => updateRule(index, { target_id: v })}
+									className='flex-1 min-w-[120px]'
+								/>
+								<Button type='button' variant='outline' size='sm' onClick={() => removeRule(index)} aria-label='Remove rule'>
+									<Trash2 className='h-4 w-4' />
+								</Button>
+							</div>
+						))
+					)}
+				</div>
+				{getFieldError(backendDetails, 'rules') && (
+					<p className='text-sm text-red-600' role='alert'>
+						{getFieldError(backendDetails, 'rules')}
+					</p>
+				)}
+			</div>
+		</Card>
+	);
+}

--- a/src/pages/settings/org/CustomerOnboardingSection.tsx
+++ b/src/pages/settings/org/CustomerOnboardingSection.tsx
@@ -1,0 +1,284 @@
+import { Card, CardHeader, Button, Input, Loader, Select, type SelectOption } from '@/components/atoms';
+import { useSettingSection } from '@/hooks/useSettingSection';
+import { DEFAULT_CUSTOMER_ONBOARDING_CONFIG, type CustomerOnboardingConfig, type CustomerOnboardingAction } from '@/types/dto/OrgSettings';
+import { Plus, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+const SETTING_KEY = 'customer_onboarding';
+
+const ACTION_TYPE_OPTIONS: SelectOption[] = [
+	{ value: 'create_customer', label: 'Create customer' },
+	{ value: 'create_wallet', label: 'Create wallet' },
+	{ value: 'create_subscription', label: 'Create subscription' },
+	{ value: 'create_feature_and_price', label: 'Create feature and price' },
+];
+
+function getFieldError(details: Record<string, string>, field: string): string | undefined {
+	return details[`value.${field}`] ?? details[field];
+}
+
+function ActionRow({
+	action,
+	onChange,
+	onRemove,
+	canRemove,
+}: {
+	action: CustomerOnboardingAction;
+	onChange: (a: CustomerOnboardingAction) => void;
+	onRemove: () => void;
+	canRemove: boolean;
+}) {
+	const type = action.action;
+	return (
+		<div className='p-4 rounded-lg border border-gray-200 bg-white space-y-3'>
+			<div className='flex items-center justify-between gap-2'>
+				<Select
+					options={ACTION_TYPE_OPTIONS}
+					value={type}
+					onChange={(value) => {
+						switch (value) {
+							case 'create_customer':
+								onChange({ action: 'create_customer' });
+								break;
+							case 'create_wallet':
+								onChange({ action: 'create_wallet', currency: 'USD' });
+								break;
+							case 'create_subscription':
+								onChange({ action: 'create_subscription', plan_id: '' });
+								break;
+							case 'create_feature_and_price':
+								onChange({ action: 'create_feature_and_price', plan_id: '' });
+								break;
+							default:
+								onChange(action);
+						}
+					}}
+					className='w-48'
+				/>
+				{canRemove && (
+					<Button type='button' variant='outline' size='sm' onClick={onRemove} aria-label='Remove action'>
+						<Trash2 className='h-4 w-4' />
+					</Button>
+				)}
+			</div>
+			{type === 'create_customer' && 'default_user_id' in action && (
+				<div>
+					<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Default user ID (optional)</label>
+					<Input
+						value={action.default_user_id ?? ''}
+						onChange={(v) => onChange({ ...action, default_user_id: v || undefined })}
+						placeholder='Optional'
+					/>
+				</div>
+			)}
+			{type === 'create_wallet' && 'currency' in action && (
+				<div className='grid grid-cols-2 gap-3'>
+					<div>
+						<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Currency</label>
+						<Input value={action.currency} onChange={(v) => onChange({ ...action, currency: v })} />
+					</div>
+					<div>
+						<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Conversion rate (optional)</label>
+						<Input
+							type='number'
+							value={action.conversion_rate != null ? String(action.conversion_rate) : ''}
+							onChange={(v) =>
+								onChange({
+									...action,
+									conversion_rate: v ? parseFloat(v) : undefined,
+								})
+							}
+							placeholder='Optional'
+						/>
+					</div>
+				</div>
+			)}
+			{type === 'create_subscription' && 'plan_id' in action && (
+				<div className='grid grid-cols-2 gap-3'>
+					<div>
+						<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Plan ID</label>
+						<Input value={action.plan_id} onChange={(v) => onChange({ ...action, plan_id: v })} />
+					</div>
+					<div>
+						<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Billing cycle</label>
+						<Select
+							options={[
+								{ value: 'anniversary', label: 'Anniversary' },
+								{ value: 'calendar', label: 'Calendar' },
+							]}
+							value={action.billing_cycle ?? ''}
+							onChange={(v) => onChange({ ...action, billing_cycle: (v as 'anniversary' | 'calendar') || undefined })}
+							placeholder='Optional'
+						/>
+					</div>
+					<div className='col-span-2'>
+						<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Start date (optional)</label>
+						<Input
+							value={action.start_date ?? ''}
+							onChange={(v) => onChange({ ...action, start_date: v || undefined })}
+							placeholder='Optional'
+						/>
+					</div>
+				</div>
+			)}
+			{type === 'create_feature_and_price' && 'plan_id' in action && (
+				<div className='grid grid-cols-2 gap-3'>
+					<div>
+						<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Plan ID</label>
+						<Input value={action.plan_id} onChange={(v) => onChange({ ...action, plan_id: v })} />
+					</div>
+					<div>
+						<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Feature type</label>
+						<Select
+							options={[
+								{ value: 'metered', label: 'Metered' },
+								{ value: 'boolean', label: 'Boolean' },
+								{ value: 'static', label: 'Static' },
+							]}
+							value={action.feature_type ?? ''}
+							onChange={(v) =>
+								onChange({
+									...action,
+									feature_type: (v as 'metered' | 'boolean' | 'static') || undefined,
+								})
+							}
+							placeholder='Optional'
+						/>
+					</div>
+					<div className='col-span-2'>
+						<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Price start date/time (optional)</label>
+						<Input
+							value={action.price_start_date_time ?? ''}
+							onChange={(v) => onChange({ ...action, price_start_date_time: v || undefined })}
+							placeholder='Optional'
+						/>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+export function CustomerOnboardingSection() {
+	const { isLoading, isError, formValue, setFormValue, saveMutation, resetMutation, backendDetails, refetch } =
+		useSettingSection<CustomerOnboardingConfig>({
+			key: SETTING_KEY,
+			defaultValue: DEFAULT_CUSTOMER_ONBOARDING_CONFIG,
+		});
+
+	const [inlineError, setInlineError] = useState<string | null>(null);
+
+	const validate = (): boolean => {
+		if (formValue.actions.length === 0) {
+			setInlineError('At least one action is required. First action must be Create customer.');
+			return false;
+		}
+		if (formValue.actions[0].action !== 'create_customer') {
+			setInlineError('First action must be Create customer.');
+			return false;
+		}
+		setInlineError(null);
+		return true;
+	};
+
+	const handleSave = () => {
+		if (!validate()) return;
+		saveMutation.mutate(formValue);
+	};
+
+	const handleReset = () => {
+		resetMutation.mutate(undefined);
+	};
+
+	const updateAction = (index: number, next: CustomerOnboardingAction) => {
+		setFormValue((prev) => {
+			const actions = [...prev.actions];
+			actions[index] = next;
+			return { ...prev, actions };
+		});
+	};
+
+	const addAction = () => {
+		setFormValue((prev) => ({
+			...prev,
+			actions: [...prev.actions, { action: 'create_customer' }],
+		}));
+	};
+
+	const removeAction = (index: number) => {
+		setFormValue((prev) => ({
+			...prev,
+			actions: prev.actions.filter((_, i) => i !== index),
+		}));
+	};
+
+	if (isLoading) {
+		return (
+			<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+				<div className='p-6'>
+					<Loader />
+				</div>
+			</Card>
+		);
+	}
+
+	return (
+		<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+			<CardHeader
+				title='Customer onboarding workflow'
+				titleClassName='text-lg font-medium text-zinc-800'
+				cta={
+					<div className='flex items-center gap-2'>
+						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
+							Reset to default
+						</Button>
+						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+							Save
+						</Button>
+					</div>
+				}
+			/>
+			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
+				{isError && (
+					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+						Failed to load settings.{' '}
+						<button type='button' onClick={() => refetch()} className='underline font-medium'>
+							Retry
+						</button>
+					</div>
+				)}
+				{inlineError && (
+					<div className='rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800' role='alert'>
+						{inlineError}
+					</div>
+				)}
+				<p className='text-sm text-zinc-600'>
+					Workflow type: <strong>customer_onboarding</strong>. First action must be Create customer.
+				</p>
+				<div className='flex items-center justify-between'>
+					<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Actions</label>
+					<Button type='button' variant='outline' size='sm' onClick={addAction}>
+						<Plus className='h-3.5 w-3.5 mr-1' />
+						Add action
+					</Button>
+				</div>
+				<div className='space-y-3'>
+					{formValue.actions.map((action, index) => (
+						<ActionRow
+							key={index}
+							action={action}
+							onChange={(next) => updateAction(index, next)}
+							onRemove={() => removeAction(index)}
+							canRemove={formValue.actions.length > 1}
+						/>
+					))}
+				</div>
+				{getFieldError(backendDetails, 'actions') && (
+					<p className='text-sm text-red-600' role='alert'>
+						{getFieldError(backendDetails, 'actions')}
+					</p>
+				)}
+			</div>
+		</Card>
+	);
+}

--- a/src/pages/settings/org/CustomerOnboardingSection.tsx
+++ b/src/pages/settings/org/CustomerOnboardingSection.tsx
@@ -1,5 +1,6 @@
-import { Card, CardHeader, Button, Input, Loader, Select, type SelectOption } from '@/components/atoms';
+import { Card, CardHeader, Button, Input, Loader, Select, Textarea, type SelectOption } from '@/components/atoms';
 import { useSettingSection } from '@/hooks/useSettingSection';
+import { useJsonEditor } from '@/hooks/useJsonEditor';
 import { DEFAULT_CUSTOMER_ONBOARDING_CONFIG, type CustomerOnboardingConfig, type CustomerOnboardingAction } from '@/types/dto/OrgSettings';
 import { Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
@@ -168,6 +169,24 @@ export function CustomerOnboardingSection() {
 
 	const [inlineError, setInlineError] = useState<string | null>(null);
 
+	const jsonEditor = useJsonEditor({
+		initialValue: formValue,
+		sendCompleteConfig: true,
+		validate: (value) => {
+			if (value.actions.length === 0) {
+				return 'At least one action is required. First action must be Create customer.';
+			}
+			if (value.actions[0].action !== 'create_customer') {
+				return 'First action must be Create customer.';
+			}
+			return null;
+		},
+		onSave: (data) => {
+			saveMutation.mutate(data as CustomerOnboardingConfig);
+			setFormValue((prev) => ({ ...prev, ...(data as CustomerOnboardingConfig) }));
+		},
+	});
+
 	const validate = (): boolean => {
 		if (formValue.actions.length === 0) {
 			setInlineError('At least one action is required. First action must be Create customer.');
@@ -232,51 +251,91 @@ export function CustomerOnboardingSection() {
 						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
 							Reset to default
 						</Button>
-						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+						<Button variant='outline' size='sm' onClick={jsonEditor.toggleEditor}>
+							{jsonEditor.showJsonEditor ? 'Form View' : 'JSON Editor'}
+						</Button>
+						<Button
+							size='sm'
+							onClick={jsonEditor.showJsonEditor ? jsonEditor.handleJsonSave : handleSave}
+							disabled={saveMutation.isPending}
+							isLoading={saveMutation.isPending}>
 							Save
 						</Button>
 					</div>
 				}
 			/>
 			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
-				{isError && (
-					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
-						Failed to load settings.{' '}
-						<button type='button' onClick={() => refetch()} className='underline font-medium'>
-							Retry
-						</button>
+				{!jsonEditor.showJsonEditor ? (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
+						{inlineError && (
+							<div className='rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800' role='alert'>
+								{inlineError}
+							</div>
+						)}
+						<p className='text-sm text-zinc-600'>
+							Workflow type: <strong>customer_onboarding</strong>. First action must be Create customer.
+						</p>
+						<div className='flex items-center justify-between'>
+							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Actions</label>
+							<Button type='button' variant='outline' size='sm' onClick={addAction}>
+								<Plus className='h-3.5 w-3.5 mr-1' />
+								Add action
+							</Button>
+						</div>
+						<div className='space-y-3'>
+							{formValue.actions.map((action, index) => (
+								<ActionRow
+									key={index}
+									action={action}
+									onChange={(next) => updateAction(index, next)}
+									onRemove={() => removeAction(index)}
+									canRemove={formValue.actions.length > 1}
+								/>
+							))}
+						</div>
+						{getFieldError(backendDetails, 'actions') && (
+							<p className='text-sm text-red-600' role='alert'>
+								{getFieldError(backendDetails, 'actions')}
+							</p>
+						)}
 					</div>
-				)}
-				{inlineError && (
-					<div className='rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800' role='alert'>
-						{inlineError}
+				) : (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
+						<div>
+							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								JSON Configuration (Developer Mode)
+							</label>
+							<Textarea
+								value={jsonEditor.jsonValue}
+								onChange={jsonEditor.setJsonValue}
+								placeholder='Paste or edit JSON configuration here...'
+								error={jsonEditor.jsonError}
+								description='Edit the customer onboarding configuration directly in JSON format. Only changed values will be saved.'
+								textAreaClassName='min-h-[400px] font-mono text-sm'
+							/>
+							{jsonEditor.jsonError && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{jsonEditor.jsonError}
+								</p>
+							)}
+						</div>
 					</div>
-				)}
-				<p className='text-sm text-zinc-600'>
-					Workflow type: <strong>customer_onboarding</strong>. First action must be Create customer.
-				</p>
-				<div className='flex items-center justify-between'>
-					<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Actions</label>
-					<Button type='button' variant='outline' size='sm' onClick={addAction}>
-						<Plus className='h-3.5 w-3.5 mr-1' />
-						Add action
-					</Button>
-				</div>
-				<div className='space-y-3'>
-					{formValue.actions.map((action, index) => (
-						<ActionRow
-							key={index}
-							action={action}
-							onChange={(next) => updateAction(index, next)}
-							onRemove={() => removeAction(index)}
-							canRemove={formValue.actions.length > 1}
-						/>
-					))}
-				</div>
-				{getFieldError(backendDetails, 'actions') && (
-					<p className='text-sm text-red-600' role='alert'>
-						{getFieldError(backendDetails, 'actions')}
-					</p>
 				)}
 			</div>
 		</Card>

--- a/src/pages/settings/org/CustomerPortalConfigSection.tsx
+++ b/src/pages/settings/org/CustomerPortalConfigSection.tsx
@@ -1,0 +1,277 @@
+import { Card, CardHeader, Button, Input, Loader, Select, type SelectOption } from '@/components/atoms';
+import { useSettingSection } from '@/hooks/useSettingSection';
+import {
+	DEFAULT_CUSTOMER_PORTAL_CONFIG_ORG,
+	type CustomerPortalConfigOrg,
+	type CustomerPortalSectionConfigOrg,
+	type CustomerPortalTabConfigOrg,
+	type CustomerPortalTabType,
+} from '@/types/dto/OrgSettings';
+import { Plus, Trash2 } from 'lucide-react';
+
+const SETTING_KEY = 'customer_portal_config';
+
+const TAB_TYPE_OPTIONS: SelectOption[] = [
+	{ value: 'metric_cards', label: 'Metric cards' },
+	{ value: 'usage_graph', label: 'Usage graph' },
+	{ value: 'current_usage', label: 'Current usage' },
+	{ value: 'usage_breakdown', label: 'Usage breakdown' },
+	{ value: 'wallet_balance', label: 'Wallet balance' },
+	{ value: 'wallet_transactions', label: 'Wallet transactions' },
+	{ value: 'invoices', label: 'Invoices' },
+	{ value: 'subscriptions', label: 'Subscriptions' },
+];
+
+function getFieldError(details: Record<string, string>, field: string): string | undefined {
+	return details[`value.${field}`] ?? details[field];
+}
+
+export function CustomerPortalConfigSection() {
+	const { isLoading, isError, formValue, setFormValue, saveMutation, resetMutation, backendDetails, refetch } =
+		useSettingSection<CustomerPortalConfigOrg>({
+			key: SETTING_KEY,
+			defaultValue: DEFAULT_CUSTOMER_PORTAL_CONFIG_ORG,
+		});
+
+	const handleSave = () => {
+		saveMutation.mutate(formValue);
+	};
+
+	const handleReset = () => {
+		resetMutation.mutate(undefined);
+	};
+
+	const setTheme = (patch: Partial<NonNullable<CustomerPortalConfigOrg['theme']>>) => {
+		setFormValue((prev) => ({
+			...prev,
+			theme: { ...(prev.theme ?? {}), ...patch },
+		}));
+	};
+
+	const addSection = () => {
+		setFormValue((prev) => ({
+			...prev,
+			sections: [
+				...prev.sections,
+				{
+					id: `section-${Date.now()}`,
+					label: 'New section',
+					enabled: true,
+					order: prev.sections.length + 1,
+					tabs: [],
+				},
+			],
+		}));
+	};
+
+	const updateSection = (index: number, patch: Partial<CustomerPortalSectionConfigOrg>) => {
+		setFormValue((prev) => {
+			const sections = [...prev.sections];
+			sections[index] = { ...sections[index], ...patch };
+			return { ...prev, sections };
+		});
+	};
+
+	const removeSection = (index: number) => {
+		setFormValue((prev) => ({
+			...prev,
+			sections: prev.sections.filter((_, i) => i !== index),
+		}));
+	};
+
+	const addTab = (sectionIndex: number) => {
+		setFormValue((prev) => {
+			const sections = [...prev.sections];
+			const sec = sections[sectionIndex];
+			const newTab: CustomerPortalTabConfigOrg = {
+				id: `tab-${Date.now()}`,
+				type: 'metric_cards',
+				enabled: true,
+				order: sec.tabs.length + 1,
+			};
+			const tabs = [...sec.tabs, newTab];
+			sections[sectionIndex] = { ...sec, tabs };
+			return { ...prev, sections };
+		});
+	};
+
+	const updateTab = (sectionIndex: number, tabIndex: number, patch: Partial<CustomerPortalTabConfigOrg>) => {
+		setFormValue((prev) => {
+			const sections = [...prev.sections];
+			const tabs = [...sections[sectionIndex].tabs];
+			tabs[tabIndex] = { ...tabs[tabIndex], ...patch };
+			sections[sectionIndex] = { ...sections[sectionIndex], tabs };
+			return { ...prev, sections };
+		});
+	};
+
+	const removeTab = (sectionIndex: number, tabIndex: number) => {
+		setFormValue((prev) => {
+			const sections = [...prev.sections];
+			sections[sectionIndex] = {
+				...sections[sectionIndex],
+				tabs: sections[sectionIndex].tabs.filter((_, i) => i !== tabIndex),
+			};
+			return { ...prev, sections };
+		});
+	};
+
+	if (isLoading) {
+		return (
+			<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+				<div className='p-6'>
+					<Loader />
+				</div>
+			</Card>
+		);
+	}
+
+	return (
+		<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+			<CardHeader
+				title='Customer portal'
+				titleClassName='text-lg font-medium text-zinc-800'
+				cta={
+					<div className='flex items-center gap-2'>
+						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
+							Reset to default
+						</Button>
+						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+							Save
+						</Button>
+					</div>
+				}
+			/>
+			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-6'>
+				{isError && (
+					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+						Failed to load settings.{' '}
+						<button type='button' onClick={() => refetch()} className='underline font-medium'>
+							Retry
+						</button>
+					</div>
+				)}
+				<div>
+					<label htmlFor='version' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+						Version
+					</label>
+					<Input id='version' value={formValue.version} onChange={(v) => setFormValue((prev) => ({ ...prev, version: v }))} />
+				</div>
+				<div>
+					<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-2'>Theme</label>
+					<div className='grid grid-cols-3 gap-3'>
+						<div>
+							<label className='block text-xs text-zinc-500 mb-1'>Primary color</label>
+							<Input
+								value={formValue.theme?.primary_color ?? ''}
+								onChange={(v) => setTheme({ primary_color: v || undefined })}
+								placeholder='#hex'
+							/>
+						</div>
+						<div>
+							<label className='block text-xs text-zinc-500 mb-1'>Secondary color</label>
+							<Input
+								value={formValue.theme?.secondary_color ?? ''}
+								onChange={(v) => setTheme({ secondary_color: v || undefined })}
+								placeholder='#hex'
+							/>
+						</div>
+						<div>
+							<label className='block text-xs text-zinc-500 mb-1'>Tertiary color</label>
+							<Input
+								value={formValue.theme?.tertiary_color ?? ''}
+								onChange={(v) => setTheme({ tertiary_color: v || undefined })}
+								placeholder='#hex'
+							/>
+						</div>
+					</div>
+				</div>
+				<div>
+					<div className='flex items-center justify-between mb-2'>
+						<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Sections</label>
+						<Button type='button' variant='outline' size='sm' onClick={addSection}>
+							<Plus className='h-3.5 w-3.5 mr-1' />
+							Add section
+						</Button>
+					</div>
+					<div className='space-y-4'>
+						{formValue.sections.map((section, sIdx) => (
+							<div key={section.id} className='p-4 rounded-lg border border-gray-200 bg-gray-50/50 space-y-3'>
+								<div className='flex flex-wrap items-center gap-2'>
+									<Input placeholder='Section ID' value={section.id} onChange={(v) => updateSection(sIdx, { id: v })} className='w-32' />
+									<Input placeholder='Label' value={section.label} onChange={(v) => updateSection(sIdx, { label: v })} className='w-40' />
+									<Input
+										type='number'
+										placeholder='Order'
+										value={String(section.order)}
+										onChange={(v) => updateSection(sIdx, { order: v ? parseInt(v, 10) : 0 })}
+										className='w-20'
+									/>
+									<label className='flex items-center gap-1.5 text-sm'>
+										<input
+											type='checkbox'
+											checked={section.enabled}
+											onChange={(e) => updateSection(sIdx, { enabled: e.target.checked })}
+											className='h-4 w-4 rounded border-gray-300'
+										/>
+										Enabled
+									</label>
+									<Button type='button' variant='outline' size='sm' onClick={() => removeSection(sIdx)} aria-label='Remove section'>
+										<Trash2 className='h-4 w-4' />
+									</Button>
+								</div>
+								<div className='pl-2 border-l-2 border-gray-200'>
+									<div className='flex items-center justify-between mb-2'>
+										<span className='text-xs font-medium text-zinc-500'>Tabs</span>
+										<Button type='button' variant='ghost' size='sm' onClick={() => addTab(sIdx)}>
+											<Plus className='h-3 w-3 mr-1' />
+											Add tab
+										</Button>
+									</div>
+									{section.tabs.map((tab, tIdx) => (
+										<div key={tab.id} className='flex flex-wrap items-center gap-2 py-1'>
+											<Input placeholder='Tab ID' value={tab.id} onChange={(v) => updateTab(sIdx, tIdx, { id: v })} className='w-24' />
+											<Select
+												options={TAB_TYPE_OPTIONS}
+												value={tab.type}
+												onChange={(v) => updateTab(sIdx, tIdx, { type: v as CustomerPortalTabType })}
+												className='w-40'
+											/>
+											<Input
+												type='number'
+												placeholder='Order'
+												value={String(tab.order)}
+												onChange={(v) => updateTab(sIdx, tIdx, { order: v ? parseInt(v, 10) : 0 })}
+												className='w-16'
+											/>
+											<label className='flex items-center gap-1 text-sm'>
+												<input
+													type='checkbox'
+													checked={tab.enabled}
+													onChange={(e) => updateTab(sIdx, tIdx, { enabled: e.target.checked })}
+													className='h-3.5 w-3.5 rounded border-gray-300'
+												/>
+												On
+											</label>
+											<Button type='button' variant='ghost' size='sm' onClick={() => removeTab(sIdx, tIdx)} aria-label='Remove tab'>
+												<Trash2 className='h-3.5 w-3.5' />
+											</Button>
+										</div>
+									))}
+								</div>
+							</div>
+						))}
+					</div>
+					{formValue.sections.length === 0 && (
+						<p className='text-sm text-zinc-500'>No sections. Add sections to configure portal layout.</p>
+					)}
+				</div>
+				{getFieldError(backendDetails, 'sections') && (
+					<p className='text-sm text-red-600' role='alert'>
+						{getFieldError(backendDetails, 'sections')}
+					</p>
+				)}
+			</div>
+		</Card>
+	);
+}

--- a/src/pages/settings/org/CustomerPortalConfigSection.tsx
+++ b/src/pages/settings/org/CustomerPortalConfigSection.tsx
@@ -1,38 +1,16 @@
-import { Card, CardHeader, Button, Input, Loader, Select, Textarea, type SelectOption } from '@/components/atoms';
+import { Card, CardHeader, Button, Loader, Textarea } from '@/components/atoms';
 import { useSettingSection } from '@/hooks/useSettingSection';
 import { useJsonEditor } from '@/hooks/useJsonEditor';
-import {
-	DEFAULT_CUSTOMER_PORTAL_CONFIG_ORG,
-	type CustomerPortalConfigOrg,
-	type CustomerPortalSectionConfigOrg,
-	type CustomerPortalTabConfigOrg,
-	type CustomerPortalTabType,
-} from '@/types/dto/OrgSettings';
-import { Plus, Trash2 } from 'lucide-react';
+import { useEffect } from 'react';
+import { DEFAULT_CUSTOMER_PORTAL_CONFIG_ORG, type CustomerPortalConfigOrg } from '@/types/dto/OrgSettings';
 
 const SETTING_KEY = 'customer_portal_config';
 
-const TAB_TYPE_OPTIONS: SelectOption[] = [
-	{ value: 'metric_cards', label: 'Metric cards' },
-	{ value: 'usage_graph', label: 'Usage graph' },
-	{ value: 'current_usage', label: 'Current usage' },
-	{ value: 'usage_breakdown', label: 'Usage breakdown' },
-	{ value: 'wallet_balance', label: 'Wallet balance' },
-	{ value: 'wallet_transactions', label: 'Wallet transactions' },
-	{ value: 'invoices', label: 'Invoices' },
-	{ value: 'subscriptions', label: 'Subscriptions' },
-];
-
-function getFieldError(details: Record<string, string>, field: string): string | undefined {
-	return details[`value.${field}`] ?? details[field];
-}
-
 export function CustomerPortalConfigSection() {
-	const { isLoading, isError, formValue, setFormValue, saveMutation, resetMutation, backendDetails, refetch } =
-		useSettingSection<CustomerPortalConfigOrg>({
-			key: SETTING_KEY,
-			defaultValue: DEFAULT_CUSTOMER_PORTAL_CONFIG_ORG,
-		});
+	const { isLoading, isError, formValue, setFormValue, saveMutation, resetMutation, refetch } = useSettingSection<CustomerPortalConfigOrg>({
+		key: SETTING_KEY,
+		defaultValue: DEFAULT_CUSTOMER_PORTAL_CONFIG_ORG,
+	});
 
 	const jsonEditor = useJsonEditor({
 		initialValue: formValue,
@@ -43,87 +21,13 @@ export function CustomerPortalConfigSection() {
 		},
 	});
 
-	const handleSave = () => {
-		saveMutation.mutate(formValue);
-	};
+	// Initialize JSON editor content since we're always showing it
+	useEffect(() => {
+		jsonEditor.setJsonValue(JSON.stringify(formValue, null, 2));
+	}, [formValue, jsonEditor]);
 
 	const handleReset = () => {
 		resetMutation.mutate(undefined);
-	};
-
-	const setTheme = (patch: Partial<NonNullable<CustomerPortalConfigOrg['theme']>>) => {
-		setFormValue((prev) => ({
-			...prev,
-			theme: { ...(prev.theme ?? {}), ...patch },
-		}));
-	};
-
-	const addSection = () => {
-		setFormValue((prev) => ({
-			...prev,
-			sections: [
-				...prev.sections,
-				{
-					id: `section-${Date.now()}`,
-					label: 'New section',
-					enabled: true,
-					order: prev.sections.length + 1,
-					tabs: [],
-				},
-			],
-		}));
-	};
-
-	const updateSection = (index: number, patch: Partial<CustomerPortalSectionConfigOrg>) => {
-		setFormValue((prev) => {
-			const sections = [...prev.sections];
-			sections[index] = { ...sections[index], ...patch };
-			return { ...prev, sections };
-		});
-	};
-
-	const removeSection = (index: number) => {
-		setFormValue((prev) => ({
-			...prev,
-			sections: prev.sections.filter((_, i) => i !== index),
-		}));
-	};
-
-	const addTab = (sectionIndex: number) => {
-		setFormValue((prev) => {
-			const sections = [...prev.sections];
-			const sec = sections[sectionIndex];
-			const newTab: CustomerPortalTabConfigOrg = {
-				id: `tab-${Date.now()}`,
-				type: 'metric_cards',
-				enabled: true,
-				order: sec.tabs.length + 1,
-			};
-			const tabs = [...sec.tabs, newTab];
-			sections[sectionIndex] = { ...sec, tabs };
-			return { ...prev, sections };
-		});
-	};
-
-	const updateTab = (sectionIndex: number, tabIndex: number, patch: Partial<CustomerPortalTabConfigOrg>) => {
-		setFormValue((prev) => {
-			const sections = [...prev.sections];
-			const tabs = [...sections[sectionIndex].tabs];
-			tabs[tabIndex] = { ...tabs[tabIndex], ...patch };
-			sections[sectionIndex] = { ...sections[sectionIndex], tabs };
-			return { ...prev, sections };
-		});
-	};
-
-	const removeTab = (sectionIndex: number, tabIndex: number) => {
-		setFormValue((prev) => {
-			const sections = [...prev.sections];
-			sections[sectionIndex] = {
-				...sections[sectionIndex],
-				tabs: sections[sectionIndex].tabs.filter((_, i) => i !== tabIndex),
-			};
-			return { ...prev, sections };
-		});
 	};
 
 	if (isLoading) {
@@ -146,191 +50,39 @@ export function CustomerPortalConfigSection() {
 						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
 							Reset to default
 						</Button>
-						<Button variant='outline' size='sm' onClick={jsonEditor.toggleEditor}>
-							{jsonEditor.showJsonEditor ? 'Form View' : 'JSON Editor'}
-						</Button>
-						<Button
-							size='sm'
-							onClick={jsonEditor.showJsonEditor ? jsonEditor.handleJsonSave : handleSave}
-							disabled={saveMutation.isPending}
-							isLoading={saveMutation.isPending}>
+						<Button size='sm' onClick={jsonEditor.handleJsonSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
 							Save
 						</Button>
 					</div>
 				}
 			/>
 			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
-				{!jsonEditor.showJsonEditor ? (
-					<div className='space-y-6'>
-						{isError && (
-							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
-								Failed to load settings.{' '}
-								<button type='button' onClick={() => refetch()} className='underline font-medium'>
-									Retry
-								</button>
-							</div>
-						)}
-						<div>
-							<label htmlFor='version' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
-								Version
-							</label>
-							<Input id='version' value={formValue.version} onChange={(v) => setFormValue((prev) => ({ ...prev, version: v }))} />
-						</div>
-						<div>
-							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-2'>Theme</label>
-							<div className='grid grid-cols-3 gap-3'>
-								<div>
-									<label className='block text-xs text-zinc-500 mb-1'>Primary color</label>
-									<Input
-										value={formValue.theme?.primary_color ?? ''}
-										onChange={(v) => setTheme({ primary_color: v || undefined })}
-										placeholder='#hex'
-									/>
-								</div>
-								<div>
-									<label className='block text-xs text-zinc-500 mb-1'>Secondary color</label>
-									<Input
-										value={formValue.theme?.secondary_color ?? ''}
-										onChange={(v) => setTheme({ secondary_color: v || undefined })}
-										placeholder='#hex'
-									/>
-								</div>
-								<div>
-									<label className='block text-xs text-zinc-500 mb-1'>Tertiary color</label>
-									<Input
-										value={formValue.theme?.tertiary_color ?? ''}
-										onChange={(v) => setTheme({ tertiary_color: v || undefined })}
-										placeholder='#hex'
-									/>
-								</div>
-							</div>
-						</div>
-						<div>
-							<div className='flex items-center justify-between mb-2'>
-								<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Sections</label>
-								<Button type='button' variant='outline' size='sm' onClick={addSection}>
-									<Plus className='h-3.5 w-3.5 mr-1' />
-									Add section
-								</Button>
-							</div>
-							<div className='space-y-4'>
-								{formValue.sections.map((section, sIdx) => (
-									<div key={section.id} className='p-4 rounded-lg border border-gray-200 bg-gray-50/50 space-y-3'>
-										<div className='flex flex-wrap items-center gap-2'>
-											<Input
-												placeholder='Section ID'
-												value={section.id}
-												onChange={(v) => updateSection(sIdx, { id: v })}
-												className='w-32'
-											/>
-											<Input
-												placeholder='Label'
-												value={section.label}
-												onChange={(v) => updateSection(sIdx, { label: v })}
-												className='w-40'
-											/>
-											<Input
-												type='number'
-												placeholder='Order'
-												value={String(section.order)}
-												onChange={(v) => updateSection(sIdx, { order: v ? parseInt(v, 10) : 0 })}
-												className='w-20'
-											/>
-											<label className='flex items-center gap-1.5 text-sm'>
-												<input
-													type='checkbox'
-													checked={section.enabled}
-													onChange={(e) => updateSection(sIdx, { enabled: e.target.checked })}
-													className='h-4 w-4 rounded border-gray-300'
-												/>
-												Enabled
-											</label>
-											<Button type='button' variant='outline' size='sm' onClick={() => removeSection(sIdx)} aria-label='Remove section'>
-												<Trash2 className='h-4 w-4' />
-											</Button>
-										</div>
-										<div className='pl-2 border-l-2 border-gray-200'>
-											<div className='flex items-center justify-between mb-2'>
-												<span className='text-xs font-medium text-zinc-500'>Tabs</span>
-												<Button type='button' variant='ghost' size='sm' onClick={() => addTab(sIdx)}>
-													<Plus className='h-3 w-3 mr-1' />
-													Add tab
-												</Button>
-											</div>
-											{section.tabs.map((tab, tIdx) => (
-												<div key={tab.id} className='flex flex-wrap items-center gap-2 py-1'>
-													<Input placeholder='Tab ID' value={tab.id} onChange={(v) => updateTab(sIdx, tIdx, { id: v })} className='w-24' />
-													<Select
-														options={TAB_TYPE_OPTIONS}
-														value={tab.type}
-														onChange={(v) => updateTab(sIdx, tIdx, { type: v as CustomerPortalTabType })}
-														className='w-40'
-													/>
-													<Input
-														type='number'
-														placeholder='Order'
-														value={String(tab.order)}
-														onChange={(v) => updateTab(sIdx, tIdx, { order: v ? parseInt(v, 10) : 0 })}
-														className='w-16'
-													/>
-													<label className='flex items-center gap-1 text-sm'>
-														<input
-															type='checkbox'
-															checked={tab.enabled}
-															onChange={(e) => updateTab(sIdx, tIdx, { enabled: e.target.checked })}
-															className='h-3.5 w-3.5 rounded border-gray-300'
-														/>
-														On
-													</label>
-													<Button type='button' variant='ghost' size='sm' onClick={() => removeTab(sIdx, tIdx)} aria-label='Remove tab'>
-														<Trash2 className='h-3.5 w-3.5' />
-													</Button>
-												</div>
-											))}
-										</div>
-									</div>
-								))}
-							</div>
-							{formValue.sections.length === 0 && (
-								<p className='text-sm text-zinc-500'>No sections. Add sections to configure portal layout.</p>
-							)}
-						</div>
-						{getFieldError(backendDetails, 'sections') && (
-							<p className='text-sm text-red-600' role='alert'>
-								{getFieldError(backendDetails, 'sections')}
-							</p>
-						)}
-					</div>
-				) : (
-					<div className='space-y-4'>
-						{isError && (
-							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
-								Failed to load settings.{' '}
-								<button type='button' onClick={() => refetch()} className='underline font-medium'>
-									Retry
-								</button>
-							</div>
-						)}
-						<div>
-							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
-								JSON Configuration (Developer Mode)
-							</label>
-							<Textarea
-								value={jsonEditor.jsonValue}
-								onChange={jsonEditor.setJsonValue}
-								placeholder='Paste or edit JSON configuration here...'
-								error={jsonEditor.jsonError}
-								description='Edit the customer portal configuration directly in JSON format. Only changed values will be saved.'
-								textAreaClassName='min-h-[400px] font-mono text-sm'
-							/>
-							{jsonEditor.jsonError && (
-								<p className='mt-1 text-sm text-red-600' role='alert'>
-									{jsonEditor.jsonError}
-								</p>
-							)}
-						</div>
+				{isError && (
+					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+						Failed to load settings.{' '}
+						<button type='button' onClick={() => refetch()} className='underline font-medium'>
+							Retry
+						</button>
 					</div>
 				)}
+				<div>
+					<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+						JSON Configuration (Developer Mode)
+					</label>
+					<Textarea
+						value={jsonEditor.jsonValue}
+						onChange={jsonEditor.setJsonValue}
+						placeholder='Paste or edit JSON configuration here...'
+						error={jsonEditor.jsonError}
+						description='Edit the customer portal configuration directly in JSON format. Only changed values will be saved.'
+						textAreaClassName='min-h-[400px] font-mono text-sm'
+					/>
+					{jsonEditor.jsonError && (
+						<p className='mt-1 text-sm text-red-600' role='alert'>
+							{jsonEditor.jsonError}
+						</p>
+					)}
+				</div>
 			</div>
 		</Card>
 	);

--- a/src/pages/settings/org/CustomerPortalConfigSection.tsx
+++ b/src/pages/settings/org/CustomerPortalConfigSection.tsx
@@ -1,5 +1,6 @@
-import { Card, CardHeader, Button, Input, Loader, Select, type SelectOption } from '@/components/atoms';
+import { Card, CardHeader, Button, Input, Loader, Select, Textarea, type SelectOption } from '@/components/atoms';
 import { useSettingSection } from '@/hooks/useSettingSection';
+import { useJsonEditor } from '@/hooks/useJsonEditor';
 import {
 	DEFAULT_CUSTOMER_PORTAL_CONFIG_ORG,
 	type CustomerPortalConfigOrg,
@@ -32,6 +33,15 @@ export function CustomerPortalConfigSection() {
 			key: SETTING_KEY,
 			defaultValue: DEFAULT_CUSTOMER_PORTAL_CONFIG_ORG,
 		});
+
+	const jsonEditor = useJsonEditor({
+		initialValue: formValue,
+		sendCompleteConfig: true,
+		onSave: (data) => {
+			saveMutation.mutate(data as CustomerPortalConfigOrg);
+			setFormValue((prev) => ({ ...prev, ...(data as CustomerPortalConfigOrg) }));
+		},
+	});
 
 	const handleSave = () => {
 		saveMutation.mutate(formValue);
@@ -136,140 +146,190 @@ export function CustomerPortalConfigSection() {
 						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
 							Reset to default
 						</Button>
-						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+						<Button variant='outline' size='sm' onClick={jsonEditor.toggleEditor}>
+							{jsonEditor.showJsonEditor ? 'Form View' : 'JSON Editor'}
+						</Button>
+						<Button
+							size='sm'
+							onClick={jsonEditor.showJsonEditor ? jsonEditor.handleJsonSave : handleSave}
+							disabled={saveMutation.isPending}
+							isLoading={saveMutation.isPending}>
 							Save
 						</Button>
 					</div>
 				}
 			/>
-			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-6'>
-				{isError && (
-					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
-						Failed to load settings.{' '}
-						<button type='button' onClick={() => refetch()} className='underline font-medium'>
-							Retry
-						</button>
-					</div>
-				)}
-				<div>
-					<label htmlFor='version' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
-						Version
-					</label>
-					<Input id='version' value={formValue.version} onChange={(v) => setFormValue((prev) => ({ ...prev, version: v }))} />
-				</div>
-				<div>
-					<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-2'>Theme</label>
-					<div className='grid grid-cols-3 gap-3'>
+			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
+				{!jsonEditor.showJsonEditor ? (
+					<div className='space-y-6'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
 						<div>
-							<label className='block text-xs text-zinc-500 mb-1'>Primary color</label>
-							<Input
-								value={formValue.theme?.primary_color ?? ''}
-								onChange={(v) => setTheme({ primary_color: v || undefined })}
-								placeholder='#hex'
-							/>
+							<label htmlFor='version' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								Version
+							</label>
+							<Input id='version' value={formValue.version} onChange={(v) => setFormValue((prev) => ({ ...prev, version: v }))} />
 						</div>
 						<div>
-							<label className='block text-xs text-zinc-500 mb-1'>Secondary color</label>
-							<Input
-								value={formValue.theme?.secondary_color ?? ''}
-								onChange={(v) => setTheme({ secondary_color: v || undefined })}
-								placeholder='#hex'
-							/>
-						</div>
-						<div>
-							<label className='block text-xs text-zinc-500 mb-1'>Tertiary color</label>
-							<Input
-								value={formValue.theme?.tertiary_color ?? ''}
-								onChange={(v) => setTheme({ tertiary_color: v || undefined })}
-								placeholder='#hex'
-							/>
-						</div>
-					</div>
-				</div>
-				<div>
-					<div className='flex items-center justify-between mb-2'>
-						<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Sections</label>
-						<Button type='button' variant='outline' size='sm' onClick={addSection}>
-							<Plus className='h-3.5 w-3.5 mr-1' />
-							Add section
-						</Button>
-					</div>
-					<div className='space-y-4'>
-						{formValue.sections.map((section, sIdx) => (
-							<div key={section.id} className='p-4 rounded-lg border border-gray-200 bg-gray-50/50 space-y-3'>
-								<div className='flex flex-wrap items-center gap-2'>
-									<Input placeholder='Section ID' value={section.id} onChange={(v) => updateSection(sIdx, { id: v })} className='w-32' />
-									<Input placeholder='Label' value={section.label} onChange={(v) => updateSection(sIdx, { label: v })} className='w-40' />
+							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-2'>Theme</label>
+							<div className='grid grid-cols-3 gap-3'>
+								<div>
+									<label className='block text-xs text-zinc-500 mb-1'>Primary color</label>
 									<Input
-										type='number'
-										placeholder='Order'
-										value={String(section.order)}
-										onChange={(v) => updateSection(sIdx, { order: v ? parseInt(v, 10) : 0 })}
-										className='w-20'
+										value={formValue.theme?.primary_color ?? ''}
+										onChange={(v) => setTheme({ primary_color: v || undefined })}
+										placeholder='#hex'
 									/>
-									<label className='flex items-center gap-1.5 text-sm'>
-										<input
-											type='checkbox'
-											checked={section.enabled}
-											onChange={(e) => updateSection(sIdx, { enabled: e.target.checked })}
-											className='h-4 w-4 rounded border-gray-300'
-										/>
-										Enabled
-									</label>
-									<Button type='button' variant='outline' size='sm' onClick={() => removeSection(sIdx)} aria-label='Remove section'>
-										<Trash2 className='h-4 w-4' />
-									</Button>
 								</div>
-								<div className='pl-2 border-l-2 border-gray-200'>
-									<div className='flex items-center justify-between mb-2'>
-										<span className='text-xs font-medium text-zinc-500'>Tabs</span>
-										<Button type='button' variant='ghost' size='sm' onClick={() => addTab(sIdx)}>
-											<Plus className='h-3 w-3 mr-1' />
-											Add tab
-										</Button>
-									</div>
-									{section.tabs.map((tab, tIdx) => (
-										<div key={tab.id} className='flex flex-wrap items-center gap-2 py-1'>
-											<Input placeholder='Tab ID' value={tab.id} onChange={(v) => updateTab(sIdx, tIdx, { id: v })} className='w-24' />
-											<Select
-												options={TAB_TYPE_OPTIONS}
-												value={tab.type}
-												onChange={(v) => updateTab(sIdx, tIdx, { type: v as CustomerPortalTabType })}
+								<div>
+									<label className='block text-xs text-zinc-500 mb-1'>Secondary color</label>
+									<Input
+										value={formValue.theme?.secondary_color ?? ''}
+										onChange={(v) => setTheme({ secondary_color: v || undefined })}
+										placeholder='#hex'
+									/>
+								</div>
+								<div>
+									<label className='block text-xs text-zinc-500 mb-1'>Tertiary color</label>
+									<Input
+										value={formValue.theme?.tertiary_color ?? ''}
+										onChange={(v) => setTheme({ tertiary_color: v || undefined })}
+										placeholder='#hex'
+									/>
+								</div>
+							</div>
+						</div>
+						<div>
+							<div className='flex items-center justify-between mb-2'>
+								<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Sections</label>
+								<Button type='button' variant='outline' size='sm' onClick={addSection}>
+									<Plus className='h-3.5 w-3.5 mr-1' />
+									Add section
+								</Button>
+							</div>
+							<div className='space-y-4'>
+								{formValue.sections.map((section, sIdx) => (
+									<div key={section.id} className='p-4 rounded-lg border border-gray-200 bg-gray-50/50 space-y-3'>
+										<div className='flex flex-wrap items-center gap-2'>
+											<Input
+												placeholder='Section ID'
+												value={section.id}
+												onChange={(v) => updateSection(sIdx, { id: v })}
+												className='w-32'
+											/>
+											<Input
+												placeholder='Label'
+												value={section.label}
+												onChange={(v) => updateSection(sIdx, { label: v })}
 												className='w-40'
 											/>
 											<Input
 												type='number'
 												placeholder='Order'
-												value={String(tab.order)}
-												onChange={(v) => updateTab(sIdx, tIdx, { order: v ? parseInt(v, 10) : 0 })}
-												className='w-16'
+												value={String(section.order)}
+												onChange={(v) => updateSection(sIdx, { order: v ? parseInt(v, 10) : 0 })}
+												className='w-20'
 											/>
-											<label className='flex items-center gap-1 text-sm'>
+											<label className='flex items-center gap-1.5 text-sm'>
 												<input
 													type='checkbox'
-													checked={tab.enabled}
-													onChange={(e) => updateTab(sIdx, tIdx, { enabled: e.target.checked })}
-													className='h-3.5 w-3.5 rounded border-gray-300'
+													checked={section.enabled}
+													onChange={(e) => updateSection(sIdx, { enabled: e.target.checked })}
+													className='h-4 w-4 rounded border-gray-300'
 												/>
-												On
+												Enabled
 											</label>
-											<Button type='button' variant='ghost' size='sm' onClick={() => removeTab(sIdx, tIdx)} aria-label='Remove tab'>
-												<Trash2 className='h-3.5 w-3.5' />
+											<Button type='button' variant='outline' size='sm' onClick={() => removeSection(sIdx)} aria-label='Remove section'>
+												<Trash2 className='h-4 w-4' />
 											</Button>
 										</div>
-									))}
-								</div>
+										<div className='pl-2 border-l-2 border-gray-200'>
+											<div className='flex items-center justify-between mb-2'>
+												<span className='text-xs font-medium text-zinc-500'>Tabs</span>
+												<Button type='button' variant='ghost' size='sm' onClick={() => addTab(sIdx)}>
+													<Plus className='h-3 w-3 mr-1' />
+													Add tab
+												</Button>
+											</div>
+											{section.tabs.map((tab, tIdx) => (
+												<div key={tab.id} className='flex flex-wrap items-center gap-2 py-1'>
+													<Input placeholder='Tab ID' value={tab.id} onChange={(v) => updateTab(sIdx, tIdx, { id: v })} className='w-24' />
+													<Select
+														options={TAB_TYPE_OPTIONS}
+														value={tab.type}
+														onChange={(v) => updateTab(sIdx, tIdx, { type: v as CustomerPortalTabType })}
+														className='w-40'
+													/>
+													<Input
+														type='number'
+														placeholder='Order'
+														value={String(tab.order)}
+														onChange={(v) => updateTab(sIdx, tIdx, { order: v ? parseInt(v, 10) : 0 })}
+														className='w-16'
+													/>
+													<label className='flex items-center gap-1 text-sm'>
+														<input
+															type='checkbox'
+															checked={tab.enabled}
+															onChange={(e) => updateTab(sIdx, tIdx, { enabled: e.target.checked })}
+															className='h-3.5 w-3.5 rounded border-gray-300'
+														/>
+														On
+													</label>
+													<Button type='button' variant='ghost' size='sm' onClick={() => removeTab(sIdx, tIdx)} aria-label='Remove tab'>
+														<Trash2 className='h-3.5 w-3.5' />
+													</Button>
+												</div>
+											))}
+										</div>
+									</div>
+								))}
 							</div>
-						))}
+							{formValue.sections.length === 0 && (
+								<p className='text-sm text-zinc-500'>No sections. Add sections to configure portal layout.</p>
+							)}
+						</div>
+						{getFieldError(backendDetails, 'sections') && (
+							<p className='text-sm text-red-600' role='alert'>
+								{getFieldError(backendDetails, 'sections')}
+							</p>
+						)}
 					</div>
-					{formValue.sections.length === 0 && (
-						<p className='text-sm text-zinc-500'>No sections. Add sections to configure portal layout.</p>
-					)}
-				</div>
-				{getFieldError(backendDetails, 'sections') && (
-					<p className='text-sm text-red-600' role='alert'>
-						{getFieldError(backendDetails, 'sections')}
-					</p>
+				) : (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
+						<div>
+							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								JSON Configuration (Developer Mode)
+							</label>
+							<Textarea
+								value={jsonEditor.jsonValue}
+								onChange={jsonEditor.setJsonValue}
+								placeholder='Paste or edit JSON configuration here...'
+								error={jsonEditor.jsonError}
+								description='Edit the customer portal configuration directly in JSON format. Only changed values will be saved.'
+								textAreaClassName='min-h-[400px] font-mono text-sm'
+							/>
+							{jsonEditor.jsonError && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{jsonEditor.jsonError}
+								</p>
+							)}
+						</div>
+					</div>
 				)}
 			</div>
 		</Card>

--- a/src/pages/settings/org/InvoiceConfigSection.tsx
+++ b/src/pages/settings/org/InvoiceConfigSection.tsx
@@ -1,0 +1,216 @@
+import { Card, CardHeader, Button, Input, Loader, Select, type SelectOption } from '@/components/atoms';
+import { useSettingSection } from '@/hooks/useSettingSection';
+import { DEFAULT_INVOICE_CONFIG, INVOICE_FORMAT, type InvoiceConfig, type InvoiceFormat } from '@/types/dto/OrgSettings';
+import { useState } from 'react';
+
+const SETTING_KEY = 'invoice_config';
+
+const FORMAT_OPTIONS: SelectOption[] = INVOICE_FORMAT.map((f) => ({ value: f, label: f }));
+
+function getFieldError(details: Record<string, string>, field: string): string | undefined {
+	return details[`value.${field}`] ?? details[field];
+}
+
+export function InvoiceConfigSection() {
+	const { isLoading, isError, formValue, setFormValue, saveMutation, resetMutation, backendDetails, refetch } =
+		useSettingSection<InvoiceConfig>({
+			key: SETTING_KEY,
+			defaultValue: DEFAULT_INVOICE_CONFIG,
+		});
+
+	const [inlineErrors, setInlineErrors] = useState<Partial<Record<keyof InvoiceConfig, string>>>({});
+
+	const validate = (): boolean => {
+		const errs: Partial<Record<keyof InvoiceConfig, string>> = {};
+		if (!formValue.prefix?.trim()) {
+			errs.prefix = 'Required (min 1 character)';
+		}
+		if (typeof formValue.start_sequence !== 'number' || formValue.start_sequence < 0) {
+			errs.start_sequence = 'Must be ≥ 0';
+		}
+		if (typeof formValue.suffix_length !== 'number' || formValue.suffix_length < 1 || formValue.suffix_length > 10) {
+			errs.suffix_length = 'Must be between 1 and 10';
+		}
+		if (formValue.due_date_days !== null && (typeof formValue.due_date_days !== 'number' || formValue.due_date_days < 0)) {
+			errs.due_date_days = 'Must be ≥ 0 or empty';
+		}
+		setInlineErrors(errs);
+		return Object.keys(errs).length === 0;
+	};
+
+	const handleSave = () => {
+		if (!validate()) return;
+		saveMutation.mutate(formValue);
+	};
+
+	const handleReset = () => {
+		resetMutation.mutate(undefined);
+	};
+
+	if (isLoading) {
+		return (
+			<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+				<div className='p-6'>
+					<Loader />
+				</div>
+			</Card>
+		);
+	}
+
+	return (
+		<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+			<CardHeader
+				title='Invoice settings'
+				titleClassName='text-lg font-medium text-zinc-800'
+				cta={
+					<div className='flex items-center gap-2'>
+						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
+							Reset to default
+						</Button>
+						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+							Save
+						</Button>
+					</div>
+				}
+			/>
+			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
+				{isError && (
+					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+						Failed to load settings.{' '}
+						<button type='button' onClick={() => refetch()} className='underline font-medium'>
+							Retry
+						</button>
+					</div>
+				)}
+				<div>
+					<label htmlFor='prefix' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+						Prefix
+					</label>
+					<Input
+						id='prefix'
+						value={formValue.prefix}
+						onChange={(value) => setFormValue((prev) => ({ ...prev, prefix: value }))}
+						className={inlineErrors.prefix || getFieldError(backendDetails, 'prefix') ? 'border-red-500' : ''}
+					/>
+					{(inlineErrors.prefix || getFieldError(backendDetails, 'prefix')) && (
+						<p className='mt-1 text-sm text-red-600' role='alert'>
+							{inlineErrors.prefix ?? getFieldError(backendDetails, 'prefix')}
+						</p>
+					)}
+				</div>
+				<div>
+					<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Format</label>
+					<Select
+						options={FORMAT_OPTIONS}
+						value={formValue.format}
+						onChange={(value) => setFormValue((prev) => ({ ...prev, format: value as InvoiceFormat }))}
+					/>
+				</div>
+				<div>
+					<label htmlFor='start_sequence' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+						Start sequence
+					</label>
+					<Input
+						id='start_sequence'
+						type='number'
+						min={0}
+						value={String(formValue.start_sequence)}
+						onChange={(value) =>
+							setFormValue((prev) => ({
+								...prev,
+								start_sequence: value ? parseInt(value, 10) : 0,
+							}))
+						}
+						className={inlineErrors.start_sequence || getFieldError(backendDetails, 'start_sequence') ? 'border-red-500' : ''}
+					/>
+					{(inlineErrors.start_sequence || getFieldError(backendDetails, 'start_sequence')) && (
+						<p className='mt-1 text-sm text-red-600' role='alert'>
+							{inlineErrors.start_sequence ?? getFieldError(backendDetails, 'start_sequence')}
+						</p>
+					)}
+				</div>
+				<div>
+					<label htmlFor='timezone' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+						Timezone
+					</label>
+					<Input id='timezone' value={formValue.timezone} onChange={(value) => setFormValue((prev) => ({ ...prev, timezone: value }))} />
+				</div>
+				<div>
+					<label htmlFor='separator' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+						Separator
+					</label>
+					<Input
+						id='separator'
+						value={formValue.separator ?? ''}
+						onChange={(value) => setFormValue((prev) => ({ ...prev, separator: value }))}
+					/>
+				</div>
+				<div>
+					<label htmlFor='suffix_length' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+						Suffix length (1–10)
+					</label>
+					<Input
+						id='suffix_length'
+						type='number'
+						min={1}
+						max={10}
+						value={String(formValue.suffix_length)}
+						onChange={(value) =>
+							setFormValue((prev) => ({
+								...prev,
+								suffix_length: value ? parseInt(value, 10) : 1,
+							}))
+						}
+						className={inlineErrors.suffix_length || getFieldError(backendDetails, 'suffix_length') ? 'border-red-500' : ''}
+					/>
+					{(inlineErrors.suffix_length || getFieldError(backendDetails, 'suffix_length')) && (
+						<p className='mt-1 text-sm text-red-600' role='alert'>
+							{inlineErrors.suffix_length ?? getFieldError(backendDetails, 'suffix_length')}
+						</p>
+					)}
+				</div>
+				<div>
+					<label htmlFor='due_date_days' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+						Due date (days, empty for null)
+					</label>
+					<Input
+						id='due_date_days'
+						type='number'
+						min={0}
+						value={formValue.due_date_days === null ? '' : String(formValue.due_date_days)}
+						onChange={(value) =>
+							setFormValue((prev) => ({
+								...prev,
+								due_date_days: value === '' ? null : parseInt(value, 10) || 0,
+							}))
+						}
+						placeholder='Optional'
+						className={inlineErrors.due_date_days || getFieldError(backendDetails, 'due_date_days') ? 'border-red-500' : ''}
+					/>
+					{(inlineErrors.due_date_days || getFieldError(backendDetails, 'due_date_days')) && (
+						<p className='mt-1 text-sm text-red-600' role='alert'>
+							{inlineErrors.due_date_days ?? getFieldError(backendDetails, 'due_date_days')}
+						</p>
+					)}
+				</div>
+				<div className='flex items-center gap-2'>
+					<input
+						id='auto_complete_purchased_credit_transaction'
+						type='checkbox'
+						checked={formValue.auto_complete_purchased_credit_transaction ?? false}
+						onChange={(e) =>
+							setFormValue((prev) => ({
+								...prev,
+								auto_complete_purchased_credit_transaction: e.target.checked,
+							}))
+						}
+						className='h-4 w-4 rounded border-gray-300'
+					/>
+					<label htmlFor='auto_complete_purchased_credit_transaction' className='text-sm text-zinc-700'>
+						Auto-complete purchased credit transaction
+					</label>
+				</div>
+			</div>
+		</Card>
+	);
+}

--- a/src/pages/settings/org/InvoiceConfigSection.tsx
+++ b/src/pages/settings/org/InvoiceConfigSection.tsx
@@ -1,5 +1,6 @@
-import { Card, CardHeader, Button, Input, Loader, Select, type SelectOption } from '@/components/atoms';
+import { Card, CardHeader, Button, Input, Loader, Select, Textarea, type SelectOption } from '@/components/atoms';
 import { useSettingSection } from '@/hooks/useSettingSection';
+import { useJsonEditor } from '@/hooks/useJsonEditor';
 import { DEFAULT_INVOICE_CONFIG, INVOICE_FORMAT, type InvoiceConfig, type InvoiceFormat } from '@/types/dto/OrgSettings';
 import { useState } from 'react';
 
@@ -19,6 +20,41 @@ export function InvoiceConfigSection() {
 		});
 
 	const [inlineErrors, setInlineErrors] = useState<Partial<Record<keyof InvoiceConfig, string>>>({});
+
+	const jsonEditor = useJsonEditor({
+		initialValue: formValue,
+		sendCompleteConfig: true, // Send complete config to satisfy backend validation
+		validate: (value) => {
+			const errs: Partial<Record<keyof InvoiceConfig, string>> = {};
+			if (!value.prefix?.trim()) {
+				errs.prefix = 'Required (min 1 character)';
+			}
+			if (typeof value.start_sequence !== 'number' || value.start_sequence < 0) {
+				errs.start_sequence = 'Must be ≥ 0';
+			}
+			if (typeof value.suffix_length !== 'number' || value.suffix_length < 1 || value.suffix_length > 10) {
+				errs.suffix_length = 'Must be between 1 and 10';
+			}
+			if (value.due_date_days !== null && (typeof value.due_date_days !== 'number' || value.due_date_days < 0)) {
+				errs.due_date_days = 'Must be ≥ 0 or empty';
+			}
+
+			if (Object.keys(errs).length > 0) {
+				return Object.values(errs).join(', ');
+			}
+			return null;
+		},
+		onSave: (data) => {
+			saveMutation.mutate(data as InvoiceConfig);
+			// Update form value with the complete parsed value if it's the full config
+			if ('prefix' in data && 'format' in data) {
+				setFormValue(data as InvoiceConfig);
+			} else {
+				// If it's partial changes, merge with existing form value
+				setFormValue((prev) => ({ ...prev, ...(data as Partial<InvoiceConfig>) }));
+			}
+		},
+	});
 
 	const validate = (): boolean => {
 		const errs: Partial<Record<keyof InvoiceConfig, string>> = {};
@@ -67,149 +103,193 @@ export function InvoiceConfigSection() {
 						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
 							Reset to default
 						</Button>
-						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+						<Button variant='outline' size='sm' onClick={jsonEditor.toggleEditor}>
+							{jsonEditor.showJsonEditor ? 'Form View' : 'JSON Editor'}
+						</Button>
+						<Button
+							size='sm'
+							onClick={jsonEditor.showJsonEditor ? jsonEditor.handleJsonSave : handleSave}
+							disabled={saveMutation.isPending}
+							isLoading={saveMutation.isPending}>
 							Save
 						</Button>
 					</div>
 				}
 			/>
 			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
-				{isError && (
-					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
-						Failed to load settings.{' '}
-						<button type='button' onClick={() => refetch()} className='underline font-medium'>
-							Retry
-						</button>
+				{!jsonEditor.showJsonEditor ? (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
+						<div>
+							<label htmlFor='prefix' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								Prefix
+							</label>
+							<Input
+								id='prefix'
+								value={formValue.prefix}
+								onChange={(value) => setFormValue((prev) => ({ ...prev, prefix: value }))}
+								className={inlineErrors.prefix || getFieldError(backendDetails, 'prefix') ? 'border-red-500' : ''}
+							/>
+							{(inlineErrors.prefix || getFieldError(backendDetails, 'prefix')) && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{inlineErrors.prefix ?? getFieldError(backendDetails, 'prefix')}
+								</p>
+							)}
+						</div>
+						<div>
+							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Format</label>
+							<Select
+								options={FORMAT_OPTIONS}
+								value={formValue.format}
+								onChange={(value) => setFormValue((prev) => ({ ...prev, format: value as InvoiceFormat }))}
+							/>
+						</div>
+						<div>
+							<label htmlFor='start_sequence' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								Start sequence
+							</label>
+							<Input
+								id='start_sequence'
+								type='number'
+								min={0}
+								value={String(formValue.start_sequence)}
+								onChange={(value) =>
+									setFormValue((prev) => ({
+										...prev,
+										start_sequence: value ? parseInt(value, 10) : 0,
+									}))
+								}
+								className={inlineErrors.start_sequence || getFieldError(backendDetails, 'start_sequence') ? 'border-red-500' : ''}
+							/>
+							{(inlineErrors.start_sequence || getFieldError(backendDetails, 'start_sequence')) && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{inlineErrors.start_sequence ?? getFieldError(backendDetails, 'start_sequence')}
+								</p>
+							)}
+						</div>
+						<div>
+							<label htmlFor='timezone' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								Timezone
+							</label>
+							<Input
+								id='timezone'
+								value={formValue.timezone}
+								onChange={(value) => setFormValue((prev) => ({ ...prev, timezone: value }))}
+							/>
+						</div>
+						<div>
+							<label htmlFor='separator' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								Separator
+							</label>
+							<Input
+								id='separator'
+								value={formValue.separator ?? ''}
+								onChange={(value) => setFormValue((prev) => ({ ...prev, separator: value }))}
+							/>
+						</div>
+						<div>
+							<label htmlFor='suffix_length' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								Suffix length (1–10)
+							</label>
+							<Input
+								id='suffix_length'
+								type='number'
+								min={1}
+								max={10}
+								value={String(formValue.suffix_length)}
+								onChange={(value) =>
+									setFormValue((prev) => ({
+										...prev,
+										suffix_length: value ? parseInt(value, 10) : 1,
+									}))
+								}
+								className={inlineErrors.suffix_length || getFieldError(backendDetails, 'suffix_length') ? 'border-red-500' : ''}
+							/>
+							{(inlineErrors.suffix_length || getFieldError(backendDetails, 'suffix_length')) && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{inlineErrors.suffix_length ?? getFieldError(backendDetails, 'suffix_length')}
+								</p>
+							)}
+						</div>
+						<div>
+							<label htmlFor='due_date_days' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								Due date (days, empty for null)
+							</label>
+							<Input
+								id='due_date_days'
+								type='number'
+								min={0}
+								value={formValue.due_date_days === null ? '' : String(formValue.due_date_days)}
+								onChange={(value) =>
+									setFormValue((prev) => ({
+										...prev,
+										due_date_days: value === '' ? null : parseInt(value, 10) || 0,
+									}))
+								}
+								placeholder='Optional'
+								className={inlineErrors.due_date_days || getFieldError(backendDetails, 'due_date_days') ? 'border-red-500' : ''}
+							/>
+							{(inlineErrors.due_date_days || getFieldError(backendDetails, 'due_date_days')) && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{inlineErrors.due_date_days ?? getFieldError(backendDetails, 'due_date_days')}
+								</p>
+							)}
+						</div>
+						<div className='flex items-center gap-2'>
+							<input
+								id='auto_complete_purchased_credit_transaction'
+								type='checkbox'
+								checked={formValue.auto_complete_purchased_credit_transaction ?? false}
+								onChange={(e) =>
+									setFormValue((prev) => ({
+										...prev,
+										auto_complete_purchased_credit_transaction: e.target.checked,
+									}))
+								}
+								className='h-4 w-4 rounded border-gray-300'
+							/>
+							<label htmlFor='auto_complete_purchased_credit_transaction' className='text-sm text-zinc-700'>
+								Auto-complete purchased credit transaction
+							</label>
+						</div>
+					</div>
+				) : (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
+						<div>
+							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								JSON Configuration (Developer Mode)
+							</label>
+							<Textarea
+								value={jsonEditor.jsonValue}
+								onChange={jsonEditor.setJsonValue}
+								placeholder='Paste or edit JSON configuration here...'
+								error={jsonEditor.jsonError}
+								description='Edit the invoice configuration directly in JSON format. Only changed values will be saved.'
+								textAreaClassName='min-h-[400px] font-mono text-sm'
+							/>
+							{jsonEditor.jsonError && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{jsonEditor.jsonError}
+								</p>
+							)}
+						</div>
 					</div>
 				)}
-				<div>
-					<label htmlFor='prefix' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
-						Prefix
-					</label>
-					<Input
-						id='prefix'
-						value={formValue.prefix}
-						onChange={(value) => setFormValue((prev) => ({ ...prev, prefix: value }))}
-						className={inlineErrors.prefix || getFieldError(backendDetails, 'prefix') ? 'border-red-500' : ''}
-					/>
-					{(inlineErrors.prefix || getFieldError(backendDetails, 'prefix')) && (
-						<p className='mt-1 text-sm text-red-600' role='alert'>
-							{inlineErrors.prefix ?? getFieldError(backendDetails, 'prefix')}
-						</p>
-					)}
-				</div>
-				<div>
-					<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Format</label>
-					<Select
-						options={FORMAT_OPTIONS}
-						value={formValue.format}
-						onChange={(value) => setFormValue((prev) => ({ ...prev, format: value as InvoiceFormat }))}
-					/>
-				</div>
-				<div>
-					<label htmlFor='start_sequence' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
-						Start sequence
-					</label>
-					<Input
-						id='start_sequence'
-						type='number'
-						min={0}
-						value={String(formValue.start_sequence)}
-						onChange={(value) =>
-							setFormValue((prev) => ({
-								...prev,
-								start_sequence: value ? parseInt(value, 10) : 0,
-							}))
-						}
-						className={inlineErrors.start_sequence || getFieldError(backendDetails, 'start_sequence') ? 'border-red-500' : ''}
-					/>
-					{(inlineErrors.start_sequence || getFieldError(backendDetails, 'start_sequence')) && (
-						<p className='mt-1 text-sm text-red-600' role='alert'>
-							{inlineErrors.start_sequence ?? getFieldError(backendDetails, 'start_sequence')}
-						</p>
-					)}
-				</div>
-				<div>
-					<label htmlFor='timezone' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
-						Timezone
-					</label>
-					<Input id='timezone' value={formValue.timezone} onChange={(value) => setFormValue((prev) => ({ ...prev, timezone: value }))} />
-				</div>
-				<div>
-					<label htmlFor='separator' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
-						Separator
-					</label>
-					<Input
-						id='separator'
-						value={formValue.separator ?? ''}
-						onChange={(value) => setFormValue((prev) => ({ ...prev, separator: value }))}
-					/>
-				</div>
-				<div>
-					<label htmlFor='suffix_length' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
-						Suffix length (1–10)
-					</label>
-					<Input
-						id='suffix_length'
-						type='number'
-						min={1}
-						max={10}
-						value={String(formValue.suffix_length)}
-						onChange={(value) =>
-							setFormValue((prev) => ({
-								...prev,
-								suffix_length: value ? parseInt(value, 10) : 1,
-							}))
-						}
-						className={inlineErrors.suffix_length || getFieldError(backendDetails, 'suffix_length') ? 'border-red-500' : ''}
-					/>
-					{(inlineErrors.suffix_length || getFieldError(backendDetails, 'suffix_length')) && (
-						<p className='mt-1 text-sm text-red-600' role='alert'>
-							{inlineErrors.suffix_length ?? getFieldError(backendDetails, 'suffix_length')}
-						</p>
-					)}
-				</div>
-				<div>
-					<label htmlFor='due_date_days' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
-						Due date (days, empty for null)
-					</label>
-					<Input
-						id='due_date_days'
-						type='number'
-						min={0}
-						value={formValue.due_date_days === null ? '' : String(formValue.due_date_days)}
-						onChange={(value) =>
-							setFormValue((prev) => ({
-								...prev,
-								due_date_days: value === '' ? null : parseInt(value, 10) || 0,
-							}))
-						}
-						placeholder='Optional'
-						className={inlineErrors.due_date_days || getFieldError(backendDetails, 'due_date_days') ? 'border-red-500' : ''}
-					/>
-					{(inlineErrors.due_date_days || getFieldError(backendDetails, 'due_date_days')) && (
-						<p className='mt-1 text-sm text-red-600' role='alert'>
-							{inlineErrors.due_date_days ?? getFieldError(backendDetails, 'due_date_days')}
-						</p>
-					)}
-				</div>
-				<div className='flex items-center gap-2'>
-					<input
-						id='auto_complete_purchased_credit_transaction'
-						type='checkbox'
-						checked={formValue.auto_complete_purchased_credit_transaction ?? false}
-						onChange={(e) =>
-							setFormValue((prev) => ({
-								...prev,
-								auto_complete_purchased_credit_transaction: e.target.checked,
-							}))
-						}
-						className='h-4 w-4 rounded border-gray-300'
-					/>
-					<label htmlFor='auto_complete_purchased_credit_transaction' className='text-sm text-zinc-700'>
-						Auto-complete purchased credit transaction
-					</label>
-				</div>
 			</div>
 		</Card>
 	);

--- a/src/pages/settings/org/InvoicePdfConfigSection.tsx
+++ b/src/pages/settings/org/InvoicePdfConfigSection.tsx
@@ -1,0 +1,127 @@
+import { Card, CardHeader, Button, Input, Loader } from '@/components/atoms';
+import { useSettingSection } from '@/hooks/useSettingSection';
+import { DEFAULT_INVOICE_PDF_CONFIG, type InvoicePdfConfig } from '@/types/dto/OrgSettings';
+import { Plus, Trash2 } from 'lucide-react';
+
+const SETTING_KEY = 'invoice_pdf_config';
+
+function getFieldError(details: Record<string, string>, field: string): string | undefined {
+	return details[`value.${field}`] ?? details[field];
+}
+
+export function InvoicePdfConfigSection() {
+	const { isLoading, isError, formValue, setFormValue, saveMutation, resetMutation, backendDetails, refetch } =
+		useSettingSection<InvoicePdfConfig>({
+			key: SETTING_KEY,
+			defaultValue: DEFAULT_INVOICE_PDF_CONFIG,
+		});
+
+	const handleSave = () => {
+		saveMutation.mutate(formValue);
+	};
+
+	const handleReset = () => {
+		resetMutation.mutate(undefined);
+	};
+
+	const addGroupBy = () => {
+		setFormValue((prev) => ({ ...prev, group_by: [...(prev.group_by ?? []), ''] }));
+	};
+
+	const setGroupByItem = (index: number, value: string) => {
+		setFormValue((prev) => {
+			const next = [...(prev.group_by ?? [])];
+			next[index] = value;
+			return { ...prev, group_by: next };
+		});
+	};
+
+	const removeGroupBy = (index: number) => {
+		setFormValue((prev) => ({
+			...prev,
+			group_by: (prev.group_by ?? []).filter((_, i) => i !== index),
+		}));
+	};
+
+	if (isLoading) {
+		return (
+			<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+				<div className='p-6'>
+					<Loader />
+				</div>
+			</Card>
+		);
+	}
+
+	const templateError = getFieldError(backendDetails, 'template_name');
+
+	return (
+		<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+			<CardHeader
+				title='Invoice PDF settings'
+				titleClassName='text-lg font-medium text-zinc-800'
+				cta={
+					<div className='flex items-center gap-2'>
+						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
+							Reset to default
+						</Button>
+						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+							Save
+						</Button>
+					</div>
+				}
+			/>
+			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
+				{isError && (
+					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+						Failed to load settings.{' '}
+						<button type='button' onClick={() => refetch()} className='underline font-medium'>
+							Retry
+						</button>
+					</div>
+				)}
+				<div>
+					<label htmlFor='template_name' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+						Template name
+					</label>
+					<Input
+						id='template_name'
+						value={formValue.template_name}
+						onChange={(value) => setFormValue((prev) => ({ ...prev, template_name: value }))}
+						placeholder='invoice.typ'
+						className={templateError ? 'border-red-500' : ''}
+					/>
+					{templateError && (
+						<p className='mt-1 text-sm text-red-600' role='alert'>
+							{templateError}
+						</p>
+					)}
+					<p className='mt-1 text-xs text-zinc-500'>Only &quot;invoice.typ&quot; is supported.</p>
+				</div>
+				<div>
+					<div className='flex items-center justify-between mb-1'>
+						<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Group by</label>
+						<Button type='button' variant='outline' size='sm' onClick={addGroupBy}>
+							<Plus className='h-3.5 w-3.5 mr-1' />
+							Add
+						</Button>
+					</div>
+					<div className='space-y-2'>
+						{(formValue.group_by ?? []).length === 0 ? (
+							<p className='text-sm text-zinc-500'>No groups. Add a field name to group invoice lines.</p>
+						) : (
+							(formValue.group_by ?? []).map((item, index) => (
+								<div key={index} className='flex items-center gap-2'>
+									<Input value={item} onChange={(v) => setGroupByItem(index, v)} placeholder='Field name' className='flex-1' />
+									<Button type='button' variant='outline' size='sm' onClick={() => removeGroupBy(index)} aria-label='Remove'>
+										<Trash2 className='h-4 w-4' />
+									</Button>
+								</div>
+							))
+						)}
+					</div>
+				</div>
+			</div>
+		</Card>
+	);
+}

--- a/src/pages/settings/org/InvoicePdfConfigSection.tsx
+++ b/src/pages/settings/org/InvoicePdfConfigSection.tsx
@@ -1,5 +1,6 @@
-import { Card, CardHeader, Button, Input, Loader } from '@/components/atoms';
+import { Card, CardHeader, Button, Input, Loader, Textarea } from '@/components/atoms';
 import { useSettingSection } from '@/hooks/useSettingSection';
+import { useJsonEditor } from '@/hooks/useJsonEditor';
 import { DEFAULT_INVOICE_PDF_CONFIG, type InvoicePdfConfig } from '@/types/dto/OrgSettings';
 import { Plus, Trash2 } from 'lucide-react';
 
@@ -15,6 +16,14 @@ export function InvoicePdfConfigSection() {
 			key: SETTING_KEY,
 			defaultValue: DEFAULT_INVOICE_PDF_CONFIG,
 		});
+
+	const jsonEditor = useJsonEditor({
+		initialValue: formValue,
+		onSave: (changedValues) => {
+			saveMutation.mutate(changedValues as InvoicePdfConfig);
+			setFormValue((prev) => ({ ...prev, ...changedValues }));
+		},
+	});
 
 	const handleSave = () => {
 		saveMutation.mutate(formValue);
@@ -65,62 +74,102 @@ export function InvoicePdfConfigSection() {
 						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
 							Reset to default
 						</Button>
-						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+						<Button variant='outline' size='sm' onClick={jsonEditor.toggleEditor}>
+							{jsonEditor.showJsonEditor ? 'Form View' : 'JSON Editor'}
+						</Button>
+						<Button
+							size='sm'
+							onClick={jsonEditor.showJsonEditor ? jsonEditor.handleJsonSave : handleSave}
+							disabled={saveMutation.isPending}
+							isLoading={saveMutation.isPending}>
 							Save
 						</Button>
 					</div>
 				}
 			/>
 			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
-				{isError && (
-					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
-						Failed to load settings.{' '}
-						<button type='button' onClick={() => refetch()} className='underline font-medium'>
-							Retry
-						</button>
+				{!jsonEditor.showJsonEditor ? (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
+						<div>
+							<label htmlFor='template_name' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								Template name
+							</label>
+							<Input
+								id='template_name'
+								value={formValue.template_name}
+								onChange={(value) => setFormValue((prev) => ({ ...prev, template_name: value }))}
+								placeholder='invoice.typ'
+								className={templateError ? 'border-red-500' : ''}
+							/>
+							{templateError && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{templateError}
+								</p>
+							)}
+							<p className='mt-1 text-xs text-zinc-500'>Only &quot;invoice.typ&quot; is supported.</p>
+						</div>
+						<div>
+							<div className='flex items-center justify-between mb-1'>
+								<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Group by</label>
+								<Button type='button' variant='outline' size='sm' onClick={addGroupBy}>
+									<Plus className='h-3.5 w-3.5 mr-1' />
+									Add
+								</Button>
+							</div>
+							<div className='space-y-2'>
+								{(formValue.group_by ?? []).length === 0 ? (
+									<p className='text-sm text-zinc-500'>No groups. Add a field name to group invoice lines.</p>
+								) : (
+									(formValue.group_by ?? []).map((item, index) => (
+										<div key={index} className='flex items-center gap-2'>
+											<Input value={item} onChange={(v) => setGroupByItem(index, v)} placeholder='Field name' className='flex-1' />
+											<Button type='button' variant='outline' size='sm' onClick={() => removeGroupBy(index)} aria-label='Remove'>
+												<Trash2 className='h-4 w-4' />
+											</Button>
+										</div>
+									))
+								)}
+							</div>
+						</div>
+					</div>
+				) : (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
+						<div>
+							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								JSON Configuration (Developer Mode)
+							</label>
+							<Textarea
+								value={jsonEditor.jsonValue}
+								onChange={jsonEditor.setJsonValue}
+								placeholder='Paste or edit JSON configuration here...'
+								error={jsonEditor.jsonError}
+								description='Edit the invoice PDF configuration directly in JSON format. Only changed values will be saved.'
+								textAreaClassName='min-h-[400px] font-mono text-sm'
+							/>
+							{jsonEditor.jsonError && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{jsonEditor.jsonError}
+								</p>
+							)}
+						</div>
 					</div>
 				)}
-				<div>
-					<label htmlFor='template_name' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
-						Template name
-					</label>
-					<Input
-						id='template_name'
-						value={formValue.template_name}
-						onChange={(value) => setFormValue((prev) => ({ ...prev, template_name: value }))}
-						placeholder='invoice.typ'
-						className={templateError ? 'border-red-500' : ''}
-					/>
-					{templateError && (
-						<p className='mt-1 text-sm text-red-600' role='alert'>
-							{templateError}
-						</p>
-					)}
-					<p className='mt-1 text-xs text-zinc-500'>Only &quot;invoice.typ&quot; is supported.</p>
-				</div>
-				<div>
-					<div className='flex items-center justify-between mb-1'>
-						<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Group by</label>
-						<Button type='button' variant='outline' size='sm' onClick={addGroupBy}>
-							<Plus className='h-3.5 w-3.5 mr-1' />
-							Add
-						</Button>
-					</div>
-					<div className='space-y-2'>
-						{(formValue.group_by ?? []).length === 0 ? (
-							<p className='text-sm text-zinc-500'>No groups. Add a field name to group invoice lines.</p>
-						) : (
-							(formValue.group_by ?? []).map((item, index) => (
-								<div key={index} className='flex items-center gap-2'>
-									<Input value={item} onChange={(v) => setGroupByItem(index, v)} placeholder='Field name' className='flex-1' />
-									<Button type='button' variant='outline' size='sm' onClick={() => removeGroupBy(index)} aria-label='Remove'>
-										<Trash2 className='h-4 w-4' />
-									</Button>
-								</div>
-							))
-						)}
-					</div>
-				</div>
 			</div>
 		</Card>
 	);

--- a/src/pages/settings/org/PrepareProcessedEventsConfigSection.tsx
+++ b/src/pages/settings/org/PrepareProcessedEventsConfigSection.tsx
@@ -1,0 +1,340 @@
+import { Card, CardHeader, Button, Input, Loader, Select, type SelectOption } from '@/components/atoms';
+import { useSettingSection } from '@/hooks/useSettingSection';
+import {
+	DEFAULT_PREPARE_PROCESSED_EVENTS_CONFIG,
+	type PrepareProcessedEventsConfig,
+	type PrepareProcessedEventsAction,
+	type MeterAggregationType,
+	type ResetUsageType,
+} from '@/types/dto/OrgSettings';
+import { Plus, Trash2 } from 'lucide-react';
+
+const SETTING_KEY = 'prepare_processed_events_config';
+
+const AGGREGATION_OPTIONS: SelectOption[] = [
+	{ value: 'COUNT', label: 'COUNT' },
+	{ value: 'SUM', label: 'SUM' },
+	{ value: 'AVG', label: 'AVG' },
+	{ value: 'COUNT_UNIQUE', label: 'COUNT_UNIQUE' },
+	{ value: 'LATEST', label: 'LATEST' },
+	{ value: 'SUM_WITH_MULTIPLIER', label: 'SUM_WITH_MULTIPLIER' },
+	{ value: 'MAX', label: 'MAX' },
+	{ value: 'WEIGHTED_SUM', label: 'WEIGHTED_SUM' },
+];
+
+const RESET_USAGE_OPTIONS: SelectOption[] = [
+	{ value: 'BILLING_PERIOD', label: 'Billing period' },
+	{ value: 'NEVER', label: 'Never' },
+];
+
+function getFieldError(details: Record<string, string>, field: string): string | undefined {
+	return details[`value.${field}`] ?? details[field];
+}
+
+export function PrepareProcessedEventsConfigSection() {
+	const { isLoading, isError, formValue, setFormValue, saveMutation, resetMutation, backendDetails, refetch } =
+		useSettingSection<PrepareProcessedEventsConfig>({
+			key: SETTING_KEY,
+			defaultValue: DEFAULT_PREPARE_PROCESSED_EVENTS_CONFIG,
+		});
+
+	const handleSave = () => {
+		saveMutation.mutate(formValue);
+	};
+
+	const handleReset = () => {
+		resetMutation.mutate(undefined);
+	};
+
+	const addAction = () => {
+		setFormValue((prev) => ({
+			...prev,
+			actions: [
+				...prev.actions,
+				{
+					action: 'create_feature_and_price',
+					feature_type: undefined,
+					meter: undefined,
+					price: undefined,
+				},
+			],
+		}));
+	};
+
+	const updateAction = (index: number, patch: Partial<PrepareProcessedEventsAction>) => {
+		setFormValue((prev) => {
+			const actions = [...prev.actions];
+			const current = actions[index];
+			if (current.action === 'create_feature_and_price' && patch.action !== 'rollout_to_subscriptions') {
+				actions[index] = { ...current, ...patch } as Extract<PrepareProcessedEventsAction, { action: 'create_feature_and_price' }>;
+			} else if (current.action === 'rollout_to_subscriptions' && patch.action !== 'create_feature_and_price') {
+				actions[index] = { ...current, ...patch } as Extract<PrepareProcessedEventsAction, { action: 'rollout_to_subscriptions' }>;
+			} else if (patch.action === 'rollout_to_subscriptions') {
+				actions[index] = { action: 'rollout_to_subscriptions', plan_id: '' };
+			} else if (patch.action === 'create_feature_and_price') {
+				actions[index] = {
+					action: 'create_feature_and_price',
+					feature_type: undefined,
+					meter: undefined,
+					price: undefined,
+				};
+			} else {
+				actions[index] = { ...current, ...patch } as PrepareProcessedEventsAction;
+			}
+			return { ...prev, actions };
+		});
+	};
+
+	const removeAction = (index: number) => {
+		setFormValue((prev) => ({
+			...prev,
+			actions: prev.actions.filter((_, i) => i !== index),
+		}));
+	};
+
+	if (isLoading) {
+		return (
+			<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+				<div className='p-6'>
+					<Loader />
+				</div>
+			</Card>
+		);
+	}
+
+	return (
+		<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+			<CardHeader
+				title='Prepare processed events'
+				titleClassName='text-lg font-medium text-zinc-800'
+				cta={
+					<div className='flex items-center gap-2'>
+						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
+							Reset to default
+						</Button>
+						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+							Save
+						</Button>
+					</div>
+				}
+			/>
+			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
+				{isError && (
+					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+						Failed to load settings.{' '}
+						<button type='button' onClick={() => refetch()} className='underline font-medium'>
+							Retry
+						</button>
+					</div>
+				)}
+				<p className='text-sm text-zinc-600'>
+					Workflow type: <strong>prepare_processed_events</strong>. Auto-create feature/meter/price from events.
+				</p>
+				<div className='flex items-center justify-between'>
+					<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Actions</label>
+					<Button type='button' variant='outline' size='sm' onClick={addAction}>
+						<Plus className='h-3.5 w-3.5 mr-1' />
+						Add action
+					</Button>
+				</div>
+				<div className='space-y-4'>
+					{formValue.actions.map((act, index) => (
+						<div key={index} className='p-4 rounded-lg border border-gray-200 bg-gray-50/50 space-y-3'>
+							<div className='flex items-center justify-between gap-2'>
+								<Select
+									options={[
+										{ value: 'create_feature_and_price', label: 'Create feature and price' },
+										{ value: 'rollout_to_subscriptions', label: 'Rollout to subscriptions' },
+									]}
+									value={act.action}
+									onChange={(v) => {
+										if (v === 'rollout_to_subscriptions') {
+											updateAction(index, { action: 'rollout_to_subscriptions', plan_id: '' });
+										} else {
+											updateAction(index, {
+												action: 'create_feature_and_price',
+												feature_type: undefined,
+												meter: undefined,
+												price: undefined,
+											});
+										}
+									}}
+									className='w-56'
+								/>
+								<Button type='button' variant='outline' size='sm' onClick={() => removeAction(index)} aria-label='Remove action'>
+									<Trash2 className='h-4 w-4' />
+								</Button>
+							</div>
+							{act.action === 'rollout_to_subscriptions' && (
+								<div>
+									<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Plan ID</label>
+									<Input value={act.plan_id} onChange={(v) => updateAction(index, { ...act, plan_id: v })} />
+								</div>
+							)}
+							{act.action === 'create_feature_and_price' && (
+								<>
+									<div>
+										<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Feature type</label>
+										<Input
+											value={act.feature_type ?? ''}
+											onChange={(v) => updateAction(index, { ...act, feature_type: v || undefined })}
+											placeholder='Optional'
+										/>
+									</div>
+									{act.meter && (
+										<div className='grid grid-cols-3 gap-2'>
+											<div>
+												<label className='block text-xs font-medium text-zinc-500 mb-1'>Meter aggregation</label>
+												<Select
+													options={AGGREGATION_OPTIONS}
+													value={act.meter.aggregation_type}
+													onChange={(v) =>
+														updateAction(index, {
+															...act,
+															meter: { ...act.meter!, aggregation_type: v as MeterAggregationType },
+														})
+													}
+												/>
+											</div>
+											<div>
+												<label className='block text-xs font-medium text-zinc-500 mb-1'>Aggregation field</label>
+												<Input
+													value={act.meter.aggregation_field ?? ''}
+													onChange={(v) =>
+														updateAction(index, {
+															...act,
+															meter: { ...act.meter!, aggregation_field: v || undefined },
+														})
+													}
+													placeholder='Optional'
+												/>
+											</div>
+											<div>
+												<label className='block text-xs font-medium text-zinc-500 mb-1'>Reset usage</label>
+												<Select
+													options={RESET_USAGE_OPTIONS}
+													value={act.meter.reset_usage ?? ''}
+													onChange={(v) =>
+														updateAction(index, {
+															...act,
+															meter: { ...act.meter!, reset_usage: (v as ResetUsageType) || undefined },
+														})
+													}
+													placeholder='Optional'
+												/>
+											</div>
+										</div>
+									)}
+									<div className='flex gap-2'>
+										{!act.meter ? (
+											<Button
+												type='button'
+												variant='outline'
+												size='sm'
+												onClick={() =>
+													updateAction(index, {
+														...act,
+														meter: {
+															aggregation_type: 'COUNT',
+															aggregation_field: undefined,
+															reset_usage: undefined,
+														},
+													})
+												}>
+												Add meter
+											</Button>
+										) : (
+											<Button type='button' variant='outline' size='sm' onClick={() => updateAction(index, { ...act, meter: undefined })}>
+												Remove meter
+											</Button>
+										)}
+										{!act.price ? (
+											<Button
+												type='button'
+												variant='outline'
+												size='sm'
+												onClick={() =>
+													updateAction(index, {
+														...act,
+														price: {},
+													})
+												}>
+												Add price
+											</Button>
+										) : (
+											<Button type='button' variant='outline' size='sm' onClick={() => updateAction(index, { ...act, price: undefined })}>
+												Remove price
+											</Button>
+										)}
+									</div>
+									{act.price && (
+										<div className='grid grid-cols-2 gap-2 pt-2 border-t border-gray-100'>
+											<div>
+												<label className='block text-xs font-medium text-zinc-500 mb-1'>Billing cadence</label>
+												<Input
+													value={act.price.billing_cadence ?? ''}
+													onChange={(v) =>
+														updateAction(index, {
+															...act,
+															price: { ...act.price!, billing_cadence: v || undefined },
+														})
+													}
+													placeholder='Optional'
+												/>
+											</div>
+											<div>
+												<label className='block text-xs font-medium text-zinc-500 mb-1'>Currency</label>
+												<Input
+													value={act.price.currency ?? ''}
+													onChange={(v) =>
+														updateAction(index, {
+															...act,
+															price: { ...act.price!, currency: v || undefined },
+														})
+													}
+													placeholder='Optional'
+												/>
+											</div>
+											<div>
+												<label className='block text-xs font-medium text-zinc-500 mb-1'>Amount</label>
+												<Input
+													type='number'
+													value={act.price.amount != null ? String(act.price.amount) : ''}
+													onChange={(v) =>
+														updateAction(index, {
+															...act,
+															price: { ...act.price!, amount: v ? parseFloat(v) : undefined },
+														})
+													}
+													placeholder='Optional'
+												/>
+											</div>
+											<div>
+												<label className='block text-xs font-medium text-zinc-500 mb-1'>Type</label>
+												<Input
+													value={act.price.type ?? ''}
+													onChange={(v) =>
+														updateAction(index, {
+															...act,
+															price: { ...act.price!, type: v || undefined },
+														})
+													}
+													placeholder='Optional'
+												/>
+											</div>
+										</div>
+									)}
+								</>
+							)}
+						</div>
+					))}
+				</div>
+				{getFieldError(backendDetails, 'actions') && (
+					<p className='text-sm text-red-600' role='alert'>
+						{getFieldError(backendDetails, 'actions')}
+					</p>
+				)}
+			</div>
+		</Card>
+	);
+}

--- a/src/pages/settings/org/PrepareProcessedEventsConfigSection.tsx
+++ b/src/pages/settings/org/PrepareProcessedEventsConfigSection.tsx
@@ -1,5 +1,6 @@
-import { Card, CardHeader, Button, Input, Loader, Select, type SelectOption } from '@/components/atoms';
+import { Card, CardHeader, Button, Input, Loader, Select, Textarea, type SelectOption } from '@/components/atoms';
 import { useSettingSection } from '@/hooks/useSettingSection';
+import { useJsonEditor } from '@/hooks/useJsonEditor';
 import {
 	DEFAULT_PREPARE_PROCESSED_EVENTS_CONFIG,
 	type PrepareProcessedEventsConfig,
@@ -37,6 +38,15 @@ export function PrepareProcessedEventsConfigSection() {
 			key: SETTING_KEY,
 			defaultValue: DEFAULT_PREPARE_PROCESSED_EVENTS_CONFIG,
 		});
+
+	const jsonEditor = useJsonEditor({
+		initialValue: formValue,
+		sendCompleteConfig: true,
+		onSave: (data) => {
+			saveMutation.mutate(data as PrepareProcessedEventsConfig);
+			setFormValue((prev) => ({ ...prev, ...(data as PrepareProcessedEventsConfig) }));
+		},
+	});
 
 	const handleSave = () => {
 		saveMutation.mutate(formValue);
@@ -112,227 +122,275 @@ export function PrepareProcessedEventsConfigSection() {
 						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
 							Reset to default
 						</Button>
-						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+						<Button variant='outline' size='sm' onClick={jsonEditor.toggleEditor}>
+							{jsonEditor.showJsonEditor ? 'Form View' : 'JSON Editor'}
+						</Button>
+						<Button
+							size='sm'
+							onClick={jsonEditor.showJsonEditor ? jsonEditor.handleJsonSave : handleSave}
+							disabled={saveMutation.isPending}
+							isLoading={saveMutation.isPending}>
 							Save
 						</Button>
 					</div>
 				}
 			/>
 			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
-				{isError && (
-					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
-						Failed to load settings.{' '}
-						<button type='button' onClick={() => refetch()} className='underline font-medium'>
-							Retry
-						</button>
-					</div>
-				)}
-				<p className='text-sm text-zinc-600'>
-					Workflow type: <strong>prepare_processed_events</strong>. Auto-create feature/meter/price from events.
-				</p>
-				<div className='flex items-center justify-between'>
-					<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Actions</label>
-					<Button type='button' variant='outline' size='sm' onClick={addAction}>
-						<Plus className='h-3.5 w-3.5 mr-1' />
-						Add action
-					</Button>
-				</div>
-				<div className='space-y-4'>
-					{formValue.actions.map((act, index) => (
-						<div key={index} className='p-4 rounded-lg border border-gray-200 bg-gray-50/50 space-y-3'>
-							<div className='flex items-center justify-between gap-2'>
-								<Select
-									options={[
-										{ value: 'create_feature_and_price', label: 'Create feature and price' },
-										{ value: 'rollout_to_subscriptions', label: 'Rollout to subscriptions' },
-									]}
-									value={act.action}
-									onChange={(v) => {
-										if (v === 'rollout_to_subscriptions') {
-											updateAction(index, { action: 'rollout_to_subscriptions', plan_id: '' });
-										} else {
-											updateAction(index, {
-												action: 'create_feature_and_price',
-												feature_type: undefined,
-												meter: undefined,
-												price: undefined,
-											});
-										}
-									}}
-									className='w-56'
-								/>
-								<Button type='button' variant='outline' size='sm' onClick={() => removeAction(index)} aria-label='Remove action'>
-									<Trash2 className='h-4 w-4' />
-								</Button>
+				{!jsonEditor.showJsonEditor ? (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
 							</div>
-							{act.action === 'rollout_to_subscriptions' && (
-								<div>
-									<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Plan ID</label>
-									<Input value={act.plan_id} onChange={(v) => updateAction(index, { ...act, plan_id: v })} />
-								</div>
-							)}
-							{act.action === 'create_feature_and_price' && (
-								<>
-									<div>
-										<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Feature type</label>
-										<Input
-											value={act.feature_type ?? ''}
-											onChange={(v) => updateAction(index, { ...act, feature_type: v || undefined })}
-											placeholder='Optional'
+						)}
+						<p className='text-sm text-zinc-600'>
+							Workflow type: <strong>prepare_processed_events</strong>. Auto-create feature/meter/price from events.
+						</p>
+						<div className='flex items-center justify-between'>
+							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide'>Actions</label>
+							<Button type='button' variant='outline' size='sm' onClick={addAction}>
+								<Plus className='h-3.5 w-3.5 mr-1' />
+								Add action
+							</Button>
+						</div>
+						<div className='space-y-4'>
+							{formValue.actions.map((act, index) => (
+								<div key={index} className='p-4 rounded-lg border border-gray-200 bg-gray-50/50 space-y-3'>
+									<div className='flex items-center justify-between gap-2'>
+										<Select
+											options={[
+												{ value: 'create_feature_and_price', label: 'Create feature and price' },
+												{ value: 'rollout_to_subscriptions', label: 'Rollout to subscriptions' },
+											]}
+											value={act.action}
+											onChange={(v) => {
+												if (v === 'rollout_to_subscriptions') {
+													updateAction(index, { action: 'rollout_to_subscriptions', plan_id: '' });
+												} else {
+													updateAction(index, {
+														action: 'create_feature_and_price',
+														feature_type: undefined,
+														meter: undefined,
+														price: undefined,
+													});
+												}
+											}}
+											className='w-56'
 										/>
+										<Button type='button' variant='outline' size='sm' onClick={() => removeAction(index)} aria-label='Remove action'>
+											<Trash2 className='h-4 w-4' />
+										</Button>
 									</div>
-									{act.meter && (
-										<div className='grid grid-cols-3 gap-2'>
-											<div>
-												<label className='block text-xs font-medium text-zinc-500 mb-1'>Meter aggregation</label>
-												<Select
-													options={AGGREGATION_OPTIONS}
-													value={act.meter.aggregation_type}
-													onChange={(v) =>
-														updateAction(index, {
-															...act,
-															meter: { ...act.meter!, aggregation_type: v as MeterAggregationType },
-														})
-													}
-												/>
-											</div>
-											<div>
-												<label className='block text-xs font-medium text-zinc-500 mb-1'>Aggregation field</label>
-												<Input
-													value={act.meter.aggregation_field ?? ''}
-													onChange={(v) =>
-														updateAction(index, {
-															...act,
-															meter: { ...act.meter!, aggregation_field: v || undefined },
-														})
-													}
-													placeholder='Optional'
-												/>
-											</div>
-											<div>
-												<label className='block text-xs font-medium text-zinc-500 mb-1'>Reset usage</label>
-												<Select
-													options={RESET_USAGE_OPTIONS}
-													value={act.meter.reset_usage ?? ''}
-													onChange={(v) =>
-														updateAction(index, {
-															...act,
-															meter: { ...act.meter!, reset_usage: (v as ResetUsageType) || undefined },
-														})
-													}
-													placeholder='Optional'
-												/>
-											</div>
+									{act.action === 'rollout_to_subscriptions' && (
+										<div>
+											<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Plan ID</label>
+											<Input value={act.plan_id} onChange={(v) => updateAction(index, { ...act, plan_id: v })} />
 										</div>
 									)}
-									<div className='flex gap-2'>
-										{!act.meter ? (
-											<Button
-												type='button'
-												variant='outline'
-												size='sm'
-												onClick={() =>
-													updateAction(index, {
-														...act,
-														meter: {
-															aggregation_type: 'COUNT',
-															aggregation_field: undefined,
-															reset_usage: undefined,
-														},
-													})
-												}>
-												Add meter
-											</Button>
-										) : (
-											<Button type='button' variant='outline' size='sm' onClick={() => updateAction(index, { ...act, meter: undefined })}>
-												Remove meter
-											</Button>
-										)}
-										{!act.price ? (
-											<Button
-												type='button'
-												variant='outline'
-												size='sm'
-												onClick={() =>
-													updateAction(index, {
-														...act,
-														price: {},
-													})
-												}>
-												Add price
-											</Button>
-										) : (
-											<Button type='button' variant='outline' size='sm' onClick={() => updateAction(index, { ...act, price: undefined })}>
-												Remove price
-											</Button>
-										)}
-									</div>
-									{act.price && (
-										<div className='grid grid-cols-2 gap-2 pt-2 border-t border-gray-100'>
+									{act.action === 'create_feature_and_price' && (
+										<>
 											<div>
-												<label className='block text-xs font-medium text-zinc-500 mb-1'>Billing cadence</label>
+												<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>Feature type</label>
 												<Input
-													value={act.price.billing_cadence ?? ''}
-													onChange={(v) =>
-														updateAction(index, {
-															...act,
-															price: { ...act.price!, billing_cadence: v || undefined },
-														})
-													}
+													value={act.feature_type ?? ''}
+													onChange={(v) => updateAction(index, { ...act, feature_type: v || undefined })}
 													placeholder='Optional'
 												/>
 											</div>
-											<div>
-												<label className='block text-xs font-medium text-zinc-500 mb-1'>Currency</label>
-												<Input
-													value={act.price.currency ?? ''}
-													onChange={(v) =>
-														updateAction(index, {
-															...act,
-															price: { ...act.price!, currency: v || undefined },
-														})
-													}
-													placeholder='Optional'
-												/>
+											{act.meter && (
+												<div className='grid grid-cols-3 gap-2'>
+													<div>
+														<label className='block text-xs font-medium text-zinc-500 mb-1'>Meter aggregation</label>
+														<Select
+															options={AGGREGATION_OPTIONS}
+															value={act.meter.aggregation_type}
+															onChange={(v) =>
+																updateAction(index, {
+																	...act,
+																	meter: { ...act.meter!, aggregation_type: v as MeterAggregationType },
+																})
+															}
+														/>
+													</div>
+													<div>
+														<label className='block text-xs font-medium text-zinc-500 mb-1'>Aggregation field</label>
+														<Input
+															value={act.meter.aggregation_field ?? ''}
+															onChange={(v) =>
+																updateAction(index, {
+																	...act,
+																	meter: { ...act.meter!, aggregation_field: v || undefined },
+																})
+															}
+															placeholder='Optional'
+														/>
+													</div>
+													<div>
+														<label className='block text-xs font-medium text-zinc-500 mb-1'>Reset usage</label>
+														<Select
+															options={RESET_USAGE_OPTIONS}
+															value={act.meter.reset_usage ?? ''}
+															onChange={(v) =>
+																updateAction(index, {
+																	...act,
+																	meter: { ...act.meter!, reset_usage: (v as ResetUsageType) || undefined },
+																})
+															}
+															placeholder='Optional'
+														/>
+													</div>
+												</div>
+											)}
+											<div className='flex gap-2'>
+												{!act.meter ? (
+													<Button
+														type='button'
+														variant='outline'
+														size='sm'
+														onClick={() =>
+															updateAction(index, {
+																...act,
+																meter: {
+																	aggregation_type: 'COUNT',
+																	aggregation_field: undefined,
+																	reset_usage: undefined,
+																},
+															})
+														}>
+														Add meter
+													</Button>
+												) : (
+													<Button
+														type='button'
+														variant='outline'
+														size='sm'
+														onClick={() => updateAction(index, { ...act, meter: undefined })}>
+														Remove meter
+													</Button>
+												)}
+												{!act.price ? (
+													<Button
+														type='button'
+														variant='outline'
+														size='sm'
+														onClick={() =>
+															updateAction(index, {
+																...act,
+																price: {},
+															})
+														}>
+														Add price
+													</Button>
+												) : (
+													<Button
+														type='button'
+														variant='outline'
+														size='sm'
+														onClick={() => updateAction(index, { ...act, price: undefined })}>
+														Remove price
+													</Button>
+												)}
 											</div>
-											<div>
-												<label className='block text-xs font-medium text-zinc-500 mb-1'>Amount</label>
-												<Input
-													type='number'
-													value={act.price.amount != null ? String(act.price.amount) : ''}
-													onChange={(v) =>
-														updateAction(index, {
-															...act,
-															price: { ...act.price!, amount: v ? parseFloat(v) : undefined },
-														})
-													}
-													placeholder='Optional'
-												/>
-											</div>
-											<div>
-												<label className='block text-xs font-medium text-zinc-500 mb-1'>Type</label>
-												<Input
-													value={act.price.type ?? ''}
-													onChange={(v) =>
-														updateAction(index, {
-															...act,
-															price: { ...act.price!, type: v || undefined },
-														})
-													}
-													placeholder='Optional'
-												/>
-											</div>
-										</div>
+											{act.price && (
+												<div className='grid grid-cols-2 gap-2 pt-2 border-t border-gray-100'>
+													<div>
+														<label className='block text-xs font-medium text-zinc-500 mb-1'>Billing cadence</label>
+														<Input
+															value={act.price.billing_cadence ?? ''}
+															onChange={(v) =>
+																updateAction(index, {
+																	...act,
+																	price: { ...act.price!, billing_cadence: v || undefined },
+																})
+															}
+															placeholder='Optional'
+														/>
+													</div>
+													<div>
+														<label className='block text-xs font-medium text-zinc-500 mb-1'>Currency</label>
+														<Input
+															value={act.price.currency ?? ''}
+															onChange={(v) =>
+																updateAction(index, {
+																	...act,
+																	price: { ...act.price!, currency: v || undefined },
+																})
+															}
+															placeholder='Optional'
+														/>
+													</div>
+													<div>
+														<label className='block text-xs font-medium text-zinc-500 mb-1'>Amount</label>
+														<Input
+															type='number'
+															value={act.price.amount != null ? String(act.price.amount) : ''}
+															onChange={(v) =>
+																updateAction(index, {
+																	...act,
+																	price: { ...act.price!, amount: v ? parseFloat(v) : undefined },
+																})
+															}
+															placeholder='Optional'
+														/>
+													</div>
+													<div>
+														<label className='block text-xs font-medium text-zinc-500 mb-1'>Type</label>
+														<Input
+															value={act.price.type ?? ''}
+															onChange={(v) =>
+																updateAction(index, {
+																	...act,
+																	price: { ...act.price!, type: v || undefined },
+																})
+															}
+															placeholder='Optional'
+														/>
+													</div>
+												</div>
+											)}
+										</>
 									)}
-								</>
+								</div>
+							))}
+						</div>
+						{getFieldError(backendDetails, 'actions') && (
+							<p className='text-sm text-red-600' role='alert'>
+								{getFieldError(backendDetails, 'actions')}
+							</p>
+						)}
+					</div>
+				) : (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
+						<div>
+							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								JSON Configuration (Developer Mode)
+							</label>
+							<Textarea
+								value={jsonEditor.jsonValue}
+								onChange={jsonEditor.setJsonValue}
+								placeholder='Paste or edit JSON configuration here...'
+								error={jsonEditor.jsonError}
+								description='Edit the prepare processed events configuration directly in JSON format. Only changed values will be saved.'
+								textAreaClassName='min-h-[400px] font-mono text-sm'
+							/>
+							{jsonEditor.jsonError && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{jsonEditor.jsonError}
+								</p>
 							)}
 						</div>
-					))}
-				</div>
-				{getFieldError(backendDetails, 'actions') && (
-					<p className='text-sm text-red-600' role='alert'>
-						{getFieldError(backendDetails, 'actions')}
-					</p>
+					</div>
 				)}
 			</div>
 		</Card>

--- a/src/pages/settings/org/SubscriptionConfigSection.tsx
+++ b/src/pages/settings/org/SubscriptionConfigSection.tsx
@@ -1,5 +1,6 @@
-import { Card, CardHeader, Button, Input, Loader } from '@/components/atoms';
+import { Card, CardHeader, Button, Input, Loader, Textarea } from '@/components/atoms';
 import { useSettingSection } from '@/hooks/useSettingSection';
+import { useJsonEditor } from '@/hooks/useJsonEditor';
 import { DEFAULT_SUBSCRIPTION_CONFIG, type SubscriptionConfig } from '@/types/dto/OrgSettings';
 import { useState } from 'react';
 
@@ -17,6 +18,24 @@ export function SubscriptionConfigSection() {
 		});
 
 	const [inlineErrors, setInlineErrors] = useState<Partial<Record<keyof SubscriptionConfig, string>>>({});
+
+	const jsonEditor = useJsonEditor({
+		initialValue: formValue,
+		sendCompleteConfig: true,
+		validate: (value) => {
+			if (value.grace_period_days < 1) {
+				return 'Grace period must be at least 1';
+			}
+			if (typeof value.grace_period_days !== 'number' || Number.isNaN(value.grace_period_days)) {
+				return 'Grace period is required';
+			}
+			return null;
+		},
+		onSave: (data) => {
+			saveMutation.mutate(data as SubscriptionConfig);
+			setFormValue((prev) => ({ ...prev, ...(data as SubscriptionConfig) }));
+		},
+	});
 
 	const validate = (): boolean => {
 		const errs: Partial<Record<keyof SubscriptionConfig, string>> = {};
@@ -61,61 +80,101 @@ export function SubscriptionConfigSection() {
 						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
 							Reset to default
 						</Button>
-						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+						<Button variant='outline' size='sm' onClick={jsonEditor.toggleEditor}>
+							{jsonEditor.showJsonEditor ? 'Form View' : 'JSON Editor'}
+						</Button>
+						<Button
+							size='sm'
+							onClick={jsonEditor.showJsonEditor ? jsonEditor.handleJsonSave : handleSave}
+							disabled={saveMutation.isPending}
+							isLoading={saveMutation.isPending}>
 							Save
 						</Button>
 					</div>
 				}
 			/>
 			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
-				{isError && (
-					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
-						Failed to load settings.{' '}
-						<button type='button' onClick={() => refetch()} className='underline font-medium'>
-							Retry
-						</button>
+				{!jsonEditor.showJsonEditor ? (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
+						<div>
+							<label htmlFor='grace_period_days' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								Grace period (days)
+							</label>
+							<Input
+								id='grace_period_days'
+								type='number'
+								min={1}
+								value={formValue.grace_period_days}
+								onChange={(value) =>
+									setFormValue((prev) => ({
+										...prev,
+										grace_period_days: value ? parseInt(value, 10) : 0,
+									}))
+								}
+								className={graceError ? 'border-red-500' : ''}
+							/>
+							{graceError && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{graceError}
+								</p>
+							)}
+						</div>
+						<div className='flex items-center gap-2'>
+							<input
+								id='auto_cancellation_enabled'
+								type='checkbox'
+								checked={formValue.auto_cancellation_enabled}
+								onChange={(e) =>
+									setFormValue((prev) => ({
+										...prev,
+										auto_cancellation_enabled: e.target.checked,
+									}))
+								}
+								className='h-4 w-4 rounded border-gray-300'
+							/>
+							<label htmlFor='auto_cancellation_enabled' className='text-sm text-zinc-700'>
+								Auto-cancellation enabled
+							</label>
+						</div>
+					</div>
+				) : (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
+						<div>
+							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								JSON Configuration (Developer Mode)
+							</label>
+							<Textarea
+								value={jsonEditor.jsonValue}
+								onChange={jsonEditor.setJsonValue}
+								placeholder='Paste or edit JSON configuration here...'
+								error={jsonEditor.jsonError}
+								description='Edit the subscription configuration directly in JSON format. Only changed values will be saved.'
+								textAreaClassName='min-h-[400px] font-mono text-sm'
+							/>
+							{jsonEditor.jsonError && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{jsonEditor.jsonError}
+								</p>
+							)}
+						</div>
 					</div>
 				)}
-				<div>
-					<label htmlFor='grace_period_days' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
-						Grace period (days)
-					</label>
-					<Input
-						id='grace_period_days'
-						type='number'
-						min={1}
-						value={formValue.grace_period_days}
-						onChange={(value) =>
-							setFormValue((prev) => ({
-								...prev,
-								grace_period_days: value ? parseInt(value, 10) : 0,
-							}))
-						}
-						className={graceError ? 'border-red-500' : ''}
-					/>
-					{graceError && (
-						<p className='mt-1 text-sm text-red-600' role='alert'>
-							{graceError}
-						</p>
-					)}
-				</div>
-				<div className='flex items-center gap-2'>
-					<input
-						id='auto_cancellation_enabled'
-						type='checkbox'
-						checked={formValue.auto_cancellation_enabled}
-						onChange={(e) =>
-							setFormValue((prev) => ({
-								...prev,
-								auto_cancellation_enabled: e.target.checked,
-							}))
-						}
-						className='h-4 w-4 rounded border-gray-300'
-					/>
-					<label htmlFor='auto_cancellation_enabled' className='text-sm text-zinc-700'>
-						Auto-cancellation enabled
-					</label>
-				</div>
 			</div>
 		</Card>
 	);

--- a/src/pages/settings/org/SubscriptionConfigSection.tsx
+++ b/src/pages/settings/org/SubscriptionConfigSection.tsx
@@ -1,0 +1,122 @@
+import { Card, CardHeader, Button, Input, Loader } from '@/components/atoms';
+import { useSettingSection } from '@/hooks/useSettingSection';
+import { DEFAULT_SUBSCRIPTION_CONFIG, type SubscriptionConfig } from '@/types/dto/OrgSettings';
+import { useState } from 'react';
+
+const SETTING_KEY = 'subscription_config';
+
+function getFieldError(details: Record<string, string>, field: string): string | undefined {
+	return details[`value.${field}`] ?? details[field];
+}
+
+export function SubscriptionConfigSection() {
+	const { isLoading, isError, formValue, setFormValue, saveMutation, resetMutation, backendDetails, refetch } =
+		useSettingSection<SubscriptionConfig>({
+			key: SETTING_KEY,
+			defaultValue: DEFAULT_SUBSCRIPTION_CONFIG,
+		});
+
+	const [inlineErrors, setInlineErrors] = useState<Partial<Record<keyof SubscriptionConfig, string>>>({});
+
+	const validate = (): boolean => {
+		const errs: Partial<Record<keyof SubscriptionConfig, string>> = {};
+		if (formValue.grace_period_days < 1) {
+			errs.grace_period_days = 'Must be at least 1';
+		}
+		if (typeof formValue.grace_period_days !== 'number' || Number.isNaN(formValue.grace_period_days)) {
+			errs.grace_period_days = errs.grace_period_days || 'Required';
+		}
+		setInlineErrors(errs);
+		return Object.keys(errs).length === 0;
+	};
+
+	const handleSave = () => {
+		if (!validate()) return;
+		saveMutation.mutate(formValue);
+	};
+
+	const handleReset = () => {
+		resetMutation.mutate(undefined);
+	};
+
+	if (isLoading) {
+		return (
+			<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+				<div className='p-6'>
+					<Loader />
+				</div>
+			</Card>
+		);
+	}
+
+	const graceError = inlineErrors.grace_period_days ?? getFieldError(backendDetails, 'grace_period_days');
+
+	return (
+		<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+			<CardHeader
+				title='Subscription settings'
+				titleClassName='text-lg font-medium text-zinc-800'
+				cta={
+					<div className='flex items-center gap-2'>
+						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
+							Reset to default
+						</Button>
+						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+							Save
+						</Button>
+					</div>
+				}
+			/>
+			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
+				{isError && (
+					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+						Failed to load settings.{' '}
+						<button type='button' onClick={() => refetch()} className='underline font-medium'>
+							Retry
+						</button>
+					</div>
+				)}
+				<div>
+					<label htmlFor='grace_period_days' className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+						Grace period (days)
+					</label>
+					<Input
+						id='grace_period_days'
+						type='number'
+						min={1}
+						value={formValue.grace_period_days}
+						onChange={(value) =>
+							setFormValue((prev) => ({
+								...prev,
+								grace_period_days: value ? parseInt(value, 10) : 0,
+							}))
+						}
+						className={graceError ? 'border-red-500' : ''}
+					/>
+					{graceError && (
+						<p className='mt-1 text-sm text-red-600' role='alert'>
+							{graceError}
+						</p>
+					)}
+				</div>
+				<div className='flex items-center gap-2'>
+					<input
+						id='auto_cancellation_enabled'
+						type='checkbox'
+						checked={formValue.auto_cancellation_enabled}
+						onChange={(e) =>
+							setFormValue((prev) => ({
+								...prev,
+								auto_cancellation_enabled: e.target.checked,
+							}))
+						}
+						className='h-4 w-4 rounded border-gray-300'
+					/>
+					<label htmlFor='auto_cancellation_enabled' className='text-sm text-zinc-700'>
+						Auto-cancellation enabled
+					</label>
+				</div>
+			</div>
+		</Card>
+	);
+}

--- a/src/pages/settings/org/WalletBalanceAlertConfigSection.tsx
+++ b/src/pages/settings/org/WalletBalanceAlertConfigSection.tsx
@@ -1,5 +1,6 @@
-import { Card, CardHeader, Button, Input, Loader, Select, type SelectOption } from '@/components/atoms';
+import { Card, CardHeader, Button, Input, Loader, Select, Textarea, type SelectOption } from '@/components/atoms';
 import { useSettingSection } from '@/hooks/useSettingSection';
+import { useJsonEditor } from '@/hooks/useJsonEditor';
 import {
 	DEFAULT_WALLET_BALANCE_ALERT_CONFIG,
 	type WalletBalanceAlertConfig,
@@ -77,6 +78,24 @@ export function WalletBalanceAlertConfigSection() {
 
 	const [inlineErrors, setInlineErrors] = useState<{ level?: string }>({});
 
+	const jsonEditor = useJsonEditor({
+		initialValue: formValue,
+		sendCompleteConfig: true,
+		validate: (value) => {
+			if (value.alert_enabled) {
+				const hasOne = value.critical !== null || value.warning !== null || value.info !== null;
+				if (!hasOne) {
+					return 'At least one of Critical, Warning, or Info must be configured when alerts are enabled.';
+				}
+			}
+			return null;
+		},
+		onSave: (data) => {
+			saveMutation.mutate(data as WalletBalanceAlertConfig);
+			setFormValue((prev) => ({ ...prev, ...(data as WalletBalanceAlertConfig) }));
+		},
+	});
+
 	const validate = (): boolean => {
 		if (formValue.alert_enabled) {
 			const hasOne = formValue.critical !== null || formValue.warning !== null || formValue.info !== null;
@@ -118,58 +137,98 @@ export function WalletBalanceAlertConfigSection() {
 						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
 							Reset to default
 						</Button>
-						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+						<Button variant='outline' size='sm' onClick={jsonEditor.toggleEditor}>
+							{jsonEditor.showJsonEditor ? 'Form View' : 'JSON Editor'}
+						</Button>
+						<Button
+							size='sm'
+							onClick={jsonEditor.showJsonEditor ? jsonEditor.handleJsonSave : handleSave}
+							disabled={saveMutation.isPending}
+							isLoading={saveMutation.isPending}>
 							Save
 						</Button>
 					</div>
 				}
 			/>
 			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
-				{isError && (
-					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
-						Failed to load settings.{' '}
-						<button type='button' onClick={() => refetch()} className='underline font-medium'>
-							Retry
-						</button>
+				{!jsonEditor.showJsonEditor ? (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
+						{inlineErrors.level && (
+							<div className='rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800' role='alert'>
+								{inlineErrors.level}
+							</div>
+						)}
+						<div className='flex items-center gap-2'>
+							<input
+								id='alert_enabled'
+								type='checkbox'
+								checked={formValue.alert_enabled}
+								onChange={(e) => setFormValue((prev) => ({ ...prev, alert_enabled: e.target.checked }))}
+								className='h-4 w-4 rounded border-gray-300'
+							/>
+							<label htmlFor='alert_enabled' className='text-sm text-zinc-700'>
+								Alert enabled
+							</label>
+						</div>
+						<div className='space-y-2'>
+							<AlertLevelRow
+								label='Critical'
+								value={formValue.critical}
+								onChange={(v) => setFormValue((prev) => ({ ...prev, critical: v }))}
+								error={getFieldError(backendDetails, 'critical')}
+							/>
+							<AlertLevelRow
+								label='Warning'
+								value={formValue.warning}
+								onChange={(v) => setFormValue((prev) => ({ ...prev, warning: v }))}
+								error={getFieldError(backendDetails, 'warning')}
+							/>
+							<AlertLevelRow
+								label='Info'
+								value={formValue.info}
+								onChange={(v) => setFormValue((prev) => ({ ...prev, info: v }))}
+								error={getFieldError(backendDetails, 'info')}
+							/>
+						</div>
+					</div>
+				) : (
+					<div className='space-y-4'>
+						{isError && (
+							<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+								Failed to load settings.{' '}
+								<button type='button' onClick={() => refetch()} className='underline font-medium'>
+									Retry
+								</button>
+							</div>
+						)}
+						<div>
+							<label className='block text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1'>
+								JSON Configuration (Developer Mode)
+							</label>
+							<Textarea
+								value={jsonEditor.jsonValue}
+								onChange={jsonEditor.setJsonValue}
+								placeholder='Paste or edit JSON configuration here...'
+								error={jsonEditor.jsonError}
+								description='Edit the wallet balance alert configuration directly in JSON format. Only changed values will be saved.'
+								textAreaClassName='min-h-[400px] font-mono text-sm'
+							/>
+							{jsonEditor.jsonError && (
+								<p className='mt-1 text-sm text-red-600' role='alert'>
+									{jsonEditor.jsonError}
+								</p>
+							)}
+						</div>
 					</div>
 				)}
-				{inlineErrors.level && (
-					<div className='rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800' role='alert'>
-						{inlineErrors.level}
-					</div>
-				)}
-				<div className='flex items-center gap-2'>
-					<input
-						id='alert_enabled'
-						type='checkbox'
-						checked={formValue.alert_enabled}
-						onChange={(e) => setFormValue((prev) => ({ ...prev, alert_enabled: e.target.checked }))}
-						className='h-4 w-4 rounded border-gray-300'
-					/>
-					<label htmlFor='alert_enabled' className='text-sm text-zinc-700'>
-						Alert enabled
-					</label>
-				</div>
-				<div className='space-y-2'>
-					<AlertLevelRow
-						label='Critical'
-						value={formValue.critical}
-						onChange={(v) => setFormValue((prev) => ({ ...prev, critical: v }))}
-						error={getFieldError(backendDetails, 'critical')}
-					/>
-					<AlertLevelRow
-						label='Warning'
-						value={formValue.warning}
-						onChange={(v) => setFormValue((prev) => ({ ...prev, warning: v }))}
-						error={getFieldError(backendDetails, 'warning')}
-					/>
-					<AlertLevelRow
-						label='Info'
-						value={formValue.info}
-						onChange={(v) => setFormValue((prev) => ({ ...prev, info: v }))}
-						error={getFieldError(backendDetails, 'info')}
-					/>
-				</div>
 			</div>
 		</Card>
 	);

--- a/src/pages/settings/org/WalletBalanceAlertConfigSection.tsx
+++ b/src/pages/settings/org/WalletBalanceAlertConfigSection.tsx
@@ -1,0 +1,176 @@
+import { Card, CardHeader, Button, Input, Loader, Select, type SelectOption } from '@/components/atoms';
+import { useSettingSection } from '@/hooks/useSettingSection';
+import {
+	DEFAULT_WALLET_BALANCE_ALERT_CONFIG,
+	type WalletBalanceAlertConfig,
+	type WalletAlertLevel,
+	type WalletAlertCondition,
+} from '@/types/dto/OrgSettings';
+import { useState } from 'react';
+
+const SETTING_KEY = 'wallet_balance_alert_config';
+
+const CONDITION_OPTIONS: SelectOption[] = [
+	{ value: 'below', label: 'Below' },
+	{ value: 'above', label: 'Above' },
+];
+
+function getFieldError(details: Record<string, string>, field: string): string | undefined {
+	return details[`value.${field}`] ?? details[field];
+}
+
+function AlertLevelRow({
+	label,
+	value,
+	onChange,
+	error,
+}: {
+	label: string;
+	value: WalletAlertLevel | null;
+	onChange: (v: WalletAlertLevel | null) => void;
+	error?: string;
+}) {
+	const enabled = value !== null;
+	return (
+		<div className='flex flex-wrap items-center gap-3 p-3 rounded-lg border border-gray-100 bg-gray-50/50'>
+			<div className='flex items-center gap-2'>
+				<input
+					type='checkbox'
+					checked={enabled}
+					onChange={(e) => {
+						if (e.target.checked) {
+							onChange({ threshold: '0', condition: 'below' });
+						} else {
+							onChange(null);
+						}
+					}}
+					className='h-4 w-4 rounded border-gray-300'
+				/>
+				<span className='text-sm font-medium text-zinc-700'>{label}</span>
+			</div>
+			{enabled && value && (
+				<>
+					<Input placeholder='Threshold' value={value.threshold} onChange={(v) => onChange({ ...value, threshold: v })} className='w-24' />
+					<Select
+						options={CONDITION_OPTIONS}
+						value={value.condition}
+						onChange={(v) => onChange({ ...value, condition: v as WalletAlertCondition })}
+						className='w-28'
+					/>
+				</>
+			)}
+			{error && (
+				<p className='w-full text-sm text-red-600' role='alert'>
+					{error}
+				</p>
+			)}
+		</div>
+	);
+}
+
+export function WalletBalanceAlertConfigSection() {
+	const { isLoading, isError, formValue, setFormValue, saveMutation, resetMutation, backendDetails, refetch } =
+		useSettingSection<WalletBalanceAlertConfig>({
+			key: SETTING_KEY,
+			defaultValue: DEFAULT_WALLET_BALANCE_ALERT_CONFIG,
+		});
+
+	const [inlineErrors, setInlineErrors] = useState<{ level?: string }>({});
+
+	const validate = (): boolean => {
+		if (formValue.alert_enabled) {
+			const hasOne = formValue.critical !== null || formValue.warning !== null || formValue.info !== null;
+			if (!hasOne) {
+				setInlineErrors({ level: 'At least one of Critical, Warning, or Info must be configured when alerts are enabled.' });
+				return false;
+			}
+		}
+		setInlineErrors({});
+		return true;
+	};
+
+	const handleSave = () => {
+		if (!validate()) return;
+		saveMutation.mutate(formValue);
+	};
+
+	const handleReset = () => {
+		resetMutation.mutate(undefined);
+	};
+
+	if (isLoading) {
+		return (
+			<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+				<div className='p-6'>
+					<Loader />
+				</div>
+			</Card>
+		);
+	}
+
+	return (
+		<Card variant='default' className='rounded-xl border-gray-200 shadow-sm bg-white'>
+			<CardHeader
+				title='Wallet balance alerts'
+				titleClassName='text-lg font-medium text-zinc-800'
+				cta={
+					<div className='flex items-center gap-2'>
+						<Button variant='outline' size='sm' onClick={handleReset} disabled={resetMutation.isPending}>
+							Reset to default
+						</Button>
+						<Button size='sm' onClick={handleSave} disabled={saveMutation.isPending} isLoading={saveMutation.isPending}>
+							Save
+						</Button>
+					</div>
+				}
+			/>
+			<div className='border-t border-gray-100 pt-4 px-6 pb-6 space-y-4'>
+				{isError && (
+					<div className='rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
+						Failed to load settings.{' '}
+						<button type='button' onClick={() => refetch()} className='underline font-medium'>
+							Retry
+						</button>
+					</div>
+				)}
+				{inlineErrors.level && (
+					<div className='rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800' role='alert'>
+						{inlineErrors.level}
+					</div>
+				)}
+				<div className='flex items-center gap-2'>
+					<input
+						id='alert_enabled'
+						type='checkbox'
+						checked={formValue.alert_enabled}
+						onChange={(e) => setFormValue((prev) => ({ ...prev, alert_enabled: e.target.checked }))}
+						className='h-4 w-4 rounded border-gray-300'
+					/>
+					<label htmlFor='alert_enabled' className='text-sm text-zinc-700'>
+						Alert enabled
+					</label>
+				</div>
+				<div className='space-y-2'>
+					<AlertLevelRow
+						label='Critical'
+						value={formValue.critical}
+						onChange={(v) => setFormValue((prev) => ({ ...prev, critical: v }))}
+						error={getFieldError(backendDetails, 'critical')}
+					/>
+					<AlertLevelRow
+						label='Warning'
+						value={formValue.warning}
+						onChange={(v) => setFormValue((prev) => ({ ...prev, warning: v }))}
+						error={getFieldError(backendDetails, 'warning')}
+					/>
+					<AlertLevelRow
+						label='Info'
+						value={formValue.info}
+						onChange={(v) => setFormValue((prev) => ({ ...prev, info: v }))}
+						error={getFieldError(backendDetails, 'info')}
+					/>
+				</div>
+			</div>
+		</Card>
+	);
+}

--- a/src/types/dto/OrgSettings.ts
+++ b/src/types/dto/OrgSettings.ts
@@ -1,0 +1,210 @@
+/**
+ * Environment-level org settings value schemas.
+ * Keys match API path segments: GET/PUT/DELETE /v1/settings/:key
+ */
+
+// ─── 1. invoice_config ───────────────────────────────────────────────────────
+
+export const INVOICE_FORMAT = ['YYYYMM', 'YYYYMMDD', 'YYMMDD', 'YY', 'YYYY'] as const;
+export type InvoiceFormat = (typeof INVOICE_FORMAT)[number];
+
+export interface InvoiceConfig {
+	prefix: string;
+	format: InvoiceFormat;
+	start_sequence: number;
+	timezone: string;
+	separator?: string;
+	suffix_length: number;
+	due_date_days: number | null;
+	auto_complete_purchased_credit_transaction?: boolean;
+}
+
+export const DEFAULT_INVOICE_CONFIG: InvoiceConfig = {
+	prefix: 'INV',
+	format: 'YYYYMM',
+	start_sequence: 1,
+	timezone: 'UTC',
+	separator: '-',
+	suffix_length: 5,
+	due_date_days: 1,
+	auto_complete_purchased_credit_transaction: false,
+};
+
+// ─── 2. subscription_config ─────────────────────────────────────────────────
+
+export interface SubscriptionConfig {
+	grace_period_days: number;
+	auto_cancellation_enabled: boolean;
+}
+
+export const DEFAULT_SUBSCRIPTION_CONFIG: SubscriptionConfig = {
+	grace_period_days: 3,
+	auto_cancellation_enabled: false,
+};
+
+// ─── 3. invoice_pdf_config ───────────────────────────────────────────────────
+
+export interface InvoicePdfConfig {
+	template_name: string;
+	group_by: string[];
+}
+
+export const DEFAULT_INVOICE_PDF_CONFIG: InvoicePdfConfig = {
+	template_name: 'invoice.typ',
+	group_by: [],
+};
+
+// ─── 4. customer_onboarding ───────────────────────────────────────────────────
+
+export type CustomerOnboardingAction =
+	| { action: 'create_customer'; default_user_id?: string }
+	| { action: 'create_wallet'; currency: string; conversion_rate?: number }
+	| { action: 'create_subscription'; plan_id: string; billing_cycle?: 'anniversary' | 'calendar'; start_date?: string }
+	| {
+			action: 'create_feature_and_price';
+			plan_id: string;
+			feature_type?: 'metered' | 'boolean' | 'static';
+			price_start_date_time?: string;
+	  };
+
+export interface CustomerOnboardingConfig {
+	workflow_type: 'customer_onboarding';
+	actions: CustomerOnboardingAction[];
+}
+
+export const DEFAULT_CUSTOMER_ONBOARDING_CONFIG: CustomerOnboardingConfig = {
+	workflow_type: 'customer_onboarding',
+	actions: [{ action: 'create_customer' }],
+};
+
+// ─── 5. wallet_balance_alert_config ───────────────────────────────────────────
+
+export type WalletAlertCondition = 'below' | 'above';
+
+export interface WalletAlertLevel {
+	threshold: string;
+	condition: WalletAlertCondition;
+}
+
+export interface WalletBalanceAlertConfig {
+	critical: WalletAlertLevel | null;
+	warning: WalletAlertLevel | null;
+	info: WalletAlertLevel | null;
+	alert_enabled: boolean;
+}
+
+export const DEFAULT_WALLET_BALANCE_ALERT_CONFIG: WalletBalanceAlertConfig = {
+	critical: null,
+	warning: null,
+	info: null,
+	alert_enabled: false,
+};
+
+// ─── 6. prepare_processed_events_config ─────────────────────────────────────────
+
+export type MeterAggregationType = 'COUNT' | 'SUM' | 'AVG' | 'COUNT_UNIQUE' | 'LATEST' | 'SUM_WITH_MULTIPLIER' | 'MAX' | 'WEIGHTED_SUM';
+
+export type ResetUsageType = 'BILLING_PERIOD' | 'NEVER';
+
+export interface PrepareProcessedEventsMeter {
+	aggregation_type: MeterAggregationType;
+	aggregation_field?: string;
+	reset_usage?: ResetUsageType;
+}
+
+export interface PrepareProcessedEventsPrice {
+	billing_cadence?: string;
+	billing_period?: string;
+	billing_model?: string;
+	currency?: string;
+	entity_type?: string;
+	invoice_cadence?: string;
+	price_unit_type?: string;
+	type?: string;
+	amount?: number;
+	billing_period_count?: number;
+}
+
+export type PrepareProcessedEventsAction =
+	| {
+			action: 'create_feature_and_price';
+			feature_type?: string;
+			meter?: PrepareProcessedEventsMeter;
+			price?: PrepareProcessedEventsPrice;
+	  }
+	| { action: 'rollout_to_subscriptions'; plan_id: string };
+
+export interface PrepareProcessedEventsConfig {
+	workflow_type: 'prepare_processed_events';
+	actions: PrepareProcessedEventsAction[];
+}
+
+export const DEFAULT_PREPARE_PROCESSED_EVENTS_CONFIG: PrepareProcessedEventsConfig = {
+	workflow_type: 'prepare_processed_events',
+	actions: [],
+};
+
+// ─── 7. custom_analytics_config ───────────────────────────────────────────────
+
+export type CustomAnalyticsTargetType = 'feature' | 'meter' | 'event_name';
+
+export interface CustomAnalyticsRule {
+	id: string;
+	target_type: CustomAnalyticsTargetType;
+	target_id: string;
+}
+
+export interface CustomAnalyticsConfig {
+	rules: CustomAnalyticsRule[];
+}
+
+export const DEFAULT_CUSTOM_ANALYTICS_CONFIG: CustomAnalyticsConfig = {
+	rules: [],
+};
+
+// ─── 8. customer_portal_config (org settings form) ─────────────────────────────
+
+export interface CustomerPortalThemeOrg {
+	primary_color?: string;
+	secondary_color?: string;
+	tertiary_color?: string;
+}
+
+export type CustomerPortalTabType =
+	| 'metric_cards'
+	| 'usage_graph'
+	| 'current_usage'
+	| 'usage_breakdown'
+	| 'wallet_balance'
+	| 'wallet_transactions'
+	| 'invoices'
+	| 'subscriptions';
+
+export interface CustomerPortalTabConfigOrg {
+	id: string;
+	type: CustomerPortalTabType;
+	enabled: boolean;
+	order: number;
+	usage_graph?: Record<string, unknown>;
+	metric_cards?: Record<string, unknown>;
+}
+
+export interface CustomerPortalSectionConfigOrg {
+	id: string;
+	label: string;
+	enabled: boolean;
+	order: number;
+	tabs: CustomerPortalTabConfigOrg[];
+}
+
+export interface CustomerPortalConfigOrg {
+	version: string;
+	theme?: CustomerPortalThemeOrg;
+	sections: CustomerPortalSectionConfigOrg[];
+}
+
+export const DEFAULT_CUSTOMER_PORTAL_CONFIG_ORG: CustomerPortalConfigOrg = {
+	version: '1.0',
+	theme: {},
+	sections: [],
+};

--- a/src/types/dto/index.ts
+++ b/src/types/dto/index.ts
@@ -320,3 +320,34 @@ export type {
 	BatchWorkflowsRequest,
 	BatchWorkflowsResponse,
 } from './Workflow';
+
+export type {
+	InvoiceConfig,
+	SubscriptionConfig,
+	InvoicePdfConfig,
+	CustomerOnboardingConfig,
+	CustomerOnboardingAction,
+	WalletBalanceAlertConfig,
+	WalletAlertLevel,
+	PrepareProcessedEventsConfig,
+	PrepareProcessedEventsAction,
+	CustomAnalyticsConfig,
+	CustomAnalyticsRule,
+	CustomAnalyticsTargetType,
+	CustomerPortalConfigOrg,
+	CustomerPortalSectionConfigOrg,
+	CustomerPortalTabConfigOrg,
+	CustomerPortalThemeOrg,
+} from './OrgSettings';
+
+export {
+	DEFAULT_INVOICE_CONFIG,
+	DEFAULT_SUBSCRIPTION_CONFIG,
+	DEFAULT_INVOICE_PDF_CONFIG,
+	DEFAULT_CUSTOMER_ONBOARDING_CONFIG,
+	DEFAULT_WALLET_BALANCE_ALERT_CONFIG,
+	DEFAULT_PREPARE_PROCESSED_EVENTS_CONFIG,
+	DEFAULT_CUSTOM_ANALYTICS_CONFIG,
+	DEFAULT_CUSTOMER_PORTAL_CONFIG_ORG,
+	INVOICE_FORMAT,
+} from './OrgSettings';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Organization Settings area with pages for invoicing, invoice PDFs, subscriptions, customer onboarding, wallet alerts, processed-events, custom analytics, and customer portal.
  * All settings provide both form-based and JSON editor modes, Save and Reset-to-default actions, loading/error states, and retry support.
  * New route to access Organization Settings and exported setting types/defaults for client usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->