### PR TITLE
feat(user): add support for create-edit-archive and copy ID functionality on service accounts page

### DIFF
--- a/src/api/UserApi.ts
+++ b/src/api/UserApi.ts
@@ -67,10 +67,10 @@ export class UserApi {
 	}
 
 	// Fetch service accounts only
-	public static async getServiceAccounts(): Promise<GetServiceAccountsResponse> {
+	public static async getServiceAccounts(params: { limit: number; offset: number } = { limit: 10, offset: 0 }): Promise<GetServiceAccountsResponse> {
 		const response = await AxiosClient.post<GetServiceAccountsResponse>(`${this.baseUrl}/search`, {
-			limit: 100,
-			offset: 0,
+			limit: params.limit,
+			offset: params.offset,
 			type: 'service_account',
 			sort: [
 				{

--- a/src/api/UserApi.ts
+++ b/src/api/UserApi.ts
@@ -105,6 +105,11 @@ export class UserApi {
 		return await AxiosClient.put<User, UpdateTenantPayload>(`tenants/update`, data);
 	}
 
+	// Update a service account (name, metadata)
+	public static async updateServiceAccount(id: string, data: { name?: string; metadata?: Record<string, string> }): Promise<User> {
+		return await AxiosClient.put<User, typeof data>(`${this.baseUrl}/${id}`, data);
+	}
+
 	// Delete a user
 	public static async deleteUser(userId: string): Promise<void> {
 		return await AxiosClient.delete<void>(`${this.baseUrl}/${userId}`);

--- a/src/components/atoms/ActionButton/ActionButton.tsx
+++ b/src/components/atoms/ActionButton/ActionButton.tsx
@@ -188,8 +188,13 @@ const ActionButton: FC<ActionProps> = ({
 			</div>
 
 			<Dialog
-				title={t('actionButton.confirmActionOnEntity', { action: confirmArchiveVerb, entity: entityName })}
-				titleClassName='text-lg font-normal text-gray-800 w-[90%]'
+				title={
+					<span className='text-lg font-normal text-gray-800'>
+						{t('actionButton.confirmActionOnEntityPrefix', { action: confirmArchiveVerb })}{' '}
+						<span className='font-semibold text-gray-900'>{entityName}</span>?
+					</span>
+				}
+				titleClassName='w-[90%]'
 				isOpen={isDialogOpen}
 				onOpenChange={setIsDialogOpen}
 				showCloseButton={false}>

--- a/src/components/molecules/ServiceAccountDrawer/ServiceAccountDrawer.tsx
+++ b/src/components/molecules/ServiceAccountDrawer/ServiceAccountDrawer.tsx
@@ -107,7 +107,7 @@ const ServiceAccountDrawer: FC<Props> = ({ isOpen, onOpenChange, data }) => {
 						value={name}
 						onChange={setName}
 					/>
-					<Button isLoading={isPending} disabled={isPending} onClick={() => updateServiceAccount()}>
+					<Button isLoading={isPending} disabled={isPending || !name.trim()} onClick={() => updateServiceAccount()}>
 						{t('developers:serviceAccountDrawer.saveButton')}
 					</Button>
 				</div>

--- a/src/components/molecules/ServiceAccountDrawer/ServiceAccountDrawer.tsx
+++ b/src/components/molecules/ServiceAccountDrawer/ServiceAccountDrawer.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useState, useMemo } from 'react';
-import { Sheet, Spacer, Button, Checkbox } from '@/components/atoms';
+import { Sheet, Button, Checkbox, Dialog, Input } from '@/components/atoms';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { UserApi } from '@/api/UserApi';
 import RbacApi, { RbacRole } from '@/api/RbacApi';
@@ -7,16 +7,25 @@ import { toast } from 'react-hot-toast';
 import { AlertTriangle, Info } from 'lucide-react';
 import { refetchQueries } from '@/core/services/tanstack/ReactQueryProvider';
 import { useTranslation } from 'react-i18next';
+import { User } from '@/models';
 
 interface Props {
 	isOpen: boolean;
 	onOpenChange: (value: boolean) => void;
+	/** When provided, the drawer is in edit mode */
+	data?: User | null;
 }
 
-const ServiceAccountDrawer: FC<Props> = ({ isOpen, onOpenChange }) => {
+const ServiceAccountDrawer: FC<Props> = ({ isOpen, onOpenChange, data }) => {
 	const { t } = useTranslation(['developers', 'common']);
-	const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
+	const isEditMode = !!data;
 	const queryClient = useQueryClient();
+
+	// Shared state
+	const [name, setName] = useState('');
+
+	// Create mode state
+	const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
 
 	const {
 		data: roles,
@@ -25,44 +34,36 @@ const ServiceAccountDrawer: FC<Props> = ({ isOpen, onOpenChange }) => {
 	} = useQuery<RbacRole[]>({
 		queryKey: ['rbac-roles'],
 		queryFn: () => RbacApi.getAllRoles(),
-		enabled: isOpen,
+		enabled: isOpen && !isEditMode,
 		retry: false,
 	});
 
 	const roleOptions = useMemo(() => {
-		if (!roles || !Array.isArray(roles)) {
-			return [];
-		}
-		return roles.map((role) => ({
-			label: role.name,
-			value: role.id,
-		}));
+		if (!roles || !Array.isArray(roles)) return [];
+		return roles.map((role) => ({ label: role.name, value: role.id }));
 	}, [roles]);
 
 	useEffect(() => {
 		if (isOpen) {
-			setSelectedRoles([]);
+			if (isEditMode && data) {
+				setName(data.name || '');
+			} else {
+				setName('');
+				setSelectedRoles([]);
+			}
 		}
-	}, [isOpen]);
+	}, [isOpen, data, isEditMode]);
 
 	const toggleRole = (roleValue: string) => {
-		setSelectedRoles((prev) => {
-			if (prev.includes(roleValue)) {
-				return prev.filter((r) => r !== roleValue);
-			}
-			return [...prev, roleValue];
-		});
+		setSelectedRoles((prev) =>
+			prev.includes(roleValue) ? prev.filter((r) => r !== roleValue) : [...prev, roleValue],
+		);
 	};
 
-	const { mutate: createServiceAccount, isPending } = useMutation({
-		mutationFn: async () => {
-			const payload = {
-				type: 'service_account' as const,
-				roles: selectedRoles,
-			};
-
-			return UserApi.createServiceAccount(payload);
-		},
+	// --- Create mutation ---
+	const { mutate: createServiceAccount, isPending: isCreating } = useMutation({
+		mutationFn: async () =>
+			UserApi.createServiceAccount({ type: 'service_account' as const, roles: selectedRoles, name: name.trim() || undefined }),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ['service-accounts'] });
 			refetchQueries(['secret-keys']);
@@ -74,20 +75,57 @@ const ServiceAccountDrawer: FC<Props> = ({ isOpen, onOpenChange }) => {
 		},
 	});
 
-	const isFormValid = useMemo(() => selectedRoles.length > 0, [selectedRoles]);
+	// --- Update mutation ---
+	const { mutate: updateServiceAccount, isPending: isUpdating } = useMutation({
+		mutationFn: async () =>
+			UserApi.updateServiceAccount(data!.id, { name: name.trim() || undefined }),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['service-accounts'] });
+			toast.success(t('developers:serviceAccountDrawer.updateSuccess'));
+			onOpenChange(false);
+		},
+		onError: (error: Error) => {
+			toast.error(error.message || t('developers:serviceAccountDrawer.updateFailed'));
+		},
+	});
 
+	const isCreateFormValid = selectedRoles.length > 0;
+	const isPending = isCreating || isUpdating;
+
+	// --- Edit mode: centered dialog ---
+	if (isEditMode) {
+		return (
+			<Dialog
+				isOpen={isOpen}
+				onOpenChange={onOpenChange}
+				title={t('developers:serviceAccountDrawer.editTitle')}
+				description={t('developers:serviceAccountDrawer.editDescription')}>
+				<div className='flex flex-col gap-6'>
+					<Input
+						label={t('developers:labels.name')}
+						placeholder={t('developers:serviceAccountDrawer.namePlaceholder')}
+						value={name}
+						onChange={setName}
+					/>
+					<Button isLoading={isPending} disabled={isPending} onClick={() => updateServiceAccount()}>
+						{t('developers:serviceAccountDrawer.saveButton')}
+					</Button>
+				</div>
+			</Dialog>
+		);
+	}
+
+	// --- Create mode: side sheet ---
 	return (
 		<Sheet
 			isOpen={isOpen}
 			onOpenChange={onOpenChange}
 			title={t('developers:serviceAccountDrawer.title')}
 			description={t('developers:serviceAccountDrawer.description')}>
-			<div className='space-y-4'>
-				<Spacer className='!h-4' />
-
+			<div className='flex flex-col gap-5 mt-2'>
 				<div className='bg-blue-50 border border-blue-200 rounded-md p-3'>
 					<div className='flex items-start gap-2'>
-						<Info className='w-4 h-4 text-blue-600 flex-shrink-0 mt-0.5' />
+						<Info className='w-4 h-4 text-blue-600 shrink-0 mt-0.5' />
 						<div className='text-sm text-blue-800'>
 							<p className='font-medium mb-1'>{t('developers:serviceAccountDrawer.intro.title')}</p>
 							<p>{t('developers:serviceAccountDrawer.intro.body')}</p>
@@ -95,10 +133,17 @@ const ServiceAccountDrawer: FC<Props> = ({ isOpen, onOpenChange }) => {
 					</div>
 				</div>
 
+				<Input
+					label={t('developers:labels.name')}
+					placeholder={t('developers:serviceAccountDrawer.namePlaceholder')}
+					value={name}
+					onChange={setName}
+				/>
+
 				{isRolesError ? (
 					<div className='bg-amber-50 border border-amber-200 rounded-md p-3'>
 						<div className='flex items-start gap-2'>
-							<AlertTriangle className='w-4 h-4 text-amber-500 flex-shrink-0 mt-0.5' />
+							<AlertTriangle className='w-4 h-4 text-amber-500 shrink-0 mt-0.5' />
 							<div className='text-sm text-amber-800'>
 								<p className='font-medium mb-1'>{t('developers:serviceAccountDrawer.rolesUnavailable.title')}</p>
 								<p>{t('developers:serviceAccountDrawer.rolesUnavailable.body')}</p>
@@ -106,12 +151,12 @@ const ServiceAccountDrawer: FC<Props> = ({ isOpen, onOpenChange }) => {
 						</div>
 					</div>
 				) : (
-					<div className='space-y-2'>
+					<div className='flex flex-col gap-2'>
 						<label className='block text-sm font-medium text-gray-700'>
 							{t('developers:labels.roleRequiredHint')} <span className='text-red-500'>*</span>
 						</label>
-						<p className='text-sm text-gray-500 mb-2'>{t('developers:serviceAccountDrawer.rolesHint')}</p>
-						<div className='border rounded-md p-4 space-y-3 bg-white'>
+						<p className='text-sm text-gray-500'>{t('developers:serviceAccountDrawer.rolesHint')}</p>
+						<div className='border rounded-md p-4 flex flex-col gap-3 bg-white'>
 							{isLoadingRoles ? (
 								<p className='text-sm text-gray-500'>{t('developers:serviceAccountDrawer.loadingRoles')}</p>
 							) : roleOptions.length === 0 ? (
@@ -126,7 +171,7 @@ const ServiceAccountDrawer: FC<Props> = ({ isOpen, onOpenChange }) => {
 										/>
 										<label
 											htmlFor={`role-${role.value}`}
-											className='text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer'>
+											className='text-sm font-medium leading-none cursor-pointer peer-disabled:cursor-not-allowed peer-disabled:opacity-70'>
 											{role.label}
 										</label>
 									</div>
@@ -137,7 +182,7 @@ const ServiceAccountDrawer: FC<Props> = ({ isOpen, onOpenChange }) => {
 				)}
 
 				{selectedRoles.length > 0 && (
-					<div className='space-y-2'>
+					<div className='flex flex-col gap-1.5'>
 						<label className='block text-sm font-medium text-gray-700'>{t('developers:labels.selectedRoles')}</label>
 						<div className='flex flex-wrap gap-1'>
 							{selectedRoles.map((role) => (
@@ -149,8 +194,7 @@ const ServiceAccountDrawer: FC<Props> = ({ isOpen, onOpenChange }) => {
 					</div>
 				)}
 
-				<Spacer className='!h-0' />
-				<Button isLoading={isPending} disabled={!isFormValid || isRolesError} onClick={() => createServiceAccount()}>
+				<Button isLoading={isPending} disabled={!isCreateFormValid || isRolesError} onClick={() => createServiceAccount()}>
 					{t('developers:serviceAccountDrawer.submit')}
 				</Button>
 			</div>

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -145,7 +145,8 @@
 		}
 	},
 	"actionButton": {
-		"confirmActionOnEntity": "Are you sure you want to {{action}} this {{entity}}?",
+		"confirmActionOnEntity": "Are you sure you want to {{action}} {{entity}}?",
+		"confirmActionOnEntityPrefix": "Are you sure you want to {{action}}",
 		"archiveFailed": "Could not archive {{entity}}. Please try again.",
 		"actionFailedGeneric": "Could not complete this action for {{entity}}. Please try again."
 	},

--- a/src/i18n/locales/en/developers.json
+++ b/src/i18n/locales/en/developers.json
@@ -2,6 +2,7 @@
 	"labels": {
 		"missingValue": "—",
 		"name": "Name",
+		"account": "Account",
 		"token": "Token",
 		"type": "Type",
 		"roles": "Roles",
@@ -136,7 +137,13 @@
 		"rolesHint": "Select one or more roles to define the permissions for this service account",
 		"loadingRoles": "Loading roles...",
 		"noRolesAvailable": "No roles available",
-		"submit": "Create Service Account"
+		"submit": "Create Service Account",
+		"editTitle": "Edit Service Account",
+		"editDescription": "Update the name for this service account.",
+		"namePlaceholder": "e.g. Event Ingestor Service",
+		"saveButton": "Save Changes",
+		"updateSuccess": "Service account updated successfully",
+		"updateFailed": "Failed to update service account"
 	},
 	"webhooks": {
 		"toastFetchError": "Error fetching webhook dashboard: {{message}}",

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -21,4 +21,5 @@ export interface User {
 	name?: string;
 	type?: 'user' | 'service_account';
 	roles?: string[];
+	metadata?: Record<string, string>;
 }

--- a/src/pages/developer/ServiceAccounts.tsx
+++ b/src/pages/developer/ServiceAccounts.tsx
@@ -15,7 +15,7 @@ import { useTranslation } from 'react-i18next';
 
 const ServiceAccountsPage = () => {
 	const { t } = useTranslation(['developers', 'common']);
-	const { page } = usePagination();
+	const { page, limit, offset } = usePagination();
 	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 	const [selectedAccount, setSelectedAccount] = useState<User | null>(null);
 
@@ -25,7 +25,7 @@ const ServiceAccountsPage = () => {
 		isError: isServiceAccountsError,
 	} = useQuery({
 		queryKey: ['service-accounts', page],
-		queryFn: async () => UserApi.getServiceAccounts(),
+		queryFn: async () => UserApi.getServiceAccounts({ limit, offset }),
 	});
 
 	const handleAdd = () => {
@@ -53,7 +53,7 @@ const ServiceAccountsPage = () => {
 							) : (
 								<code className='px-2 py-0.5 text-sm bg-gray-100 rounded font-mono text-gray-500'>{maskedId}</code>
 							)}
-							<span className='opacity-0 group-hover:opacity-100 transition-opacity'>
+							<span className='opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity'>
 								<CopyIdButton id={row.id} entityType='Service Account' />
 							</span>
 						</div>

--- a/src/pages/developer/ServiceAccounts.tsx
+++ b/src/pages/developer/ServiceAccounts.tsx
@@ -1,4 +1,4 @@
-import { Button, Page, ShortPagination, SectionHeader } from '@/components/atoms';
+import { Button, Page, ShortPagination, SectionHeader, ActionButton, CopyIdButton } from '@/components/atoms';
 import { ColumnData, FlexpriceTable, ApiDocsContent } from '@/components/molecules';
 import { UserApi } from '@/api/UserApi';
 import { useQuery } from '@tanstack/react-query';
@@ -6,7 +6,7 @@ import { User } from '@/models';
 import usePagination from '@/hooks/usePagination';
 import { formatDateShort } from '@/utils/common/helper_functions';
 import { Plus, Loader, Bot } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { toast } from 'react-hot-toast';
 import { EmptyPage } from '@/components/organisms';
 import { API_DOCS_TAGS } from '@/constants/apiDocsTags';
@@ -16,7 +16,8 @@ import { useTranslation } from 'react-i18next';
 const ServiceAccountsPage = () => {
 	const { t } = useTranslation(['developers', 'common']);
 	const { page } = usePagination();
-	const [isServiceAccountDrawerOpen, setIsServiceAccountDrawerOpen] = useState(false);
+	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+	const [selectedAccount, setSelectedAccount] = useState<User | null>(null);
 
 	const {
 		data: serviceAccountsResponse,
@@ -24,28 +25,37 @@ const ServiceAccountsPage = () => {
 		isError: isServiceAccountsError,
 	} = useQuery({
 		queryKey: ['service-accounts', page],
-		queryFn: async () => {
-			return await UserApi.getServiceAccounts();
-		},
+		queryFn: async () => UserApi.getServiceAccounts(),
 	});
 
-	const handleAddServiceAccount = () => {
-		setIsServiceAccountDrawerOpen(true);
+	const handleAdd = () => {
+		setSelectedAccount(null);
+		setIsDrawerOpen(true);
 	};
+
+	const handleEdit = useCallback((account: User) => {
+		setSelectedAccount(account);
+		setIsDrawerOpen(true);
+	}, []);
 
 	const serviceAccountColumns: ColumnData<User>[] = useMemo(
 		() => [
 			{
-				title: t('labels.id'),
-				render: (rowData: User) => {
-					const displayId = rowData.id;
-					const prefix = displayId.slice(0, 8);
-					const suffix = displayId.slice(-4);
-					const masked = `${prefix}••••${suffix}`;
+				title: t('labels.account'),
+				render: (row: User) => {
+					const displayName = row.name || null;
+					const maskedId = `${row.id.slice(0, 8)}••••${row.id.slice(-4)}`;
 
 					return (
-						<div className='flex gap-2 items-center'>
-							<code className='px-2 py-1 text-sm bg-gray-100 rounded font-mono'>{masked}</code>
+						<div className='flex items-center gap-1.5 group'>
+							{displayName ? (
+								<span className='text-sm font-medium text-gray-800'>{displayName}</span>
+							) : (
+								<code className='px-2 py-0.5 text-sm bg-gray-100 rounded font-mono text-gray-500'>{maskedId}</code>
+							)}
+							<span className='opacity-0 group-hover:opacity-100 transition-opacity'>
+								<CopyIdButton id={row.id} entityType='Service Account' />
+							</span>
 						</div>
 					);
 				},
@@ -53,24 +63,21 @@ const ServiceAccountsPage = () => {
 			{
 				title: t('labels.type'),
 				render: () => (
-					<div className='flex gap-2 items-center'>
-						<div className='flex items-center gap-1.5 text-purple-600'>
-							<Bot size={16} />
-							<span className='text-sm font-medium'>{t('apiKeys.accountTypes.serviceAccount')}</span>
-						</div>
+					<div className='flex items-center gap-1.5 text-purple-600'>
+						<Bot size={16} />
+						<span className='text-sm font-medium'>{t('apiKeys.accountTypes.serviceAccount')}</span>
 					</div>
 				),
 			},
 			{
 				title: t('labels.roles'),
-				render: (rowData: User) => {
-					if (!rowData.roles || rowData.roles.length === 0) {
+				render: (row: User) => {
+					if (!row.roles || row.roles.length === 0) {
 						return <span className='text-gray-500 text-sm'>{t('serviceAccounts.noRoles')}</span>;
 					}
-
 					return (
 						<div className='flex flex-wrap gap-1'>
-							{rowData.roles.map((role) => (
+							{row.roles.map((role) => (
 								<span key={role} className='inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800'>
 									{role}
 								</span>
@@ -83,12 +90,30 @@ const ServiceAccountsPage = () => {
 				title: t('labels.createdAt'),
 				width: 150,
 				align: 'right',
-				render: (rowData) => (
-					<span className='text-gray-600'>{formatDateShort(rowData.tenant?.created_at || rowData.tenant?.updated_at || '')}</span>
+				render: (row) => (
+					<span className='text-gray-600'>{formatDateShort(row.tenant?.created_at || row.tenant?.updated_at || '')}</span>
+				),
+			},
+			{
+				fieldVariant: 'interactive',
+				render: (row: User) => (
+					<ActionButton
+						id={row.id}
+						entityName={row.name || row.id}
+						deleteMutationFn={async () => UserApi.deleteUser(row.id)}
+						refetchQueryKey='service-accounts'
+						edit={{
+							enabled: true,
+							onClick: () => handleEdit(row),
+						}}
+						archive={{
+							enabled: true,
+						}}
+					/>
 				),
 			},
 		],
-		[t],
+		[t, handleEdit],
 	);
 
 	if (isLoadingServiceAccounts) {
@@ -102,17 +127,21 @@ const ServiceAccountsPage = () => {
 	return (
 		<div>
 			<ApiDocsContent tags={API_DOCS_TAGS.Users} />
-			<ServiceAccountDrawer isOpen={isServiceAccountDrawerOpen} onOpenChange={setIsServiceAccountDrawerOpen} />
+			<ServiceAccountDrawer
+				isOpen={isDrawerOpen}
+				onOpenChange={setIsDrawerOpen}
+				data={selectedAccount}
+			/>
 
 			{serviceAccountsResponse?.items.length === 0 && (
 				<EmptyPage
 					heading={t('common:nav.serviceAccounts')}
-					onAddClick={handleAddServiceAccount}
+					onAddClick={handleAdd}
 					emptyStateCard={{
 						heading: t('serviceAccounts.emptyCard.heading'),
 						description: t('serviceAccounts.emptyCard.description'),
 						buttonLabel: t('serviceAccounts.emptyCard.button'),
-						buttonAction: handleAddServiceAccount,
+						buttonAction: handleAdd,
 					}}
 					tags={API_DOCS_TAGS.Users}
 				/>
@@ -120,7 +149,7 @@ const ServiceAccountsPage = () => {
 			{(serviceAccountsResponse?.items.length || 0) > 0 && (
 				<Page>
 					<SectionHeader title={t('common:nav.serviceAccounts')} titleClassName='text-3xl font-medium'>
-						<Button prefixIcon={<Plus />} onClick={handleAddServiceAccount}>
+						<Button prefixIcon={<Plus />} onClick={handleAdd}>
 							{t('common:actions.add')}
 						</Button>
 					</SectionHeader>

--- a/src/types/dto/UserApi.ts
+++ b/src/types/dto/UserApi.ts
@@ -12,6 +12,7 @@ export interface GetServiceAccountsResponse {
 export interface CreateServiceAccountPayload {
 	type: 'service_account';
 	roles: string[];
+	name?: string;
 }
 
 /** Request for POST /users - add user to tenant. Backend returns one-time password. */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service accounts can now be edited after creation, with customizable names and metadata.
  * Service account creation now supports optional custom naming.
  * Account details display improvements, including name visibility and quick ID copy functionality.

* **Chores**
  * Updated and added translation strings for service account management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->