### PR TITLE
refactor(invoice): enhance invoice number display logic to show 'To b…

### DIFF
--- a/src/components/molecules/InvoiceTable/CustomerInvoiceTable.tsx
+++ b/src/components/molecules/InvoiceTable/CustomerInvoiceTable.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import FlexpriceTable, { ColumnData } from '../Table';
 import { getCurrencySymbol } from '@/utils/common/helper_functions';
 import { formatBillingPeriod } from '@/utils/common/format_date';
-import { Invoice } from '@/models/Invoice';
+import { Invoice, INVOICE_STATUS } from '@/models/Invoice';
 import { getPaymentStatusChip, getStatusChip } from './InvoiceTable';
 
 import InvoiceTableMenu from './InvoiceTableMenu';
@@ -17,7 +17,12 @@ const CustomerInvoiceTable: FC<Props> = ({ data, onRowClick }) => {
 	const columnData: ColumnData<Invoice>[] = [
 		{
 			title: 'Invoice Number',
-			render: (row) => <>{row.invoice_number || '--'}</>,
+			render: (row) =>
+				row.invoice_status?.toUpperCase() === INVOICE_STATUS.DRAFT ? (
+					<span className='text-gray-400 italic text-[13px]'>To be generated</span>
+				) : (
+					<>{row.invoice_number || '--'}</>
+				),
 		},
 		{
 			title: 'Status',


### PR DESCRIPTION
…e generated' for draft invoices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the invoice table to properly display "To be generated" (in gray italics) for draft invoices instead of showing an invoice number, clarifying that the invoice identifier is not yet available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->