### PR TITLE
feat(agent-discovery): Link headers, Content-Signals, API catalog, Ag…

### DIFF
--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://agentskills.io/schemas/v0.2.0/index.json",
+  "skills": []
+}

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,16 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://api.cloud.flexprice.io",
+      "service-desc": [
+        { "href": "https://api.cloud.flexprice.io/swagger/doc.json", "type": "application/json" }
+      ],
+      "service-doc": [
+        { "href": "https://docs.flexprice.io", "type": "text/html" }
+      ],
+      "status": [
+        { "href": "https://api.cloud.flexprice.io/health", "type": "application/json" }
+      ]
+    }
+  ]
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+
+Sitemap: https://admin.flexprice.io/sitemap.xml

--- a/src/agent/webmcp.ts
+++ b/src/agent/webmcp.ts
@@ -1,0 +1,28 @@
+type ModelContextNavigator = Navigator & {
+	modelContext?: {
+		provideContext: (ctx: { tools: unknown[] }) => void;
+	};
+};
+
+export function registerWebMCPTools() {
+	if (typeof navigator === 'undefined') return;
+	const nav = navigator as ModelContextNavigator;
+	if (!nav.modelContext?.provideContext) return;
+
+	nav.modelContext.provideContext({
+		tools: [
+			{
+				name: 'get_flexprice_app_info',
+				description:
+					'Returns metadata about the Flexprice dashboard the user is currently viewing: product name, build version, and canonical documentation and API URLs.',
+				inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+				execute: async () => ({
+					name: 'Flexprice Dashboard',
+					version: __APP_VERSION__,
+					docs: 'https://docs.flexprice.io',
+					api: 'https://api.cloud.flexprice.io',
+				}),
+			},
+		],
+	});
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,8 +5,11 @@ import PosthogProvider from './core/services/posthog/PosthogProvider.tsx';
 import SentryProvider from './core/services/sentry/SentryProvider.tsx';
 import VercelSpeedInsights from './core/services/vercel/vercel.tsx';
 import { NODE_ENV, NodeEnv } from './types/index.ts';
+import { registerWebMCPTools } from './agent/webmcp.ts';
 
 const isProd = NODE_ENV === NodeEnv.PROD;
+
+registerWebMCPTools();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
 	<div>

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,30 @@
             "source": "/(.*)",
             "destination": "/"
         }
+    ],
+    "headers": [
+        {
+            "source": "/",
+            "headers": [
+                {
+                    "key": "Link",
+                    "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", <https://docs.flexprice.io>; rel=\"service-doc\"; type=\"text/html\", <https://api.cloud.flexprice.io/swagger/doc.json>; rel=\"service-desc\"; type=\"application/json\""
+                }
+            ]
+        },
+        {
+            "source": "/.well-known/api-catalog",
+            "headers": [
+                { "key": "Content-Type", "value": "application/linkset+json" },
+                { "key": "Cache-Control", "value": "public, max-age=3600" }
+            ]
+        },
+        {
+            "source": "/.well-known/agent-skills/index.json",
+            "headers": [
+                { "key": "Content-Type", "value": "application/json" },
+                { "key": "Cache-Control", "value": "public, max-age=3600" }
+            ]
+        }
     ]
 }


### PR DESCRIPTION
### Summary

