### PR TITLE
fix(subscriptions): rem support of dropdown update for inherited subs

### DIFF
--- a/src/components/molecules/SubscriptionTable/SubscriptionTable.tsx
+++ b/src/components/molecules/SubscriptionTable/SubscriptionTable.tsx
@@ -2,7 +2,7 @@ import { FC, useState } from 'react';
 import { ActionButton, Chip } from '@/components/atoms';
 import FlexpriceTable, { ColumnData } from '../Table';
 import formatDate from '@/utils/common/format_date';
-import { Subscription, SUBSCRIPTION_STATUS } from '@/models/Subscription';
+import { Subscription, SUBSCRIPTION_STATUS, SUBSCRIPTION_TYPE } from '@/models/Subscription';
 import { useNavigate } from 'react-router';
 import { RouteNames } from '@/core/routes/Routes';
 import RedirectCell from '../Table/RedirectCell';
@@ -81,7 +81,7 @@ const SubscriptionTable: FC<Props> = ({ data, onEdit }) => {
 						{
 							text: 'Cancel',
 							icon: <Trash2 />,
-							enabled: row.subscription_status !== SUBSCRIPTION_STATUS.CANCELLED,
+							enabled: row.subscription_status !== SUBSCRIPTION_STATUS.CANCELLED && row.subscription_type !== SUBSCRIPTION_TYPE.INHERITED,
 							onClick: () => setCancelSubscriptionId(row.id),
 						},
 					]}

--- a/src/components/organisms/Subscription/SubscriptionActionButton.tsx
+++ b/src/components/organisms/Subscription/SubscriptionActionButton.tsx
@@ -4,6 +4,7 @@ import {
 	SUBSCRIPTION_CANCELLATION_TYPE,
 	SUBSCRIPTION_CANCEL_IMMEDIATELY_INVOICE_POLICY,
 	SUBSCRIPTION_STATUS,
+	SUBSCRIPTION_TYPE,
 } from '@/models/Subscription';
 import { useMutation } from '@tanstack/react-query';
 import { CirclePause, CirclePlay, X, Plus, Pencil, Play } from 'lucide-react';
@@ -147,6 +148,7 @@ const SubscriptionActionButton: React.FC<Props> = ({ subscription }) => {
 	const isPaused = subscription.subscription_status.toUpperCase() === 'PAUSED';
 	const isCancelled = subscription.subscription_status.toUpperCase() === 'CANCELLED';
 	const isDraft = subscription.subscription_status === SUBSCRIPTION_STATUS.DRAFT;
+	const isInherited = subscription.subscription_type === SUBSCRIPTION_TYPE.INHERITED;
 
 	const menuOptions: DropdownMenuOption[] = [
 		...(isDraft
@@ -201,7 +203,7 @@ const SubscriptionActionButton: React.FC<Props> = ({ subscription }) => {
 
 	return (
 		<>
-			<DropdownMenu options={menuOptions} />
+			{!isInherited && <DropdownMenu options={menuOptions} />}
 
 			{/* Pause Modal */}
 			<Modal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controls for inherited subscriptions - cancel button is now properly disabled and dropdown menu is hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->