### PR TITLE
feat(customer): add support for sorting invoices by period start on this page customer invoices tab

### DIFF
--- a/src/api/InvoiceApi.ts
+++ b/src/api/InvoiceApi.ts
@@ -3,6 +3,7 @@ import { Invoice } from '@/models';
 import { generateQueryParams } from '@/utils/common/api_helper';
 import AuthService from '@/core/auth/AuthService';
 import EnvironmentApi from '@/api/EnvironmentApi';
+import { SortDirection } from '@/types/common/QueryBuilder';
 import {
 	GetInvoicesResponse,
 	InvoiceFilter,
@@ -24,7 +25,10 @@ class InvoiceApi {
 
 	/** List invoices for a single customer. Uses listInvoices with customer_id filter. */
 	public static async getCustomerInvoices(customerId: string): Promise<GetInvoicesResponse> {
-		return await this.listInvoices({ customer_id: customerId });
+		return await this.listInvoices({
+			customer_id: customerId,
+			sort: [{ field: 'period_start', direction: SortDirection.DESC }],
+		});
 	}
 
 	public static async getInvoiceById(invoiceId: string): Promise<Invoice> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice results are now automatically sorted by period start date in descending order for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->