### PR TITLE
feat(auth): add support for local auth provider

### DIFF
--- a/src/i18n/locales/ar/auth.json
+++ b/src/i18n/locales/ar/auth.json
@@ -85,5 +85,9 @@
 		"completingDescription": "يرجى الانتظار بينما نقوم بإعداد حسابك",
 		"processingHeading": "جارٍ معالجة معلوماتك...",
 		"processingDescription": "سيتم توجيهك قريباً"
+	},
+	"flexpriceAuth": {
+		"passwordResetUnavailable": "إعادة تعيين كلمة المرور غير متاحة في هذه البيئة. يرجى التواصل مع المسؤول لإعادة تعيين كلمة المرور.",
+		"emailVerificationUnavailable": "التحقق من البريد الإلكتروني غير مستخدم في هذه البيئة."
 	}
 }

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -85,5 +85,9 @@
 		"completingDescription": "Please wait while we set up your account",
 		"processingHeading": "Processing your information...",
 		"processingDescription": "You'll be redirected shortly"
+	},
+	"flexpriceAuth": {
+		"passwordResetUnavailable": "Password reset is not available in this environment. Please contact your administrator to reset your password.",
+		"emailVerificationUnavailable": "Email verification is not used in this environment."
 	}
 }

--- a/src/pages/auth/EmailVerification.tsx
+++ b/src/pages/auth/EmailVerification.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useLocation } from 'react-router';
+import { useNavigate, useLocation, Navigate } from 'react-router';
 import { Button } from '@/components/atoms';
 import { useMutation } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
@@ -6,13 +6,15 @@ import supabase from '@/core/services/supbase/config';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { useTranslation } from 'react-i18next';
 import { useBrand } from '@/config/branding';
-import { config } from '@/config/config';
+import { config, AUTH_PROVIDER } from '@/config/config';
+import { RouteNames } from '@/core/routes/Routes';
 
 const EmailVerification = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const { t } = useTranslation('auth');
 	const { logo, name } = useBrand();
+	const isFlexpriceAuth = config.auth.provider === AUTH_PROVIDER.Flexprice;
 
 	const searchParams = new URLSearchParams(location.search);
 	const email = searchParams.get('email') || '';
