### PR TITLE
ci: publish app image to GHCR on tag

### DIFF
--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -1,0 +1,110 @@
+name: Publish App Image to GHCR
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to publish (e.g., v1.0.0). Required for manual runs.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/flexprice-front
+
+jobs:
+  build-and-publish:
+    name: Build, scan, publish multi-arch image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve image tag
+        id: tag
+        env:
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$DISPATCH_TAG"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          if ! echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$'; then
+            echo "::error::Invalid tag format: $TAG"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "semver=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ vars.GHCR_USERNAME || github.actor }}
+          password: ${{ secrets.GHCR_PUBLISH_TOKEN }}
+
+      - name: Build & push multi-arch image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: true
+          sbom: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.semver }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.tag.outputs.semver }}
+            org.opencontainers.image.licenses=AGPL-3.0-only
+
+      - name: Trivy vulnerability scan (fail on HIGH/CRITICAL)
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+          format: table
+          exit-code: '1'
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Summary
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: |
+          {
+            echo "## App Image Published"
+            echo ""
+            echo "- Image: \`${IMG}:${TAG}\`"
+            echo "- Platforms: linux/amd64, linux/arm64"
+            echo "- Digest: \`${DIGEST}\`"
+            echo "- SBOM + provenance: attached"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Mirrors the GHCR publish workflow from [`flexprice/flexprice`](https://github.com/flexprice/flexprice/blob/main/.github/workflows/publish-app-image.yml) into this repo so frontend container images ship the same way.
- Publishes multi-arch (`linux/amd64`, `linux/arm64`) images to `ghcr.io/<owner>/flexprice-front` on `v*` tag push or manual `workflow_dispatch`.
- Includes Trivy HIGH/CRITICAL scan gate and signed build provenance attestation (SBOM + provenance).

## Image
- Registry: `ghcr.io`
- Image: `ghcr.io/<owner>/flexprice-front`
- Tags published per run: `vX.Y.Z` and `X.Y.Z`

## Triggers
- `push` of tags matching `v*` (SemVer validated: `v1.2.3`, `v1.2.3-rc.1`, etc.)
- `workflow_dispatch` with a required `tag` input

## Requirements (repo config)
Same as the backend repo — must be configured before the first CI run:

- **Secret** `GHCR_PUBLISH_TOKEN` — classic PAT with `write:packages`, `read:packages` scopes. Default `GITHUB_TOKEN` can't push to an org GHCR package until the package is linked to the repo with Write access.
- **Variable** `GHCR_USERNAME` *(optional)* — set if the PAT owner differs from `github.actor`.
- **First push must be done locally** to create the package, then link `flexprice-front` repo to it with **Write** access at: GHCR → package → Package settings → Manage Actions access.

## Differences from `flexprice/flexprice`
- `IMAGE_NAME` is `${owner}/flexprice-front` (only change).
- Everything else — auth, build, scan, attest, summary — is identical.

## Test plan
- [ ] Add `GHCR_PUBLISH_TOKEN` secret to repo
- [ ] Locally build + push first `flexprice-front` image to GHCR to create the package
- [ ] Link package → repo with Write access in GHCR package settings
- [ ] Run workflow manually via `workflow_dispatch` with tag `v0.0.1-test` and verify:
  - [ ] Image appears at `ghcr.io/<owner>/flexprice-front:v0.0.1-test`
  - [ ] Multi-arch manifest present (amd64 + arm64)
  - [ ] Trivy scan passes
  - [ ] Provenance attestation visible on the package
- [ ] Push a real `v*` tag and confirm automatic publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Docker image publishing to GitHub Container Registry on version releases.
  * Multi-architecture image builds now support both standard and ARM-based processors.
  * Automated security vulnerability scanning is included in the publication process.
  * Build provenance is now attached to published images for enhanced transparency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice-front/pull/943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->