### PR TITLE
feat(environment): add support for env cloning

### DIFF
--- a/src/api/EnvironmentApi.ts
+++ b/src/api/EnvironmentApi.ts
@@ -1,7 +1,7 @@
 import { AxiosClient } from '@/core/axios/verbs';
 import { ACTIVE_ENVIRONMENT_ID_KEY } from '@/hooks/useEnvironment';
 import { Environment } from '@/models';
-import { CreateEnvironmentPayload, ListEnvironmentResponse } from '@/types/dto';
+import { CloneEnvironmentPayload, CloneEnvironmentResponse, CreateEnvironmentPayload, ListEnvironmentResponse } from '@/types/dto';
 
 class EnvironmentApi {
 	private static baseUrl = '/environments';
@@ -25,6 +25,10 @@ class EnvironmentApi {
 
 	public static async createEnvironment(payload: CreateEnvironmentPayload): Promise<Environment | null> {
 		return await AxiosClient.post<Environment>(this.baseUrl, payload);
+	}
+
+	public static async cloneEnvironment(sourceEnvironmentId: string, payload: CloneEnvironmentPayload): Promise<CloneEnvironmentResponse> {
+		return await AxiosClient.post<CloneEnvironmentResponse>(`${this.baseUrl}/${sourceEnvironmentId}/clone`, payload);
 	}
 
 	public static getActiveEnvironmentId(): string | null {

--- a/src/components/molecules/EnvironmentCopier/EnvironmentCopier.tsx
+++ b/src/components/molecules/EnvironmentCopier/EnvironmentCopier.tsx
@@ -104,7 +104,7 @@ const EnvironmentCopier: React.FC<Props> = ({ isOpen, onOpenChange, sourceEnviro
 		handleOpenChange(false);
 	}, [handleOpenChange]);
 
-	const isSubmitDisabled = isPending || (isNewEnvironment && !name.trim());
+	const isSubmitDisabled = isPending || !sourceEnvironment?.id || (isNewEnvironment && !name.trim());
 
 	return (
 		<Dialog

--- a/src/components/molecules/EnvironmentCopier/EnvironmentCopier.tsx
+++ b/src/components/molecules/EnvironmentCopier/EnvironmentCopier.tsx
@@ -1,0 +1,172 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Dialog, Input, Select, Button } from '@/components/atoms';
+import { ENVIRONMENT_TYPE, Environment } from '@/models/Environment';
+import { CloneEnvironmentPayload } from '@/types/dto/Environment';
+import EnvironmentApi from '@/api/EnvironmentApi';
+import toast from 'react-hot-toast';
+import { Copy, CheckCircle2, AlertTriangle, Clock } from 'lucide-react';
+
+interface Props {
+	isOpen: boolean;
+	onOpenChange: (isOpen: boolean) => void;
+	sourceEnvironment: Environment | null;
+	onEnvironmentCloned: (environmentId?: string) => void | Promise<void>;
+}
+
+const EnvironmentCopier: React.FC<Props> = ({ isOpen, onOpenChange, sourceEnvironment, onEnvironmentCloned }) => {
+	const [name, setName] = useState('');
+	const [type, setType] = useState<ENVIRONMENT_TYPE.DEVELOPMENT | ENVIRONMENT_TYPE.PRODUCTION>(ENVIRONMENT_TYPE.DEVELOPMENT);
+	const queryClient = useQueryClient();
+
+	const environmentTypeOptions = useMemo(
+		() => [
+			{
+				value: ENVIRONMENT_TYPE.DEVELOPMENT,
+				label: 'Sandbox',
+				description: 'For development and testing purposes',
+			},
+			{
+				value: ENVIRONMENT_TYPE.PRODUCTION,
+				label: 'Production',
+				description: 'For live production environment',
+			},
+		],
+		[],
+	);
+
+	const { mutate: cloneEnvironment, isPending } = useMutation({
+		mutationFn: async (payload: CloneEnvironmentPayload) => {
+			if (!sourceEnvironment?.id) throw new Error('No source environment selected');
+			return await EnvironmentApi.cloneEnvironment(sourceEnvironment.id, payload);
+		},
+		onSuccess: async () => {
+			toast.success('Environment clone started — features and plans are being copied in the background.');
+			setName('');
+			setType(ENVIRONMENT_TYPE.DEVELOPMENT);
+			onOpenChange(false);
+			queryClient.invalidateQueries({ queryKey: ['environments'] });
+			await onEnvironmentCloned();
+		},
+		onError: (error: ServerError) => {
+			const errorMessage = error?.error?.message || 'Failed to clone environment';
+			toast.error(errorMessage);
+		},
+	});
+
+	const handleClone = useCallback(() => {
+		if (!name.trim()) {
+			toast.error('Environment name is required');
+			return;
+		}
+		cloneEnvironment({ name: name.trim(), type });
+	}, [name, type, cloneEnvironment]);
+
+	const handleCancel = useCallback(() => {
+		setName('');
+		setType(ENVIRONMENT_TYPE.DEVELOPMENT);
+		onOpenChange(false);
+	}, [onOpenChange]);
+
+	return (
+		<Dialog
+			isOpen={isOpen}
+			onOpenChange={onOpenChange}
+			title='Copy Environment'
+			className='max-w-[520px]'
+			description={
+				sourceEnvironment ? (
+					<span className='text-sm text-muted-foreground'>
+						Copying from{' '}
+						<span className='inline-flex items-center font-semibold text-gray-900 bg-gray-100 border border-gray-200 rounded px-1.5 py-0.5 text-[12px] leading-none'>
+							{sourceEnvironment.name}
+						</span>{' '}
+						into a new environment.
+					</span>
+				) : (
+					'Copy all published configuration into a new environment.'
+				)
+			}>
+			<div className='space-y-5'>
+				{/* Cleanup callout */}
+				<div className='rounded-lg border border-amber-200 bg-gradient-to-br from-amber-50 to-orange-50 px-4 py-3.5'>
+					<div className='flex items-start gap-2.5'>
+						<AlertTriangle className='h-4 w-4 mt-0.5 flex-shrink-0 text-amber-500' />
+						<div>
+							<p className='text-[13px] font-semibold text-amber-800 mb-0.5'>Clean up before copying</p>
+							<p className='text-[13px] text-amber-700 leading-relaxed'>
+								All published features and plans will be copied as-is. Archive or remove anything you don't want in the new environment{' '}
+								<span className='font-medium'>before</span> proceeding.
+							</p>
+						</div>
+					</div>
+				</div>
+
+				{/* Form fields */}
+				<Input
+					label='New Environment Name'
+					placeholder='e.g. Staging, Production Clone'
+					value={name}
+					onChange={setName}
+					disabled={isPending}
+				/>
+				<Select
+					label='Type'
+					placeholder='Select environment type'
+					options={environmentTypeOptions}
+					value={type}
+					onChange={(value) => setType(value as ENVIRONMENT_TYPE.DEVELOPMENT | ENVIRONMENT_TYPE.PRODUCTION)}
+					disabled={isPending}
+				/>
+
+				{/* What gets copied */}
+				<div className='rounded-lg border border-gray-200 divide-y divide-gray-100 overflow-hidden'>
+					<div className='px-4 py-2.5 bg-gray-50'>
+						<p className='text-[11px] font-semibold text-gray-400 uppercase tracking-widest'>What will be copied</p>
+					</div>
+					<div className='px-4 py-3 flex items-start gap-3'>
+						<CheckCircle2 className='h-4 w-4 mt-0.5 flex-shrink-0 text-emerald-500' />
+						<div>
+							<p className='text-sm font-medium text-gray-800'>All published features</p>
+							<p className='text-xs text-gray-500 mt-0.5'>Static, Boolean & Metered features along with their associated meters</p>
+						</div>
+					</div>
+					<div className='px-4 py-3 flex items-start gap-3'>
+						<CheckCircle2 className='h-4 w-4 mt-0.5 flex-shrink-0 text-emerald-500' />
+						<div>
+							<p className='text-sm font-medium text-gray-800'>All published plans</p>
+							<p className='text-xs text-gray-500 mt-0.5'>Including all prices, entitlements, and credit grants attached to each plan</p>
+						</div>
+					</div>
+					<div className='px-4 py-2.5 bg-gray-50'>
+						<p className='text-xs text-gray-400'>
+							Draft entities, archived entities, customers, subscriptions, invoices, and wallet balances are{' '}
+							<span className='font-medium'>not</span> copied.
+						</p>
+					</div>
+				</div>
+
+				{/* Async note */}
+				<div className='flex items-center gap-2.5 text-gray-500'>
+					<Clock className='h-3.5 w-3.5 flex-shrink-0' />
+					<p className='text-xs'>
+						The environment is created immediately. Features and plans are cloned in the background and may take a few seconds to appear.
+					</p>
+				</div>
+
+				{/* Actions */}
+				<div className='flex justify-end gap-2 pt-1'>
+					<Button variant='outline' onClick={handleCancel} disabled={isPending}>
+						Cancel
+					</Button>
+					<Button onClick={handleClone} disabled={isPending || !name.trim()}>
+						<Copy className='h-4 w-4 mr-1.5' />
+						{isPending ? 'Copying...' : 'Copy Environment'}
+					</Button>
+				</div>
+			</div>
+		</Dialog>
+	);
+};
+
+export default EnvironmentCopier;

--- a/src/components/molecules/EnvironmentCopier/EnvironmentCopier.tsx
+++ b/src/components/molecules/EnvironmentCopier/EnvironmentCopier.tsx
@@ -4,6 +4,7 @@ import { Dialog, Input, Select, Button } from '@/components/atoms';
 import { ENVIRONMENT_TYPE, Environment } from '@/models/Environment';
 import { CloneEnvironmentPayload } from '@/types/dto/Environment';
 import EnvironmentApi from '@/api/EnvironmentApi';
+import { ServerError } from '@/core/axios/types';
 import toast from 'react-hot-toast';
 import { Copy, CheckCircle2, AlertTriangle, Clock } from 'lucide-react';
 
@@ -35,6 +36,17 @@ const EnvironmentCopier: React.FC<Props> = ({ isOpen, onOpenChange, sourceEnviro
 		[],
 	);
 
+	const handleOpenChange = useCallback(
+		(open: boolean) => {
+			if (!open) {
+				setName('');
+				setType(ENVIRONMENT_TYPE.DEVELOPMENT);
+			}
+			onOpenChange(open);
+		},
+		[onOpenChange],
+	);
+
 	const { mutate: cloneEnvironment, isPending } = useMutation({
 		mutationFn: async (payload: CloneEnvironmentPayload) => {
 			if (!sourceEnvironment?.id) throw new Error('No source environment selected');
@@ -42,9 +54,7 @@ const EnvironmentCopier: React.FC<Props> = ({ isOpen, onOpenChange, sourceEnviro
 		},
 		onSuccess: async () => {
 			toast.success('Environment clone started — features and plans are being copied in the background.');
-			setName('');
-			setType(ENVIRONMENT_TYPE.DEVELOPMENT);
-			onOpenChange(false);
+			handleOpenChange(false);
 			queryClient.invalidateQueries({ queryKey: ['environments'] });
 			await onEnvironmentCloned();
 		},
@@ -63,15 +73,13 @@ const EnvironmentCopier: React.FC<Props> = ({ isOpen, onOpenChange, sourceEnviro
 	}, [name, type, cloneEnvironment]);
 
 	const handleCancel = useCallback(() => {
-		setName('');
-		setType(ENVIRONMENT_TYPE.DEVELOPMENT);
-		onOpenChange(false);
-	}, [onOpenChange]);
+		handleOpenChange(false);
+	}, [handleOpenChange]);
 
 	return (
 		<Dialog
 			isOpen={isOpen}
-			onOpenChange={onOpenChange}
+			onOpenChange={handleOpenChange}
 			title='Copy Environment'
 			className='max-w-[520px]'
 			description={

--- a/src/components/molecules/EnvironmentCopier/EnvironmentCopier.tsx
+++ b/src/components/molecules/EnvironmentCopier/EnvironmentCopier.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { Dialog, Input, Select, Button } from '@/components/atoms';
 import { ENVIRONMENT_TYPE, Environment } from '@/models/Environment';
 import { CloneEnvironmentPayload } from '@/types/dto/Environment';
@@ -16,9 +16,33 @@ interface Props {
 }
 
 const EnvironmentCopier: React.FC<Props> = ({ isOpen, onOpenChange, sourceEnvironment, onEnvironmentCloned }) => {
+	const NEW_ENV_SENTINEL = '__new__';
+	const [targetEnvironmentId, setTargetEnvironmentId] = useState<string>(NEW_ENV_SENTINEL);
 	const [name, setName] = useState('');
 	const [type, setType] = useState<ENVIRONMENT_TYPE.DEVELOPMENT | ENVIRONMENT_TYPE.PRODUCTION>(ENVIRONMENT_TYPE.DEVELOPMENT);
 	const queryClient = useQueryClient();
+
+	const isNewEnvironment = targetEnvironmentId === NEW_ENV_SENTINEL;
+
+	const { data: allEnvironments = [] } = useQuery({
+		queryKey: ['environments'],
+		queryFn: async () => {
+			const res = await EnvironmentApi.getAllEnvironments();
+			return res.environments;
+		},
+	});
+
+	const targetEnvironmentOptions = useMemo(() => {
+		const others = allEnvironments.filter((env) => env.id !== sourceEnvironment?.id);
+		return [
+			{ value: NEW_ENV_SENTINEL, label: 'Create a new environment', description: 'A new environment will be created for the copy' },
+			...others.map((env) => ({
+				value: env.id,
+				label: env.name,
+				description: env.type === ENVIRONMENT_TYPE.PRODUCTION ? 'Production' : 'Sandbox',
+			})),
+		];
+	}, [allEnvironments, sourceEnvironment?.id]);
 
 	const environmentTypeOptions = useMemo(
 		() => [
@@ -39,6 +63,7 @@ const EnvironmentCopier: React.FC<Props> = ({ isOpen, onOpenChange, sourceEnviro
 	const handleOpenChange = useCallback(
 		(open: boolean) => {
 			if (!open) {
+				setTargetEnvironmentId(NEW_ENV_SENTINEL);
 				setName('');
 				setType(ENVIRONMENT_TYPE.DEVELOPMENT);
 			}
@@ -65,16 +90,21 @@ const EnvironmentCopier: React.FC<Props> = ({ isOpen, onOpenChange, sourceEnviro
 	});
 
 	const handleClone = useCallback(() => {
-		if (!name.trim()) {
+		if (isNewEnvironment && !name.trim()) {
 			toast.error('Environment name is required');
 			return;
 		}
-		cloneEnvironment({ name: name.trim(), type });
-	}, [name, type, cloneEnvironment]);
+		const payload: CloneEnvironmentPayload = isNewEnvironment
+			? { name: name.trim(), type }
+			: { target_environment_id: targetEnvironmentId };
+		cloneEnvironment(payload);
+	}, [isNewEnvironment, name, type, targetEnvironmentId, cloneEnvironment]);
 
 	const handleCancel = useCallback(() => {
 		handleOpenChange(false);
 	}, [handleOpenChange]);
+
+	const isSubmitDisabled = isPending || (isNewEnvironment && !name.trim());
 
 	return (
 		<Dialog
@@ -89,10 +119,10 @@ const EnvironmentCopier: React.FC<Props> = ({ isOpen, onOpenChange, sourceEnviro
 						<span className='inline-flex items-center font-semibold text-gray-900 bg-gray-100 border border-gray-200 rounded px-1.5 py-0.5 text-[12px] leading-none'>
 							{sourceEnvironment.name}
 						</span>{' '}
-						into a new environment.
+						into {isNewEnvironment ? 'a new environment' : 'the selected environment'}.
 					</span>
 				) : (
-					'Copy all published configuration into a new environment.'
+					'Copy all published configuration into an environment.'
 				)
 			}>
 			<div className='space-y-5'>
@@ -103,29 +133,43 @@ const EnvironmentCopier: React.FC<Props> = ({ isOpen, onOpenChange, sourceEnviro
 						<div>
 							<p className='text-[13px] font-semibold text-amber-800 mb-0.5'>Clean up before copying</p>
 							<p className='text-[13px] text-amber-700 leading-relaxed'>
-								All published features and plans will be copied as-is. Archive or remove anything you don't want in the new environment{' '}
+								All active features and plans will be copied as-is. Archive or remove anything you don't want carried over{' '}
 								<span className='font-medium'>before</span> proceeding.
 							</p>
 						</div>
 					</div>
 				</div>
 
-				{/* Form fields */}
-				<Input
-					label='New Environment Name'
-					placeholder='e.g. Staging, Production Clone'
-					value={name}
-					onChange={setName}
-					disabled={isPending}
-				/>
+				{/* Target environment */}
 				<Select
-					label='Type'
-					placeholder='Select environment type'
-					options={environmentTypeOptions}
-					value={type}
-					onChange={(value) => setType(value as ENVIRONMENT_TYPE.DEVELOPMENT | ENVIRONMENT_TYPE.PRODUCTION)}
+					label='Copy into'
+					placeholder='Select target environment'
+					options={targetEnvironmentOptions}
+					value={targetEnvironmentId}
+					onChange={(value) => setTargetEnvironmentId(value)}
 					disabled={isPending}
 				/>
+
+				{/* New environment fields — only shown when no target is selected */}
+				{isNewEnvironment && (
+					<>
+						<Input
+							label='New Environment Name'
+							placeholder='e.g. Staging, Production Clone'
+							value={name}
+							onChange={setName}
+							disabled={isPending}
+						/>
+						<Select
+							label='Type'
+							placeholder='Select environment type'
+							options={environmentTypeOptions}
+							value={type}
+							onChange={(value) => setType(value as ENVIRONMENT_TYPE.DEVELOPMENT | ENVIRONMENT_TYPE.PRODUCTION)}
+							disabled={isPending}
+						/>
+					</>
+				)}
 
 				{/* What gets copied */}
 				<div className='rounded-lg border border-gray-200 divide-y divide-gray-100 overflow-hidden'>
@@ -135,14 +179,14 @@ const EnvironmentCopier: React.FC<Props> = ({ isOpen, onOpenChange, sourceEnviro
 					<div className='px-4 py-3 flex items-start gap-3'>
 						<CheckCircle2 className='h-4 w-4 mt-0.5 flex-shrink-0 text-emerald-500' />
 						<div>
-							<p className='text-sm font-medium text-gray-800'>All published features</p>
+							<p className='text-sm font-medium text-gray-800'>All active features</p>
 							<p className='text-xs text-gray-500 mt-0.5'>Static, Boolean & Metered features along with their associated meters</p>
 						</div>
 					</div>
 					<div className='px-4 py-3 flex items-start gap-3'>
 						<CheckCircle2 className='h-4 w-4 mt-0.5 flex-shrink-0 text-emerald-500' />
 						<div>
-							<p className='text-sm font-medium text-gray-800'>All published plans</p>
+							<p className='text-sm font-medium text-gray-800'>All active plans</p>
 							<p className='text-xs text-gray-500 mt-0.5'>Including all prices, entitlements, and credit grants attached to each plan</p>
 						</div>
 					</div>
@@ -158,7 +202,9 @@ const EnvironmentCopier: React.FC<Props> = ({ isOpen, onOpenChange, sourceEnviro
 				<div className='flex items-center gap-2.5 text-gray-500'>
 					<Clock className='h-3.5 w-3.5 flex-shrink-0' />
 					<p className='text-xs'>
-						The environment is created immediately. Features and plans are cloned in the background and may take a few seconds to appear.
+						{isNewEnvironment
+							? 'The environment is created immediately. Features and plans are cloned in the background and may take a few seconds to appear.'
+							: 'Features and plans are cloned in the background and may take a few seconds to appear.'}
 					</p>
 				</div>
 
@@ -167,7 +213,7 @@ const EnvironmentCopier: React.FC<Props> = ({ isOpen, onOpenChange, sourceEnviro
 					<Button variant='outline' onClick={handleCancel} disabled={isPending}>
 						Cancel
 					</Button>
-					<Button onClick={handleClone} disabled={isPending || !name.trim()}>
+					<Button onClick={handleClone} disabled={isSubmitDisabled}>
 						<Copy className='h-4 w-4 mr-1.5' />
 						{isPending ? 'Copying...' : 'Copy Environment'}
 					</Button>

--- a/src/components/molecules/EnvironmentCopier/index.ts
+++ b/src/components/molecules/EnvironmentCopier/index.ts
@@ -1,0 +1,1 @@
+export { default } from './EnvironmentCopier';

--- a/src/components/molecules/EnvironmentSelector/EnvironmentSelector.tsx
+++ b/src/components/molecules/EnvironmentSelector/EnvironmentSelector.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils';
 import React, { useState } from 'react';
 import { Skeleton } from '@/components/ui';
-import { Blocks, Rocket, Server, ChevronsUpDown, Plus } from 'lucide-react';
+import { Blocks, Rocket, Server, ChevronsUpDown, Plus, Copy } from 'lucide-react';
 import { useGlobalLoading } from '@/core/services/tanstack/ReactQueryProvider';
 import useUser from '@/hooks/useUser';
 import { Select, SelectContent, useSidebar } from '@/components/ui';
@@ -13,6 +13,7 @@ import { useEnvironment } from '@/hooks/useEnvironment';
 import { useRestrictedEnvs, EnvRestrictionState } from '@/hooks/useRestrictedEnvs';
 import { Button } from '@/components/atoms';
 import EnvironmentCreator from '../EnvironmentCreator/EnvironmentCreator';
+import EnvironmentCopier from '../EnvironmentCopier/EnvironmentCopier';
 import ContactUsDialog from '../ContactUsDialog/ContactUsDialog';
 import { ENVIRONMENT_TYPE } from '@/models/Environment';
 
@@ -72,6 +73,7 @@ const EnvironmentSelector: React.FC<Props> = ({ disabled = false, className }) =
 
 	const [isOpen, setIsOpen] = useState(false);
 	const [isCreatorOpen, setIsCreatorOpen] = useState(false);
+	const [isCopierOpen, setIsCopierOpen] = useState(false);
 	const [isSuspendedDialogOpen, setIsSuspendedDialogOpen] = useState(false);
 
 	if (loading)
@@ -167,7 +169,7 @@ const EnvironmentSelector: React.FC<Props> = ({ disabled = false, className }) =
 							</div>
 						</SelectItem>
 					))}
-					<div className='flex items-center gap-2 m-2 text-muted-foreground'>
+					<div className='flex flex-col gap-1.5 m-2 text-muted-foreground'>
 						<Button
 							onClick={() => {
 								setIsOpen(false);
@@ -179,6 +181,18 @@ const EnvironmentSelector: React.FC<Props> = ({ disabled = false, className }) =
 							className='w-full text-center rounded-[6px] justify-center items-center'>
 							<Plus className='h-4 w-4' />
 							Add Environment
+						</Button>
+						<Button
+							onClick={() => {
+								setIsOpen(false);
+								setIsCopierOpen(true);
+							}}
+							key='copy'
+							size='sm'
+							variant='outline'
+							className='w-full text-center rounded-[6px] justify-center items-center'>
+							<Copy className='h-4 w-4' />
+							Copy Environment
 						</Button>
 					</div>
 				</SelectContent>
@@ -192,6 +206,15 @@ const EnvironmentSelector: React.FC<Props> = ({ disabled = false, className }) =
 					if (environmentId) {
 						handleChange(environmentId);
 					}
+				}}
+			/>
+
+			<EnvironmentCopier
+				isOpen={isCopierOpen}
+				onOpenChange={setIsCopierOpen}
+				sourceEnvironment={currentEnvironment}
+				onEnvironmentCloned={async () => {
+					await refetchEnvironments();
 				}}
 			/>
 

--- a/src/pages/product-catalog/features/AddFeature.tsx
+++ b/src/pages/product-catalog/features/AddFeature.tsx
@@ -297,6 +297,7 @@ const FeatureDetailsSection = ({
 		(name: string) => {
 			onUpdateFeature({
 				name,
+				lookup_key: 'feat-' + name.replace(/\s/g, '-').toLowerCase(),
 				meter: data.meter ? { ...data.meter, name } : undefined,
 			});
 		},

--- a/src/types/dto/Environment.ts
+++ b/src/types/dto/Environment.ts
@@ -12,3 +12,14 @@ export interface CreateEnvironmentPayload {
 export interface ListEnvironmentResponse extends Pagination {
 	environments: Environment[];
 }
+
+export interface CloneEnvironmentPayload {
+	name: string;
+	type: ENVIRONMENT_TYPE.DEVELOPMENT | ENVIRONMENT_TYPE.PRODUCTION;
+}
+
+export interface CloneEnvironmentResponse {
+	workflow_id: string;
+	run_id: string;
+	message: string;
+}

--- a/src/types/dto/Environment.ts
+++ b/src/types/dto/Environment.ts
@@ -14,8 +14,9 @@ export interface ListEnvironmentResponse extends Pagination {
 }
 
 export interface CloneEnvironmentPayload {
-	name: string;
-	type: ENVIRONMENT_TYPE.DEVELOPMENT | ENVIRONMENT_TYPE.PRODUCTION;
+	target_environment_id?: string;
+	name?: string;
+	type?: ENVIRONMENT_TYPE.DEVELOPMENT | ENVIRONMENT_TYPE.PRODUCTION;
 }
 
 export interface CloneEnvironmentResponse {

--- a/src/types/dto/index.ts
+++ b/src/types/dto/index.ts
@@ -193,7 +193,13 @@ export type {
 	CreditNoteLineItem,
 } from './CreditNote';
 
-export type { UpdateEnvironmentPayload, CreateEnvironmentPayload, ListEnvironmentResponse } from './Environment';
+export type {
+	UpdateEnvironmentPayload,
+	CreateEnvironmentPayload,
+	ListEnvironmentResponse,
+	CloneEnvironmentPayload,
+	CloneEnvironmentResponse,
+} from './Environment';
 
 export { CREDIT_NOTE_STATUS, CREDIT_NOTE_REASON, CREDIT_NOTE_TYPE } from '@/models';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Copy Environment" dialog to duplicate an environment (create new or choose existing) plus a "Copy Environment" button in the selector.

* **Improvements**
  * Validation for required name, success/error toasts, disabled inputs while copying, submit label changes to "Copying...", and automatic refresh after clone.

* **UX**
  * Reworked selector action layout and automatic generation of a feature lookup key when editing a feature name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->