Makes the Flexprice dashboard discoverable to AI agents and crawlers (ChatGPT, Claude, Perplexity, Gemini, Google AI Overviews, WebMCP-enabled browsers) by publishing the emerging discovery signals flagged by the [isitagentready.com](https://isitagentready.com) audit.

Agents visiting `admin.flexprice.io` can now:
- Read AI content-usage preferences from `robots.txt`.
- Follow a `Link:` response header straight to the API catalog, API docs, and the OpenAPI spec.
- Fetch a machine-readable RFC 9727 linkset at `/.well-known/api-catalog`.
- Detect WebMCP tool availability at page load.

### What changed

| Area | File | Change |
|---|---|---|
| Crawler signals | `public/robots.txt` | New. Adds `Content-Signal: ai-train=no, search=yes, ai-input=yes` (draft-romm-aipref-contentsignals). |
| API discovery | `public/.well-known/api-catalog` | New. RFC 9727 linkset with `service-desc`, `service-doc`, and `status` relations for `api.cloud.flexprice.io`. |
| Agent skills | `public/.well-known/agent-skills/index.json` | New. Empty scaffold per Agent Skills Discovery RFC v0.2.0 — future skills can be added with no infra change. |
| Response headers | `vercel.json` | Adds `headers` array: `Link:` on `/` pointing to api-catalog + service-doc + service-desc; `Content-Type: application/linkset+json` on `/.well-known/api-catalog`; `Content-Type: application/json` on the skills index. |
| WebMCP | `src/agent/webmcp.ts` | New. Registers a single read-only `get_flexprice_app_info` tool via `navigator.modelContext.provideContext()`. Feature-detected; silent no-op in browsers without WebMCP. |
| Wiring | `src/main.tsx` | Calls `registerWebMCPTools()` at module load, before React renders. |

### Why each signal

- **Content-Signal** — lets us declare preferences programmatically instead of relying on each AI vendor's bespoke directives. `ai-train=no` (opt out of training), `search=yes` (allow search indexing), `ai-input=yes` (allow inference-time context so agents can answer "what is Flexprice?"). Tune per product/legal guidance later; emitting the directive is the requirement.
- **Link header with three relations** — agents that don't parse linksets can still jump straight to docs or the OpenAPI spec. RFC 8288 permits multiple comma-separated links in one header value.
- **API catalog** — RFC 9727 is the emerging standard for programmatic API discovery. The linkset points to the public Flexprice API host and its OpenAPI spec (`/swagger/doc.json`).
- **Agent Skills index** — empty today, but publishing the well-known path now costs nothing and lets future skills ship as a one-file change.
- **WebMCP** — WebMCP-aware browsers (Chrome experimental, etc.) will detect that this site exposes tools. The single tool is intentionally read-only metadata; anything touching billing data would need auth/permission design and is not in scope for a discoverability fix.

### What's explicitly out of scope

The audit also flagged:
- `/.well-known/openid-configuration` & `/.well-known/oauth-authorization-server`
- `/.well-known/oauth-protected-resource`
- `/.well-known/mcp/server-card.json`

These describe **authorization servers, protected APIs, and MCP servers** — they belong on `api.cloud.flexprice.io`, not on the dashboard SPA. Publishing them here would mislead agents about who issues tokens and where to reach MCP endpoints. Handle in a backend PR.

### Deployment note

Vercel serves files in `public/` before applying `rewrites`, so the SPA catch-all rewrite (`/(.*) → /`) does not intercept `/robots.txt` or `/.well-known/*`. No change to the existing rewrite rule was needed.

### Test plan

- [ ] `npm run build` passes with no TS errors (verified locally).
- [ ] `dist/robots.txt`, `dist/.well-known/api-catalog`, and `dist/.well-known/agent-skills/index.json` are emitted in the build output (verified locally).
- [ ] Both JSON files parse cleanly (verified locally).
- [ ] After preview deploy, confirm response headers:
  ```bash
  curl -sSI https://<preview-url>/
  # Expect: Link: </.well-known/api-catalog>; rel="api-catalog"; ... ,<https://docs.flexprice.io>; rel="service-doc"; ... ,<...swagger/doc.json>; rel="service-desc"; ...

  curl -sSI https://<preview-url>/.well-known/api-catalog
  # Expect: Content-Type: application/linkset+json

  curl -sSI https://<preview-url>/.well-known/agent-skills/index.json
  # Expect: Content-Type: application/json
  ```
- [ ] After preview deploy, confirm `robots.txt` body contains the `Content-Signal:` line.
- [ ] Load the preview in any browser; confirm no console errors from `registerWebMCPTools()` (WebMCP-absent browsers should silently no-op).
- [ ] Re-run the [isitagentready.com](https://isitagentready.com) audit against the preview URL — the five in-scope findings should clear.

### References

- RFC 8288 (Link header): https://www.rfc-editor.org/rfc/rfc8288
- RFC 9727 (API Catalog): https://www.rfc-editor.org/rfc/rfc9727
- Content Signals: https://contentsignals.org/
- Agent Skills Discovery RFC: https://github.com/cloudflare/agent-skills-discovery-rfc
- WebMCP: https://webmachinelearning.github.io/webmcp/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WebMCP tool registration for agent integration, exposing application metadata and version information
  * Added API catalog endpoint to advertise service metadata, documentation, and health endpoints

* **Chores**
  * Added web crawler directives and sitemap configuration for improved search engine optimization
  * Configured HTTP response headers for API catalog and agent skills endpoints with caching policies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->