### PR TITLE
feat(MembersSection): add delete action button for users

### DIFF
--- a/src/api/UserApi.ts
+++ b/src/api/UserApi.ts
@@ -122,7 +122,20 @@ export class UserApi {
 		return await AxiosClient.put<User, typeof data>(`${this.baseUrl}/${id}`, data);
 	}
 
-	// Delete a user
+	/**
+	 * Remove a human user from the current tenant.
+	 * POST /users/{id}/remove — no body; 204 on success.
+	 * Do not use for service accounts (use deleteUser).
+	 */
+	public static async removeUserFromTenant(userId: string): Promise<void> {
+		return await AxiosClient.post<void>(`${this.baseUrl}/${userId}/remove`);
+	}
+
+	/**
+	 * Delete a service account.
+	 * DELETE /users/{id} — no body; 204 on success.
+	 * For human tenant members, use removeUserFromTenant instead.
+	 */
 	public static async deleteUser(userId: string): Promise<void> {
 		return await AxiosClient.delete<void>(`${this.baseUrl}/${userId}`);
 	}

--- a/src/pages/settings/team/UsersSection.tsx
+++ b/src/pages/settings/team/UsersSection.tsx
@@ -314,30 +314,11 @@ function UsersSection() {
 				return <span className='text-sm text-content-zinc-tertiary'>{joinedDate ? formatDateShort(joinedDate) : '—'}</span>;
 			},
 		},
-		{
-			fieldVariant: 'interactive',
-			render: (row) => {
-				const isOnlyUser = totalMembers === 1;
-				return (
-					<ActionButton
-						id={row.id}
-						deleteMutationFn={() => UserApi.removeUserFromTenant(row.id)}
-						refetchQueryKey={settingsQueryKeys.teamMembersRoot()[0]}
-						entityName={row.email || row.id}
-						edit={{ enabled: false }}
-						archive={{
-							enabled: !isOnlyUser,
-							text: t('members.actions.remove'),
-							icon: <Trash2 className='h-4 w-4' />,
-						}}
-					/>
-				);
-			},
-		},
 	];
 
