### PR TITLE
fix(subscription): rem pause support

### DIFF
--- a/src/api/SubscriptionApi.ts
+++ b/src/api/SubscriptionApi.ts
@@ -5,10 +5,11 @@ import {
 	ListSubscriptionsResponse,
 	GetSubscriptionDetailsPayload,
 	GetSubscriptionPreviewResponse,
-	PauseSubscriptionPayload,
-	ResumeSubscriptionPayload,
-	SubscriptionPauseResponse,
-	SubscriptionResumeResponse,
+	// Pause/Resume subscription support (backend routes removed)
+	// PauseSubscriptionPayload,
+	// ResumeSubscriptionPayload,
+	// SubscriptionPauseResponse,
+	// SubscriptionResumeResponse,
 	CancelSubscriptionPayload,
 	CreateSubscriptionRequest,
 	UpdateSubscriptionRequest,
@@ -25,7 +26,8 @@ import {
 	UpdateSubscriptionLineItemRequest,
 	DeleteSubscriptionLineItemRequest,
 	SubscriptionLineItemResponse,
-	ListSubscriptionPausesResponse,
+	// Pause history support (backend routes removed)
+	// ListSubscriptionPausesResponse,
 	PreviewSubscriptionChangeRequest,
 	PreviewSubscriptionChangeResponse,
 	ExecuteSubscriptionChangeRequest,
@@ -54,7 +56,7 @@ class SubscriptionApi {
 	 * Get a subscription by ID with expand options (v2 - minimal response support)
 	 * @param id - Subscription ID
 	 * @param options - Optional parameters
-	 * @param options.expand - Comma-separated list of fields to expand (e.g., 'plan,schedule,pauses'). Pass empty string for minimal response.
+	 * @param options.expand - Comma-separated list of fields to expand (e.g., 'plan,schedule'). Pass empty string for minimal response.
 	 */
 	public static async getSubscriptionV2(id: string, options?: { expand?: string }): Promise<SubscriptionResponse> {
 		const params = new URLSearchParams();
@@ -108,20 +110,25 @@ class SubscriptionApi {
 	// =============================================================================
 	// SUBSCRIPTION STATUS METHODS
 	// =============================================================================
-
-	/**
-	 * Pause subscription
-	 */
-	public static async pauseSubscription(id: string, payload: PauseSubscriptionPayload): Promise<SubscriptionPauseResponse> {
-		return await AxiosClient.post(`${this.baseUrl}/${id}/pause`, payload);
-	}
-
-	/**
-	 * Resume subscription
-	 */
-	public static async resumeSubscription(id: string, payload: ResumeSubscriptionPayload): Promise<SubscriptionResumeResponse> {
-		return await AxiosClient.post(`${this.baseUrl}/${id}/resume`, payload);
-	}
+	//
+	// Pause/Resume support disabled:
+	// Backend routes removed:
+	// - POST /subscriptions/:id/pause
+	// - POST /subscriptions/:id/resume
+	//
+	// /**
+	//  * Pause subscription
+	//  */
+	// public static async pauseSubscription(id: string, payload: PauseSubscriptionPayload): Promise<SubscriptionPauseResponse> {
+	// 	return await AxiosClient.post(`${this.baseUrl}/${id}/pause`, payload);
+	// }
+	//
+	// /**
+	//  * Resume subscription
+	//  */
+	// public static async resumeSubscription(id: string, payload: ResumeSubscriptionPayload): Promise<SubscriptionResumeResponse> {
+	// 	return await AxiosClient.post(`${this.baseUrl}/${id}/resume`, payload);
+	// }
 
 	/**
 	 * Activate draft subscription
@@ -240,16 +247,18 @@ class SubscriptionApi {
 	}
 
 	// =============================================================================
-	// SUBSCRIPTION PAUSE METHODS
+	// SUBSCRIPTION PAUSE METHODS (disabled)
 	// =============================================================================
-
-	/**
-	 * List all pauses for a subscription
-	 * GET /subscriptions/:id/pauses
-	 */
-	public static async listPauses(subscriptionId: string): Promise<ListSubscriptionPausesResponse> {
-		return await AxiosClient.get<ListSubscriptionPausesResponse>(`${this.baseUrl}/${subscriptionId}/pauses`);
-	}
+	//
+	// Backend route removed:
+	// - GET /subscriptions/:id/pauses
+	//
+	// /**
+	//  * List all pauses for a subscription
+	//  */
+	// public static async listPauses(subscriptionId: string): Promise<ListSubscriptionPausesResponse> {
+	// 	return await AxiosClient.get<ListSubscriptionPausesResponse>(`${this.baseUrl}/${subscriptionId}/pauses`);
+	// }
 
 	// =============================================================================
 	// SUBSCRIPTION CHANGE METHODS

--- a/src/components/organisms/Subscription/SubscriptionActionButton.tsx
+++ b/src/components/organisms/Subscription/SubscriptionActionButton.tsx
@@ -6,7 +6,7 @@ import {
 	SUBSCRIPTION_STATUS,
 } from '@/models/Subscription';
 import { useMutation } from '@tanstack/react-query';
-import { CirclePause, CirclePlay, X, Plus, Pencil, Play } from 'lucide-react';
+import { X, Plus, Pencil, Play } from 'lucide-react';
 import React, { useState, useMemo } from 'react';
 import SubscriptionApi from '@/api/SubscriptionApi';
 import { DatePicker, Label, Modal, Input, Button, FormHeader, Spacer, Select, Toggle } from '@/components/atoms';
@@ -14,7 +14,6 @@ import { toast } from 'react-hot-toast';
 import DropdownMenu, { DropdownMenuOption } from '@/components/molecules/DropdownMenu/DropdownMenu';
 import { refetchQueries } from '@/core/services/tanstack/ReactQueryProvider';
 import { isInheritedSubscription } from '@/utils/subscription/isInheritedSubscription';
-import { addDays, format } from 'date-fns';
 import { useNavigate } from 'react-router';
 import { RouteNames } from '@/core/routes/Routes';
 import { ServerError } from '@/core/axios/types';
@@ -26,14 +25,14 @@ interface Props {
 const SubscriptionActionButton: React.FC<Props> = ({ subscription }) => {
 	const navigate = useNavigate();
 	const [state, setState] = useState({
-		isPauseModalOpen: false,
-		isResumeModalOpen: false,
+		// isPauseModalOpen: false,
+		// isResumeModalOpen: false,
 		isCancelModalOpen: false,
 		isAddPhaseModalOpen: false,
 		isActivateModalOpen: false,
-		pauseStartDate: new Date(),
-		pauseDays: '',
-		pauseReason: '',
+		// pauseStartDate: new Date(),
+		// pauseDays: '',
+		// pauseReason: '',
 		activateStartDate: new Date(),
 		cancelCancellationType: SUBSCRIPTION_CANCELLATION_TYPE.IMMEDIATE,
 		cancelProrationBehavior: SUBSCRIPTION_PRORATION_BEHAVIOR.NONE,
@@ -58,49 +57,47 @@ const SubscriptionActionButton: React.FC<Props> = ({ subscription }) => {
 		state.cancelGenerateInvoice
 			? SUBSCRIPTION_CANCEL_IMMEDIATELY_INVOICE_POLICY.GENERATE_INVOICE
 			: SUBSCRIPTION_CANCEL_IMMEDIATELY_INVOICE_POLICY.SKIP;
-
-	const pauseEndDate = useMemo(() => {
-		if (!state.pauseDays) return null;
-		return addDays(state.pauseStartDate, parseInt(state.pauseDays));
-	}, [state.pauseStartDate, state.pauseDays]);
-
+	// const pauseEndDate = useMemo(() => {
+	// 	if (!state.pauseDays) return null;
+	// 	return addDays(state.pauseStartDate, parseInt(state.pauseDays));
+	// }, [state.pauseStartDate, state.pauseDays]);
 	const minCancelScheduledAt = useMemo(() => new Date(), []);
 
-	const { mutate: pauseSubscription, isPending: isPauseLoading } = useMutation({
-		mutationFn: (id: string) =>
-			SubscriptionApi.pauseSubscription(id, {
-				pause_start: state.pauseStartDate.toISOString(),
-				pause_days: parseInt(state.pauseDays),
-				pause_mode: 'immediate',
-			}),
-		onSuccess: async () => {
-			setState((prev) => ({ ...prev, isPauseModalOpen: false }));
-			toast.success('Subscription paused successfully');
-			await refetchQueries(['subscriptionDetails']);
-			await refetchQueries(['subscriptions']);
-		},
-		onError: (error: ServerError) => {
-			setState((prev) => ({ ...prev, isPauseModalOpen: false }));
-			toast.error(error.error.message || 'Failed to pause subscription');
-		},
-	});
+	// const { mutate: pauseSubscription, isPending: isPauseLoading } = useMutation({
+	// 	mutationFn: (id: string) =>
+	// 		SubscriptionApi.pauseSubscription(id, {
+	// 			pause_start: state.pauseStartDate.toISOString(),
+	// 			pause_days: parseInt(state.pauseDays),
+	// 			pause_mode: 'immediate',
+	// 		}),
+	// 	onSuccess: async () => {
+	// 		setState((prev) => ({ ...prev, isPauseModalOpen: false }));
+	// 		toast.success('Subscription paused successfully');
+	// 		await refetchQueries(['subscriptionDetails']);
+	// 		await refetchQueries(['subscriptions']);
+	// 	},
+	// 	onError: (error: ServerError) => {
+	// 		setState((prev) => ({ ...prev, isPauseModalOpen: false }));
+	// 		toast.error(error.error.message || 'Failed to pause subscription');
+	// 	},
+	// });
 
-	const { mutate: resumeSubscription, isPending: isResumeLoading } = useMutation({
-		mutationFn: (id: string) =>
-			SubscriptionApi.resumeSubscription(id, {
-				resume_mode: 'immediate',
-			}),
-		onSuccess: async () => {
-			setState((prev) => ({ ...prev, isResumeModalOpen: false }));
-			toast.success('Subscription resumed successfully');
-			await refetchQueries(['subscriptionDetails']);
-			await refetchQueries(['subscriptions']);
-		},
-		onError: (err: ServerError) => {
-			setState((prev) => ({ ...prev, isResumeModalOpen: false }));
-			toast.error(err.error.message || 'Failed to resume subscription');
-		},
-	});
+	// const { mutate: resumeSubscription, isPending: isResumeLoading } = useMutation({
+	// 	mutationFn: (id: string) =>
+	// 		SubscriptionApi.resumeSubscription(id, {
+	// 			resume_mode: 'immediate',
+	// 		}),
+	// 	onSuccess: async () => {
+	// 		setState((prev) => ({ ...prev, isResumeModalOpen: false }));
+	// 		toast.success('Subscription resumed successfully');
+	// 		await refetchQueries(['subscriptionDetails']);
+	// 		await refetchQueries(['subscriptions']);
+	// 	},
+	// 	onError: (err: ServerError) => {
+	// 		setState((prev) => ({ ...prev, isResumeModalOpen: false }));
+	// 		toast.error(err.error.message || 'Failed to resume subscription');
+	// 	},
+	// });
 
 	const cancelScheduledInvalid =
 		state.cancelCancellationType === SUBSCRIPTION_CANCELLATION_TYPE.SCHEDULED_DATE && state.cancelScheduledAt === undefined;
@@ -167,14 +164,14 @@ const SubscriptionActionButton: React.FC<Props> = ({ subscription }) => {
 			onSelect: () => navigate(`${RouteNames.subscriptions}/${subscription.id}/edit`),
 			disabled: isCancelled || readOnly,
 		},
-		...(!isPaused && !isCancelled && !isDraft
+		...(!isCancelled && !isDraft
 			? [
-					{
-						label: 'Pause Subscription',
-						icon: <CirclePause className='h-4 w-4' />,
-						onSelect: () => setState((prev) => ({ ...prev, isPauseModalOpen: true })),
-						disabled: isPaused || isCancelled || readOnly,
-					},
+					// {
+					// 	label: 'Pause Subscription',
+					// 	icon: <CirclePause className='h-4 w-4' />,
+					// 	onSelect: () => setState((prev) => ({ ...prev, isPauseModalOpen: true })),
+					// 	disabled: isPaused || isCancelled || readOnly,
+					// },
 					{
 						label: 'Add Subscription Phase',
 						icon: <Plus className='h-4 w-4' />,
@@ -183,16 +180,16 @@ const SubscriptionActionButton: React.FC<Props> = ({ subscription }) => {
 					},
 				]
 			: []),
-		...(isPaused && !isCancelled
-			? [
-					{
-						label: 'Resume Subscription',
-						icon: <CirclePlay className='h-4 w-4' />,
-						onSelect: () => setState((prev) => ({ ...prev, isResumeModalOpen: true })),
-						disabled: isCancelled || readOnly,
-					},
-				]
-			: []),
+		// ...(isPaused && !isCancelled
+		// 	? [
+		// 			{
+		// 				label: 'Resume Subscription',
+		// 				icon: <CirclePlay className='h-4 w-4' />,
+		// 				onSelect: () => setState((prev) => ({ ...prev, isResumeModalOpen: true })),
+		// 				disabled: isCancelled || readOnly,
+		// 			},
+		// 		]
+		// 	: []),
 		{
 			label: 'Cancel Subscription',
 			icon: <X className='h-4 w-4' />,
@@ -205,90 +202,6 @@ const SubscriptionActionButton: React.FC<Props> = ({ subscription }) => {
 	return (
 		<>
 			<DropdownMenu options={menuOptions} />
-
-			{/* Pause Modal */}
-			<Modal
-				isOpen={state.isPauseModalOpen}
-				onOpenChange={(open) => setState((prev) => ({ ...prev, isPauseModalOpen: open }))}
-				className='bg-white rounded-lg p-6 w-[560px] max-w-[90vw]'>
-				<div className=''>
-					<FormHeader
-						title='Pause Subscription'
-						variant='sub-header'
-						subtitle='Pausing the subscription will stop the subscription from charging the customer for the selected period.'
-					/>
-					<Spacer className='!my-6' />
-					<div className='flex gap-4 w-full items-end'>
-						<DatePicker
-							label='Pause Start Date'
-							date={state.pauseStartDate}
-							setDate={(date) => setState((prev) => ({ ...prev, pauseStartDate: date || new Date() }))}
-							minDate={new Date()}
-							className='!w-full '
-						/>
-
-						<Input
-							label='Number of days'
-							value={state.pauseDays}
-							onChange={(value) => setState((prev) => ({ ...prev, pauseDays: value }))}
-							suffix='days'
-							placeholder='Enter number of days'
-							variant='integer'
-							className='!h-10'
-							labelClassName='!text-muted-foreground font-normal mb-0'
-						/>
-					</div>
-
-					{state.pauseDays && pauseEndDate && (
-						<p className='text-sm text-muted-foreground  mt-4'>
-							The subscription of <span className='text-black'>{subscription.customer?.name}</span> to{' '}
-							<span className='text-black'>{subscription.plan?.name}</span> will be paused from{' '}
-							<span className='text-black'>{format(state.pauseStartDate, 'do MMM')}</span> to{' '}
-							<span className='text-black'>{format(pauseEndDate, 'do MMM')}</span>. The subscription will resume from{' '}
-							<span className='text-black'>{format(addDays(pauseEndDate, 1), 'do MMM')}</span> and the customer will not be charged until{' '}
-							<span className='text-black'>{format(pauseEndDate, 'do MMM')}</span>.
-						</p>
-					)}
-
-					<div className='flex justify-end gap-3 pt-4'>
-						<Button
-							variant='outline'
-							onClick={() => setState((prev) => ({ ...prev, isPauseModalOpen: false }))}
-							disabled={isPauseLoading}
-							className='px-6'>
-							Cancel
-						</Button>
-						<Button onClick={() => pauseSubscription(subscription.id)} disabled={isPauseLoading || !state.pauseDays} className='px-6'>
-							{isPauseLoading ? 'Pausing...' : 'Schedule Pause'}
-						</Button>
-					</div>
-				</div>
-			</Modal>
-
-			{/* Resume Modal */}
-			<Modal
-				isOpen={state.isResumeModalOpen}
-				onOpenChange={(open) => setState((prev) => ({ ...prev, isResumeModalOpen: open }))}
-				className='bg-white rounded-lg p-6 w-[800px] max-w-[90vw]'>
-				<div className='space-y-4'>
-					<FormHeader title='Resume Subscription' variant='sub-header' />
-					<Spacer className='!my-6' />
-					<p className='text-sm text-muted-foreground  mt-4'>
-						{`Resuming the subscription will start a new billing cycle from ${format(new Date(), 'do MMM')} and generate a new invoice. Customers using advance charging will be charged immediately.`}
-					</p>
-					<div className='flex justify-end gap-3 pt-4'>
-						<Button
-							variant='outline'
-							onClick={() => setState((prev) => ({ ...prev, isResumeModalOpen: false }))}
-							disabled={isResumeLoading}>
-							Cancel
-						</Button>
-						<Button onClick={() => resumeSubscription(subscription.id)} disabled={isResumeLoading}>
-							{isResumeLoading ? 'Resuming...' : 'Yes, Resume'}
-						</Button>
-					</div>
-				</div>
-			</Modal>
 
 			{/* Cancel Modal */}
 			<Modal

--- a/src/types/dto/Subscription.ts
+++ b/src/types/dto/Subscription.ts
@@ -113,62 +113,70 @@ export interface GetSubscriptionPreviewResponse {
 	total_tax: number;
 }
 
-export interface PauseSubscriptionPayload {
-	dry_run?: boolean;
-	metadata?: Metadata;
-	pause_days?: number;
-	pause_end?: string;
-	pause_mode?: 'immediate';
-	pause_start?: string;
-	reason?: string;
-}
+// =============================================================================
+// SUBSCRIPTION PAUSE SUPPORT (disabled)
+// =============================================================================
+// Backend routes removed:
+// - POST /subscriptions/:id/pause
+// - POST /subscriptions/:id/resume
+// - GET /subscriptions/:id/pauses
 
-export interface ResumeSubscriptionPayload {
-	dry_run?: boolean;
-	metadata?: Metadata;
-	resume_mode?: 'immediate';
-}
+// export interface PauseSubscriptionPayload {
+// 	dry_run?: boolean;
+// 	metadata?: Metadata;
+// 	pause_days?: number;
+// 	pause_end?: string;
+// 	pause_mode?: 'immediate';
+// 	pause_start?: string;
+// 	reason?: string;
+// }
 
-export interface SubscriptionPauseResponse {
-	created_at: string;
-	created_by: string;
-	environment_id: string;
-	id: string;
-	metadata: Metadata;
-	original_period_end: string;
-	original_period_start: string;
-	pause_end: string;
-	pause_mode: string;
-	pause_start: string;
-	pause_status: string;
-	reason: string;
-	resume_mode: string;
-	resumed_at: string;
-	status: 'published';
-	subscription_id: string;
-	tenant_id: string;
-	updated_at: string;
-	updated_by: string;
-}
+// export interface ResumeSubscriptionPayload {
+// 	dry_run?: boolean;
+// 	metadata?: Metadata;
+// 	resume_mode?: 'immediate';
+// }
 
-// Since both responses have the same structure, we can reuse the interface
-export type SubscriptionResumeResponse = SubscriptionPauseResponse;
+// export interface SubscriptionPauseResponse {
+// 	created_at: string;
+// 	created_by: string;
+// 	environment_id: string;
+// 	id: string;
+// 	metadata: Metadata;
+// 	original_period_end: string;
+// 	original_period_start: string;
+// 	pause_end: string;
+// 	pause_mode: string;
+// 	pause_start: string;
+// 	pause_status: string;
+// 	reason: string;
+// 	resume_mode: string;
+// 	resumed_at: string;
+// 	status: 'published';
+// 	subscription_id: string;
+// 	tenant_id: string;
+// 	updated_at: string;
+// 	updated_by: string;
+// }
 
-export interface SubscriptionPause {
-	id: string;
-	subscription_id: string;
-	pause_start: string;
-	pause_end: string;
-	pause_status: string;
-	pause_mode: string;
-	created_at: string;
-	updated_at: string;
-}
+// // Since both responses have the same structure, we can reuse the interface
+// export type SubscriptionResumeResponse = SubscriptionPauseResponse;
 
-export interface ListSubscriptionPausesResponse {
-	pauses: SubscriptionPause[];
-	total: number;
-}
+// export interface SubscriptionPause {
+// 	id: string;
+// 	subscription_id: string;
+// 	pause_start: string;
+// 	pause_end: string;
+// 	pause_status: string;
+// 	pause_mode: string;
+// 	created_at: string;
+// 	updated_at: string;
+// }
+
+// export interface ListSubscriptionPausesResponse {
+// 	pauses: SubscriptionPause[];
+// 	total: number;
+// }
 
 // Subscription Change Types
 export interface PreviewSubscriptionChangeRequest {

--- a/src/types/dto/index.ts
+++ b/src/types/dto/index.ts
@@ -149,10 +149,11 @@ export type { GetAllSecretKeysResponse, CreateSecretKeyPayload, CreateSecretKeyR
 export type {
 	GetSubscriptionDetailsPayload,
 	GetSubscriptionPreviewResponse,
-	PauseSubscriptionPayload,
-	ResumeSubscriptionPayload,
-	SubscriptionPauseResponse,
-	SubscriptionResumeResponse,
+	// Pause/Resume subscription support (backend routes removed; intentionally commented out)
+	// PauseSubscriptionPayload,
+	// ResumeSubscriptionPayload,
+	// SubscriptionPauseResponse,
+	// SubscriptionResumeResponse,
 	CreateSubscriptionRequest,
 	SubscriptionInheritanceConfig,
 	UpdateSubscriptionRequest,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Subscription Management Changes**
  * Pause and resume subscription functionality has been removed from the platform. Users can no longer pause or resume their active subscriptions, and pause history information is no longer available. Subscription management is now limited to activation and cancellation options. The pause/resume menu items and related dialogs have been removed from the subscription management interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->