### PR TITLE
fix(commitment): time buckets in price override instead of new line i…

### DIFF
--- a/src/pages/customer/customers/CreateCustomerSubscriptionPage.tsx
+++ b/src/pages/customer/customers/CreateCustomerSubscriptionPage.tsx
@@ -45,11 +45,7 @@ import type { AddedSubscriptionLineItem } from '@/components/organisms/Subscript
 import { cn } from '@/lib/utils';
 import { toSentenceCase } from '@/utils/common/helper_functions';
 import { ExtendedPriceOverride, getLineItemOverrides } from '@/utils/common/price_override_helpers';
-import {
-	extractLineItemCommitments,
-	buildCommitmentTimeBucketLineItems,
-	mergeCreateSubscriptionLineItems,
-} from '@/utils/common/commitment_helpers';
+import { extractLineItemCommitments } from '@/utils/common/commitment_helpers';
 import { extractSubscriptionBoundaries, extractFirstPhaseData } from '@/utils/subscription/phaseConversion';
 
 import { useBreadcrumbsStore } from '@/store/useBreadcrumbsStore';
@@ -550,7 +546,6 @@ const CreateCustomerSubscriptionPage: React.FC = () => {
 		let finalLineItemCoupons: Record<string, string[]> | undefined;
 		let finalOverrideLineItems: OverrideLineItemRequest[] | undefined;
 		let finalLineItemCommitments: Record<string, any> | undefined;
-		let finalCommitmentTimeBucketLineItems: ReturnType<typeof buildCommitmentTimeBucketLineItems> | undefined;
 		let sanitizedPhases: SubscriptionPhaseCreateRequest[] | undefined;
 
 		if (phases.length > 0) {
@@ -566,7 +561,6 @@ const CreateCustomerSubscriptionPage: React.FC = () => {
 
 			// Commitments are subscription-level only; phases do not have line_item_commitments per backend
 			finalLineItemCommitments = undefined;
-			finalCommitmentTimeBucketLineItems = undefined;
 
 			// Sanitize phases (quantity exclusion for USAGE prices handled in PhaseList conversion)
 			sanitizedPhases = phases.map((phase) => ({
@@ -590,10 +584,9 @@ const CreateCustomerSubscriptionPage: React.FC = () => {
 			// Note: getLineItemOverrides automatically excludes quantity for USAGE type prices
 			finalOverrideLineItems = getLineItemOverrides(currentPrices, priceOverrides);
 
-			// Extract line item commitments from price overrides
+			// Extract line item commitments from price overrides (time buckets are folded in)
 			const commitments = extractLineItemCommitments(priceOverrides);
 			finalLineItemCommitments = Object.keys(commitments).length > 0 ? commitments : undefined;
-			finalCommitmentTimeBucketLineItems = buildCommitmentTimeBucketLineItems(priceOverrides);
 
 			finalCoupons = linkedCoupon ? [linkedCoupon.id] : undefined;
 			finalLineItemCoupons =
@@ -653,7 +646,6 @@ const CreateCustomerSubscriptionPage: React.FC = () => {
 			finalLineItemCoupons,
 			finalOverrideLineItems,
 			finalLineItemCommitments,
-			finalCommitmentTimeBucketLineItems,
 			sanitizedPhases,
 			tax_rate_overrides,
 			overageFactor,
@@ -757,8 +749,7 @@ const CreateCustomerSubscriptionPage: React.FC = () => {
 			line_items: (() => {
 				if (sanitized.sanitizedPhases) return undefined;
 				const addedItems = sanitized.addedSubscriptionLineItems?.map(({ tempId: _tempId, ...req }) => req) ?? [];
-				const merged = mergeCreateSubscriptionLineItems(addedItems, sanitized.finalCommitmentTimeBucketLineItems ?? []);
-				return merged.length > 0 ? merged : undefined;
+				return addedItems.length > 0 ? addedItems : undefined;
 			})(),
 			inheritance: Object.keys(inheritancePayload).length > 0 ? inheritancePayload : undefined,
 			...(sanitized.trial_period_days !== undefined ? { trial_period_days: sanitized.trial_period_days } : {}),

--- a/src/types/dto/LineItemCommitmentConfig.ts
+++ b/src/types/dto/LineItemCommitmentConfig.ts
@@ -1,4 +1,5 @@
 import { BILLING_PERIOD } from '@/constants/constants';
+import type { CommitmentTimeBucket } from './CommitmentTimeBucket';
 
 export enum CommitmentType {
 	AMOUNT = 'amount',
@@ -27,6 +28,10 @@ export interface LineItemCommitmentConfig {
 	// CommitmentDuration specifies the duration period for the commitment (e.g., ANNUAL, MONTHLY)
 	// If not set, defaults to the subscription's billing period
 	commitment_duration?: BILLING_PERIOD;
+
+	// CommitmentTimeBuckets restricts commitment application to specific UTC time-of-day windows.
+	// Requires is_window_commitment=true.
+	commitment_time_buckets?: CommitmentTimeBucket[];
 }
 
 export type LineItemCommitmentsMap = Record<string, LineItemCommitmentConfig>;

--- a/src/utils/common/commitment_helpers.ts
+++ b/src/utils/common/commitment_helpers.ts
@@ -2,8 +2,6 @@ import { BUCKET_SIZE } from '@/models/Meter';
 import { Price } from '@/models/Price';
 import { CommitmentType, LineItemCommitmentConfig, LineItemCommitmentsMap } from '@/types/dto/LineItemCommitmentConfig';
 import type { CommitmentTimeBucket } from '@/types/dto/CommitmentTimeBucket';
-import type { CreateSubscriptionLineItemRequest } from '@/types/dto/Subscription';
-import type { ExtendedPriceOverride } from './price_override_helpers';
 
 /**
  * Check if a price has commitment configured
@@ -176,53 +174,26 @@ export const validateCommitmentTimeBuckets = (buckets: CommitmentTimeBucket[]): 
 };
 
 /**
- * Build inline line_items entries for commitment_time_buckets (not supported on line_item_commitments map).
- */
-export const buildCommitmentTimeBucketLineItems = (
-	priceOverrides: Record<string, ExtendedPriceOverride>,
-): CreateSubscriptionLineItemRequest[] =>
-	Object.entries(priceOverrides)
-		.filter(([, override]) => override.commitment_time_buckets && override.commitment_time_buckets.length > 0)
-		.map(([priceId, override]) => ({
-			price_id: priceId,
-			commitment_windowed: override.commitment?.is_window_commitment ?? true,
-			commitment_time_buckets: override.commitment_time_buckets,
-		}));
-
-/** Merge manually added line items with time-bucket line items, keyed by price_id. */
-export const mergeCreateSubscriptionLineItems = (
-	addedItems: CreateSubscriptionLineItemRequest[],
-	timeBucketItems: CreateSubscriptionLineItemRequest[],
-): CreateSubscriptionLineItemRequest[] => {
-	const merged = [...addedItems];
-	for (const timeBucketItem of timeBucketItems) {
-		if (!timeBucketItem.price_id) {
-			merged.push(timeBucketItem);
-			continue;
-		}
-		const existingIndex = merged.findIndex((item) => item.price_id === timeBucketItem.price_id);
-		if (existingIndex >= 0) {
-			merged[existingIndex] = { ...merged[existingIndex], ...timeBucketItem };
-		} else {
-			merged.push(timeBucketItem);
-		}
-	}
-	return merged;
-};
-
-/**
  * Extract line item commitments from price overrides
- * Converts the frontend ExtendedPriceOverride format to backend LineItemCommitmentsMap
+ * Converts the frontend ExtendedPriceOverride format to backend LineItemCommitmentsMap.
+ * Commitment time buckets are stored on the override at the top level for UI ergonomics; we
+ * fold them into the commitment config here so the whole config rides on line_item_commitments
+ * (avoiding a duplicate line_items[] entry on the backend).
  */
 export const extractLineItemCommitments = (
-	priceOverrides: Record<string, { commitment?: LineItemCommitmentConfig }>,
+	priceOverrides: Record<string, { commitment?: LineItemCommitmentConfig; commitment_time_buckets?: CommitmentTimeBucket[] }>,
 ): LineItemCommitmentsMap => {
 	const commitments: LineItemCommitmentsMap = {};
 
 	Object.entries(priceOverrides).forEach(([priceId, override]) => {
-		if (override.commitment) {
-			commitments[priceId] = override.commitment;
+		const hasBuckets = override.commitment_time_buckets && override.commitment_time_buckets.length > 0;
+		if (!override.commitment && !hasBuckets) {
+			return;
 		}
+		commitments[priceId] = {
+			...(override.commitment ?? {}),
+			...(hasBuckets ? { commitment_time_buckets: override.commitment_time_buckets } : {}),
+		};
 	});
 
 	return commitments;


### PR DESCRIPTION
…tems

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for restricting commitment application to specific UTC time-of-day windows during subscription creation.

* **Refactor**
  * Simplified internal subscription payload construction and commitment data handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->