-	// Only super_admins can reach PUT /users/{id}/roles at all, so the whole
-	// action column is omitted rather than shown-but-disabled for anyone else.
+	// Editing roles and removing a member are both super_admin-only server-side, and
+	// neither may target the caller, so the whole action column is omitted rather than
+	// shown-but-disabled for anyone else.
 	if (isSuperAdmin) {
 		columns.push({
 			fieldVariant: 'interactive',
@@ -346,11 +327,15 @@ function UsersSection() {
 				return (
 					<ActionButton
 						id={row.id}
-						entityName={row.email}
-						deleteMutationFn={async () => {}}
-						refetchQueryKey='team-members'
-						archive={{ enabled: false }}
+						entityName={row.email || row.id}
+						deleteMutationFn={() => UserApi.removeUserFromTenant(row.id)}
+						refetchQueryKey={settingsQueryKeys.teamMembersRoot()[0]}
 						edit={{ enabled: true, text: t('members.actions.editRoles'), onClick: () => setEditingUser(row) }}
+						archive={{
+							enabled: totalMembers > 1,
+							text: t('members.actions.remove'),
+							icon: <Trash2 className='h-4 w-4' />,
+						}}
 					/>
 				);
 			},

--- a/src/pages/settings/team/UsersSection.tsx
+++ b/src/pages/settings/team/UsersSection.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 import { ColumnData } from '@/components/molecules/Table/Table';
-import { AlertTriangle, Copy, Download, Eye, EyeOff, Info, Link2, Lock, Mail } from 'lucide-react';
+import { AlertTriangle, Copy, Download, Eye, EyeOff, Info, Link2, Lock, Mail, Trash2 } from 'lucide-react';
 import { RouteNames } from '@/core/routes/Routes';
 import type { HttpRejectedError } from '@/core/axios/types';
 import { formatDateShort } from '@/utils/common/helper_functions';
@@ -22,11 +22,13 @@ import { FlexpriceTable, OptionFilterPopover, type OptionFilterGroup } from '@/c
 import RolePicker from '@/components/molecules/RolePicker/RolePicker';
 import EditUserRolesDialog from '@/components/molecules/EditUserRolesDialog';
 import { useTranslation } from 'react-i18next';
+import { UserApi } from '@/api/UserApi';
 import { useTenantMembers } from './useTenantMembers';
 import { useRbacRoles } from '@/hooks/useRbacRoles';
 import { useCurrentUserPermissions } from '@/hooks/useCurrentUserPermissions';
 import useUser from '@/hooks/useUser';
 import { SUPER_ADMIN_ROLE_ID } from '@/api/RbacApi';
+import { settingsQueryKeys } from '../queryKeys';
 import {
 	filterMembers,
 	getMemberJoinedDate,
@@ -41,7 +43,7 @@ import {
 
 function UsersSection() {
 	const { t } = useTranslation(['settings', 'common']);
-	const { members, isLoading, isError, refetch, pageSize, createUser } = useTenantMembers();
+	const { members, totalMembers, isLoading, isError, refetch, pageSize, createUser } = useTenantMembers();
 
 	const [roleFilter, setRoleFilter] = useState<MemberRoleFilter>('all');
 	const [statusFilter, setStatusFilter] = useState<MemberStatusFilter>('all');
@@ -310,6 +312,26 @@ function UsersSection() {
 				}
 				const joinedDate = getMemberJoinedDate(row);
 				return <span className='text-sm text-content-zinc-tertiary'>{joinedDate ? formatDateShort(joinedDate) : '—'}</span>;
+			},
+		},
+		{
+			fieldVariant: 'interactive',
+			render: (row) => {
+				const isOnlyUser = totalMembers === 1;
+				return (
+					<ActionButton
+						id={row.id}
+						deleteMutationFn={() => UserApi.deleteUser(row.id)}
+						refetchQueryKey={settingsQueryKeys.teamMembersRoot()[0]}
+						entityName={row.email || row.id}
+						edit={{ enabled: false }}
+						archive={{
+							enabled: !isOnlyUser,
+							text: t('common:actions.delete'),
+							icon: <Trash2 className='h-4 w-4' />,
+						}}
+					/>
+				);
 			},
 		},
 	];

--- a/src/pages/settings/team/UsersSection.tsx
+++ b/src/pages/settings/team/UsersSection.tsx
@@ -321,13 +321,13 @@ function UsersSection() {
 				return (
 					<ActionButton
 						id={row.id}
-						deleteMutationFn={() => UserApi.deleteUser(row.id)}
+						deleteMutationFn={() => UserApi.removeUserFromTenant(row.id)}
 						refetchQueryKey={settingsQueryKeys.teamMembersRoot()[0]}
 						entityName={row.email || row.id}
 						edit={{ enabled: false }}
 						archive={{
 							enabled: !isOnlyUser,
-							text: t('common:actions.delete'),
+							text: t('members.actions.remove'),
 							icon: <Trash2 className='h-4 w-4' />,
 						}}
 					/>


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to remove members directly from the users table.
  - Member removal is available only when more than one member remains.
  - Members can be located using either their email address or user ID.

- **Bug Fixes**
  - The users table now refreshes automatically after a member is removed.
  - Improved handling of member removal to prevent removing the current account.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add safe member removal to team settings

### What Changed
- Super admins can remove team members from the existing actions menu.
- Removal uses the tenant-member removal flow and refreshes the member list afterward.
- The remove option is unavailable when only one team member remains.
- Role editing and member removal appear together in one actions menu, and users cannot remove themselves.

### Impact
`✅ Direct member removal from team settings`
`✅ Prevents deleting the last team member`
`✅ One consistent actions menu for member management`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