@@ -47,6 +49,10 @@ const EmailVerification = () => {
 	const handleGoToLogin = () => {
 		navigate('/auth');
 	};
+
+	if (isFlexpriceAuth) {
+		return <Navigate to={RouteNames.auth} replace />;
+	}
 
 	return (
 		<div

--- a/src/pages/auth/ForgotPasswordForm.tsx
+++ b/src/pages/auth/ForgotPasswordForm.tsx
@@ -5,6 +5,7 @@ import supabase from '@/core/services/supbase/config';
 import { useMutation } from '@tanstack/react-query';
 import { AuthTab } from './authTabs';
 import { useTranslation } from 'react-i18next';
+import { config, AUTH_PROVIDER } from '@/config/config';
 
 interface ForgotPasswordFormProps {
 	switchTab: (tab: AuthTab) => void;
@@ -13,8 +14,8 @@ interface ForgotPasswordFormProps {
 const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({ switchTab }) => {
 	const { t } = useTranslation('auth');
 	const [email, setEmail] = useState('');
+	const isFlexpriceAuth = config.auth.provider === AUTH_PROVIDER.Flexprice;
 
-	// Use React Query for forgot password mutation
 	const forgotPasswordMutation = useMutation({
 		mutationFn: async (emailToReset: string): Promise<any> => {
 			const redirectTo = `${window.location.origin}/auth?tab=${AuthTab.RESET_PASSWORD}`;
@@ -44,6 +45,22 @@ const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({ switchTab }) =>
 
 		forgotPasswordMutation.mutate(email);
 	};
+
+	if (isFlexpriceAuth) {
+		return (
+			<>
+				<div className='rounded-xl border border-gray-200/80 bg-gray-50/50 p-6 text-center shadow-sm'>
+					<p className='text-sm text-gray-600'>{t('flexpriceAuth.passwordResetUnavailable')}</p>
+				</div>
+				<p className='mt-6 text-center text-sm text-gray-600'>
+					{t('rememberPassword')}{' '}
+					<button onClick={() => switchTab(AuthTab.LOGIN)} className='text-grey-600 underline font-medium'>
+						{t('links.backToLogin')}
+					</button>
+				</p>
+			</>
+		);
+	}
 
 	return (
 		<>

--- a/src/pages/auth/ResendVerification.tsx
+++ b/src/pages/auth/ResendVerification.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate, useLocation } from 'react-router';
+import { useNavigate, useLocation, Navigate } from 'react-router';
 import Button from '@/components/atoms/Button/Button';
 import Input from '@/components/atoms/Input/Input';
 import { useMutation } from '@tanstack/react-query';
@@ -7,6 +7,8 @@ import toast from 'react-hot-toast';
 import supabase from '@/core/services/supbase/config';
 import { useTranslation } from 'react-i18next';
 import { useBrand } from '@/config/branding';
+import { config, AUTH_PROVIDER } from '@/config/config';
+import { RouteNames } from '@/core/routes/Routes';
 
 const ResendVerification = () => {
 	const [email, setEmail] = useState('');
@@ -14,10 +16,9 @@ const ResendVerification = () => {
 	const location = useLocation();
 	const { t } = useTranslation('auth');
 	const { logo, name } = useBrand();
-
+	const isFlexpriceAuth = config.auth.provider === AUTH_PROVIDER.Flexprice;
 	const isNewSignup = location.search.includes('new=true');
 	const userEmail = new URLSearchParams(location.search).get('email') || '';
-
 	const [resendSuccess, setResendSuccess] = useState(false);
 
 	const { mutate: resendVerification, isPending } = useMutation({
@@ -47,6 +48,10 @@ const ResendVerification = () => {
 	const handleGoToLogin = () => {
 		navigate('/auth');
 	};
+
+	if (isFlexpriceAuth) {
+		return <Navigate to={RouteNames.auth} replace />;
+	}
 
 	if (isNewSignup || resendSuccess) {
 		return (

--- a/src/pages/auth/ResetPasswordForm.tsx
+++ b/src/pages/auth/ResetPasswordForm.tsx
@@ -6,6 +6,7 @@ import supabase from '@/core/services/supbase/config';
 import { useMutation } from '@tanstack/react-query';
 import { AuthTab } from './authTabs';
 import { useTranslation } from 'react-i18next';
+import { config, AUTH_PROVIDER } from '@/config/config';
 
 interface ResetPasswordFormProps {
 	switchTab: (tab: AuthTab) => void;
@@ -19,8 +20,14 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ switchTab }) => {
 	const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 	const [sessionReady, setSessionReady] = useState(false);
 	const [hasSession, setHasSession] = useState(false);
+	const isFlexpriceAuth = config.auth.provider === AUTH_PROVIDER.Flexprice;
 
 	useEffect(() => {
+		if (isFlexpriceAuth) {
+			setSessionReady(true);
+			return;
+		}
+
 		const checkSession = async () => {
 			const {
 				data: { session },
@@ -32,7 +39,7 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ switchTab }) => {
 			setSessionReady(true);
 		};
 		checkSession();
-	}, []);
+	}, [isFlexpriceAuth]);
 
 	const updatePasswordMutation = useMutation({
 		mutationFn: async (newPassword: string): Promise<void> => {
@@ -60,6 +67,22 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ switchTab }) => {
 		}
 		updatePasswordMutation.mutate(password);
 	};
+
+	if (isFlexpriceAuth) {
+		return (
+			<>
+				<div className='rounded-xl border border-gray-200/80 bg-gray-50/50 p-6 text-center shadow-sm'>
+					<p className='text-sm text-gray-600'>{t('flexpriceAuth.passwordResetUnavailable')}</p>
+				</div>
+				<p className='mt-6 text-center text-sm text-gray-600'>
+					{t('rememberPassword')}{' '}
+					<button onClick={() => switchTab(AuthTab.LOGIN)} className='text-grey-600 underline font-medium hover:no-underline'>
+						{t('links.backToLogin')}
+					</button>
+				</p>
+			</>
+		);
+	}
 
 	if (!sessionReady) {
 		return (

--- a/src/pages/auth/SignupConfirmation.tsx
+++ b/src/pages/auth/SignupConfirmation.tsx
@@ -4,13 +4,16 @@ import AuthApi from '@/api/AuthApi';
 import { useMutation } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import toast from 'react-hot-toast';
-import { useNavigate } from 'react-router';
+import { useNavigate, Navigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
+import { config, AUTH_PROVIDER } from '@/config/config';
+import { RouteNames } from '@/core/routes/Routes';
 
 const SignupConfirmation = () => {
 	const userContext = useUser();
 	const navigate = useNavigate();
 	const { t } = useTranslation('auth');
+	const isFlexpriceAuth = config.auth.provider === AUTH_PROVIDER.Flexprice;
 
 	const { mutate, isPending } = useMutation({
 		mutationFn: async () => {
@@ -60,8 +63,15 @@ const SignupConfirmation = () => {
 	};
 
 	useEffect(() => {
+		if (isFlexpriceAuth) {
+			return;
+		}
 		handleSubmit();
-	}, []);
+	}, [isFlexpriceAuth]);
+
+	if (isFlexpriceAuth) {
+		return <Navigate to={RouteNames.home} replace />;
+	}
 
 	return (
 		<div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Internationalization**
  * Added localized messages (Arabic and English) for password reset and email verification unavailability.

* **Authentication Updates**
  * When the Flexprice auth provider is configured, password reset and email verification are hidden and replaced with unavailable notices.
  * Auth pages now show the unavailable messaging and redirect or navigate appropriately for the Flexprice provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->