### PR TITLE
fix(customers): correct empty state description on customers page

### DIFF
--- a/src/i18n/locales/en/customers.json
+++ b/src/i18n/locales/en/customers.json
@@ -5,7 +5,7 @@
 		"entityName": "Customer",
 		"openPortal": "Open Customer Portal",
 		"emptyHeading": "Customers",
-		"emptyDescription": "Create a plan to display pricing and start billing customers.",
+		"emptyDescription": "Add your first customer to start managing subscriptions and billing.",
 		"createCustomer": "Create Customer",
 		"columns": {
 			"name": "Name",


### PR DESCRIPTION
## Summary

This PR fixes the incorrect empty state description shown on the Customers page.

## Changes Made

* Updated the customer empty state description in `customers.json`
* Replaced the plans-related message with customer-specific copy

## Root Cause

The Customers page uses:

`t('list.emptyDescription')`

which points to the customer translation file. The existing translation contained plans-related copy, causing incorrect text to appear in the Customers empty state.

## Before

Create a plan to display pricing and start billing customers.

## After

Add your first customer to start managing subscriptions and billing.

Fixes #897

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the empty state message in the customers list to provide clearer guidance for new users getting started with subscriptions and billing management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->