### PR TITLE
Added storybook for atoms and some molecules

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,7 +1,29 @@
 import 'tailwindcss/tailwind.css';
+import React from 'react';
 import type { Preview } from '@storybook/react';
+import { createInstance } from 'i18next';
+import { initReactI18next, I18nextProvider } from 'react-i18next';
+import commonEn from '../src/i18n/locales/en/common.json';
+
+const storybookI18n = createInstance();
+storybookI18n.use(initReactI18next).init({
+	lng: 'en',
+	fallbackLng: 'en',
+	defaultNS: 'common',
+	ns: ['common'],
+	resources: {
+		en: {
+			common: commonEn,
+		},
+	},
+	interpolation: {
+		escapeValue: false,
+	},
+	initImmediate: false,
+});
 
 const preview: Preview = {
+	decorators: [(Story) => React.createElement(I18nextProvider, { i18n: storybookI18n }, React.createElement(Story))],
 	parameters: {
 		controls: {
 			matchers: {

--- a/src/components/atoms/Button/Button.stories.tsx
+++ b/src/components/atoms/Button/Button.stories.tsx
@@ -1,0 +1,65 @@
+/* eslint-disable i18next/no-literal-string */
+import type { Meta, StoryObj } from '@storybook/react';
+import { Plus } from 'lucide-react';
+import { fn } from '@storybook/test';
+import Button from './Button';
+import { AddButton } from '.';
+
+const meta: Meta<typeof Button> = {
+	title: 'Atoms/Button',
+	component: Button,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+	args: {
+		onClick: fn(),
+		children: 'Button',
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+	args: {
+		variant: 'default',
+		children: 'Primary',
+	},
+};
+
+export const Secondary: Story = {
+	args: {
+		variant: 'secondary',
+		children: 'Secondary',
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		variant: 'outline',
+		children: 'Disabled',
+		disabled: true,
+	},
+};
+
+export const Loading: Story = {
+	args: {
+		variant: 'default',
+		children: 'Loading',
+		isLoading: true,
+	},
+};
+
+export const WithIcons: Story = {
+	args: {
+		variant: 'outline',
+		children: 'Add item',
+		prefixIcon: <Plus />,
+		suffixIcon: <Plus className='rotate-45' />,
+	},
+};
+
+export const AddAction: Story = {
+	render: () => <AddButton label='Add plan' onClick={fn()} />,
+};

--- a/src/components/atoms/Checkbox/Checkbox.stories.tsx
+++ b/src/components/atoms/Checkbox/Checkbox.stories.tsx
@@ -45,5 +45,6 @@ export const Disabled: Story = {
 		label: 'Disabled option',
 		description: 'This option is unavailable.',
 		checked: true,
+		disabled: true,
 	},
 };

--- a/src/components/atoms/Checkbox/Checkbox.stories.tsx
+++ b/src/components/atoms/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import Checkbox from './Checkbox';
+
+const meta: Meta<typeof Checkbox> = {
+	title: 'Atoms/Checkbox',
+	component: Checkbox,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const CheckboxWithState = (args: Story['args']) => {
+	const [checked, setChecked] = useState(Boolean(args?.checked));
+
+	return <Checkbox {...args} checked={checked} onCheckedChange={setChecked} />;
+};
+
+export const Unchecked: Story = {
+	render: (args) => <CheckboxWithState {...args} />,
+	args: {
+		id: 'checkbox-unchecked',
+		label: 'Enable notifications',
+		description: 'Receive updates about billing and usage.',
+	},
+};
+
+export const Checked: Story = {
+	render: (args) => <CheckboxWithState {...args} />,
+	args: {
+		id: 'checkbox-checked',
+		label: 'Enable notifications',
+		description: 'Receive updates about billing and usage.',
+		checked: true,
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		id: 'checkbox-disabled',
+		label: 'Disabled option',
+		description: 'This option is unavailable.',
+		checked: true,
+	},
+};

--- a/src/components/atoms/Chip/Chip.stories.tsx
+++ b/src/components/atoms/Chip/Chip.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import Chip from './Chip';
+
+const meta: Meta<typeof Chip> = {
+	title: 'Atoms/Chip',
+	component: Chip,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		label: 'Default',
+	},
+};
+
+export const Success: Story = {
+	args: {
+		label: 'Success',
+		variant: 'success',
+	},
+};
+
+export const Warning: Story = {
+	args: {
+		label: 'Warning',
+		variant: 'warning',
+	},
+};
+
+export const Failed: Story = {
+	args: {
+		label: 'Failed',
+		variant: 'failed',
+	},
+};
+
+export const Info: Story = {
+	args: {
+		label: 'Info',
+		variant: 'info',
+	},
+};
+
+export const Clickable: Story = {
+	args: {
+		label: 'Clickable chip',
+		onClick: fn(),
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		label: 'Disabled chip',
+		onClick: fn(),
+		disabled: true,
+	},
+};

--- a/src/components/atoms/CodeBlock/CodeBlock.stories.tsx
+++ b/src/components/atoms/CodeBlock/CodeBlock.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CodeBlock from './CodeBlock';
+
+const meta: Meta<typeof CodeBlock> = {
+	title: 'Atoms/CodeBlock',
+	component: CodeBlock,
+	parameters: {
+		layout: 'padded',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TypeScriptExample: Story = {
+	args: {
+		language: 'tsx',
+		code: `function greet(name: string) {
+  return \`Hello, \${name}!\`;
+}
+
+console.log(greet('Storybook'));`,
+	},
+};

--- a/src/components/atoms/ComingSoon/ComingSoon.stories.tsx
+++ b/src/components/atoms/ComingSoon/ComingSoon.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ComingSoonTag from './ComingSoon';
+
+const meta: Meta<typeof ComingSoonTag> = {
+	title: 'Atoms/ComingSoon',
+	component: ComingSoonTag,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/atoms/CopyIdButton/CopyIdButton.stories.tsx
+++ b/src/components/atoms/CopyIdButton/CopyIdButton.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CopyIdButton } from './CopyIdButton';
+
+const meta: Meta<typeof CopyIdButton> = {
+	title: 'Atoms/CopyIdButton',
+	component: CopyIdButton,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		id: 'plan_01HZY4B1N7P4Z7Q7M2H4X0Y3AB',
+		entityType: 'Plan',
+	},
+};
+
+export const CustomToast: Story = {
+	args: {
+		id: 'customer_01HZY4B1N7P4Z7Q7M2H4X0Y3AB',
+		entityType: 'Customer',
+		toastMessage: 'Customer ID copied to clipboard',
+	},
+};

--- a/src/components/atoms/Divider/Divider.stories.tsx
+++ b/src/components/atoms/Divider/Divider.stories.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable i18next/no-literal-string */
+import type { Meta, StoryObj } from '@storybook/react';
+import Divider from './Divider';
+
+const meta: Meta<typeof Divider> = {
+	title: 'Atoms/Divider',
+	component: Divider,
+	parameters: {
+		layout: 'padded',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Center: Story = {
+	args: {
+		alignment: 'center',
+		width: '100%',
+	},
+	render: (args) => (
+		<div className='w-full max-w-md space-y-3'>
+			<p className='text-sm text-muted-foreground'>Centered divider</p>
+			<Divider {...args} />
+		</div>
+	),
+};
+
+export const Left: Story = {
+	args: {
+		alignment: 'left',
+		width: '60%',
+	},
+	render: (args) => (
+		<div className='w-full max-w-md space-y-3'>
+			<p className='text-sm text-muted-foreground'>Left aligned divider</p>
+			<Divider {...args} />
+		</div>
+	),
+};
+
+export const Right: Story = {
+	args: {
+		alignment: 'right',
+		width: '40%',
+	},
+	render: (args) => (
+		<div className='w-full max-w-md space-y-3'>
+			<p className='text-sm text-muted-foreground'>Right aligned divider</p>
+			<Divider {...args} />
+		</div>
+	),
+};

--- a/src/components/atoms/Input/Input.stories.tsx
+++ b/src/components/atoms/Input/Input.stories.tsx
@@ -1,64 +1,66 @@
-// import type { Meta, StoryObj } from '@storybook/react';
-// import   Input  from './Input';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import Input from './Input';
 
-// const meta = {
-//   title: 'Atoms/Input',
-//   component: Input,
-//   parameters: {
-//     layout: 'centered',
-//   },
-//   tags: ['autodocs'],
-// } satisfies Meta<typeof Input>;
+const meta: Meta<typeof Input> = {
+	title: 'Atoms/Input',
+	component: Input,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+};
 
-// export default meta;
-// type Story = StoryObj<typeof meta>;
+export default meta;
+type Story = StoryObj<typeof meta>;
 
-// export const Default: Story = {
-//   args: {
-//     placeholder: 'Enter text here',
-//   },
-// };
+const ControlledInput = (args: Story['args']) => {
+	const [value, setValue] = useState(String(args?.value ?? ''));
 
-// export const WithLabel: Story = {
-//   args: {
-//     label: 'Email',
-//     placeholder: 'Enter your email',
-//     type: 'email',
-//   },
-// };
+	return <Input {...args} value={value} onChange={setValue} />;
+};
 
-// export const WithError: Story = {
-//   args: {
-//     label: 'Password',
-//     type: 'password',
-//     error: 'Password must be at least 8 characters',
-//     placeholder: 'Enter your password',
-//   },
-// };
+export const Default: Story = {
+	render: (args) => <ControlledInput {...args} />,
+	args: {
+		placeholder: 'Enter text here',
+	},
+};
 
-// export const Disabled: Story = {
-//   args: {
-//     label: 'Username',
-//     placeholder: 'Enter your username',
-//     disabled: true,
-//   },
-// };
+export const WithLabel: Story = {
+	render: (args) => <ControlledInput {...args} />,
+	args: {
+		label: 'Email',
+		placeholder: 'Enter your email',
+		type: 'email',
+	},
+};
 
-// export const FullWidth: Story = {
-//   args: {
-//     label: 'Full Name',
-//     placeholder: 'Enter your full name',
-//     fullWidth: true,
-//   },
-//   parameters: {
-//     layout: 'padded',
-//   },
-// };
+export const WithError: Story = {
+	render: (args) => <ControlledInput {...args} />,
+	args: {
+		label: 'Password',
+		type: 'password',
+		error: 'Password must be at least 8 characters',
+		placeholder: 'Enter your password',
+	},
+};
 
-// export const WithValue: Story = {
-//   args: {
-//     label: 'Name',
-//     value: 'John Doe',
-//     placeholder: 'Enter your name',
-//   },
-// };
+export const Disabled: Story = {
+	render: (args) => <ControlledInput {...args} />,
+	args: {
+		label: 'Username',
+		placeholder: 'Enter your username',
+		disabled: true,
+	},
+};
+
+export const FormattedNumber: Story = {
+	render: (args) => <ControlledInput {...args} />,
+	args: {
+		label: 'Amount',
+		placeholder: 'Enter amount',
+		variant: 'formatted-number',
+		value: '1234567.89',
+	},
+};

--- a/src/components/atoms/Label/Label.stories.tsx
+++ b/src/components/atoms/Label/Label.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Label from './Label';
+
+const meta: Meta<typeof Label> = {
+	title: 'Atoms/Label',
+	component: Label,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		label: 'Email address',
+		htmlFor: 'email',
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		label: 'Plan name',
+		htmlFor: 'plan-name',
+		disabled: true,
+	},
+};

--- a/src/components/atoms/Loader/Loader.stories.tsx
+++ b/src/components/atoms/Loader/Loader.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Loader, { PageLoader } from './Loader';
+
+const meta: Meta<typeof Loader> = {
+	title: 'Atoms/Loader',
+	component: Loader,
+	parameters: {
+		layout: 'fullscreen',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Inline: Story = {
+	render: () => (
+		<div className='h-[360px] w-full rounded-md border overflow-hidden'>
+			<Loader />
+		</div>
+	),
+};
+
+export const Page: Story = {
+	render: () => <PageLoader />,
+};

--- a/src/components/atoms/NoDataCard/NoDataCard.stories.tsx
+++ b/src/components/atoms/NoDataCard/NoDataCard.stories.tsx
@@ -1,0 +1,23 @@
+/* eslint-disable i18next/no-literal-string */
+import type { Meta, StoryObj } from '@storybook/react';
+import NoDataCard from './NoDataCard';
+
+const meta: Meta<typeof NoDataCard> = {
+	title: 'Atoms/NoDataCard',
+	component: NoDataCard,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		title: 'No plans yet',
+		subtitle: 'Create your first plan to start selling usage-based pricing.',
+		cta: <button className='rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground'>Create plan</button>,
+	},
+};

--- a/src/components/atoms/Progress/Progress.stories.tsx
+++ b/src/components/atoms/Progress/Progress.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Progress from './Progress';
+
+const meta: Meta<typeof Progress> = {
+	title: 'Atoms/Progress',
+	component: Progress,
+	parameters: {
+		layout: 'padded',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Low: Story = {
+	args: {
+		value: 20,
+		label: 'Usage at 20%',
+	},
+};
+
+export const Half: Story = {
+	args: {
+		value: 50,
+		label: 'Usage at 50%',
+	},
+};
+
+export const Complete: Story = {
+	args: {
+		value: 100,
+		label: 'Usage complete',
+	},
+};

--- a/src/components/atoms/ShortPagination/ShortPagination.stories.tsx
+++ b/src/components/atoms/ShortPagination/ShortPagination.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+import ShortPagination from './ShortPagination';
+
+const meta: Meta<typeof ShortPagination> = {
+	title: 'Atoms/ShortPagination',
+	component: ShortPagination,
+	parameters: {
+		layout: 'padded',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const RouterWrapper = ({ children, initialEntries = ['/?page=1'] }: { children: ReactNode; initialEntries?: string[] }) => (
+	<MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+);
+
+export const Default: Story = {
+	render: () => (
+		<RouterWrapper>
+			<ShortPagination totalItems={120} pageSize={10} />
+		</RouterWrapper>
+	),
+};
+
+export const WithPageNumbers: Story = {
+	render: () => (
+		<RouterWrapper initialEntries={['/?page=4']}>
+			<ShortPagination totalItems={120} pageSize={10} showPages />
+		</RouterWrapper>
+	),
+};
+
+export const PrefixedPagination: Story = {
+	render: () => (
+		<RouterWrapper initialEntries={['/?wallet_transactions_page=2']}>
+			<ShortPagination totalItems={25} pageSize={5} showPages prefix='wallet_transactions' unit='records' />
+		</RouterWrapper>
+	),
+};

--- a/src/components/atoms/Spacer/Spacer.stories.tsx
+++ b/src/components/atoms/Spacer/Spacer.stories.tsx
@@ -1,0 +1,35 @@
+/* eslint-disable i18next/no-literal-string */
+import type { Meta, StoryObj } from '@storybook/react';
+import Spacer from './Spacer';
+
+const meta: Meta<typeof Spacer> = {
+	title: 'Atoms/Spacer',
+	component: Spacer,
+	parameters: {
+		layout: 'padded',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Vertical: Story = {
+	render: () => (
+		<div className='w-full max-w-sm rounded-md border p-4'>
+			<div className='rounded bg-slate-100 p-3 text-sm'>Top block</div>
+			<Spacer height={24} />
+			<div className='rounded bg-slate-100 p-3 text-sm'>Bottom block</div>
+		</div>
+	),
+};
+
+export const Horizontal: Story = {
+	render: () => (
+		<div className='flex items-center rounded-md border p-4 text-sm'>
+			<span className='rounded bg-slate-100 px-3 py-2'>Left</span>
+			<Spacer width={32} />
+			<span className='rounded bg-slate-100 px-3 py-2'>Right</span>
+		</div>
+	),
+};

--- a/src/components/atoms/Spinner/Spinner.stories.tsx
+++ b/src/components/atoms/Spinner/Spinner.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Spinner from './Spinner';
+
+const meta: Meta<typeof Spinner> = {
+	title: 'Atoms/Spinner',
+	component: Spinner,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Small: Story = {
+	args: {
+		size: 16,
+		className: 'text-primary',
+	},
+};
+
+export const Default: Story = {
+	args: {
+		size: 24,
+		className: 'text-primary',
+	},
+};
+
+export const Large: Story = {
+	args: {
+		size: 40,
+		className: 'text-primary',
+	},
+};

--- a/src/components/atoms/Stepper/Stepper.stories.tsx
+++ b/src/components/atoms/Stepper/Stepper.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Stepper from './Stepper';
+
+const meta: Meta<typeof Stepper> = {
+	title: 'Atoms/Stepper',
+	component: Stepper,
+	parameters: {
+		layout: 'padded',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const steps = [{ label: 'Plan details' }, { label: 'Pricing' }, { label: 'Review' }, { label: 'Publish' }];
+
+export const FirstStep: Story = {
+	args: {
+		steps,
+		activeStep: 0,
+	},
+};
+
+export const Midway: Story = {
+	args: {
+		steps,
+		activeStep: 1,
+	},
+};
+
+export const Completed: Story = {
+	args: {
+		steps,
+		activeStep: 3,
+	},
+};

--- a/src/components/atoms/Toggle/Toggle.stories.tsx
+++ b/src/components/atoms/Toggle/Toggle.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import Toggle from './Toggle';
+
+const meta: Meta<typeof Toggle> = {
+	title: 'Atoms/Toggle',
+	component: Toggle,
+	parameters: {
+		layout: 'padded',
+	},
+	tags: ['autodocs'],
+	args: {
+		onChange: () => {},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const ToggleWithState = (args: Story['args']) => {
+	const [checked, setChecked] = useState(Boolean(args?.checked));
+
+	return <Toggle {...args} checked={checked} onChange={setChecked} />;
+};
+
+export const Off: Story = {
+	render: (args) => <ToggleWithState {...args} />,
+	args: {
+		title: 'Notifications',
+		label: 'Enable email notifications',
+		description: 'Send billing and usage updates to the team inbox.',
+		checked: false,
+	},
+};
+
+export const On: Story = {
+	render: (args) => <ToggleWithState {...args} />,
+	args: {
+		title: 'Notifications',
+		label: 'Enable email notifications',
+		description: 'Send billing and usage updates to the team inbox.',
+		checked: true,
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		title: 'Notifications',
+		label: 'Enable email notifications',
+		description: 'Send billing and usage updates to the team inbox.',
+		checked: true,
+		disabled: true,
+	},
+};

--- a/src/components/molecules/DetailsCard.stories.tsx
+++ b/src/components/molecules/DetailsCard.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import DetailsCard, { type Detail } from './DetailsCard/DetailsCard';
+
+const meta: Meta<typeof DetailsCard> = {
+	title: 'Molecules/DetailsCard',
+	component: DetailsCard,
+	parameters: {
+		layout: 'padded',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const baseData: Detail[] = [
+	{ label: 'Plan name', value: 'Pro' },
+	{ label: 'Status', value: 'Published', tag: { text: 'Live', variant: 'default' } },
+	{ label: 'Seats', value: 'Unlimited' },
+	{ variant: 'divider' },
+	{ variant: 'heading', label: 'Billing' },
+	{ label: 'Currency', value: 'USD' },
+	{ label: 'Price', value: '$49 / month', labelStyle: 'semibold' },
+];
+
+export const Default: Story = {
+	args: {
+		title: 'Plan details',
+		data: baseData,
+	},
+};
+
+export const Stacked: Story = {
+	args: {
+		title: 'Plan details',
+		variant: 'stacked',
+		cardStyle: 'compact',
+		gridCols: 3,
+		data: baseData,
+	},
+};

--- a/src/components/molecules/MetricCard.stories.tsx
+++ b/src/components/molecules/MetricCard.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import MetricCard from './MetricCard';
+
+const meta: Meta<typeof MetricCard> = {
+	title: 'Molecules/MetricCard',
+	component: MetricCard,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Revenue: Story = {
+	args: {
+		title: 'Monthly revenue',
+		value: 12450.5,
+		currency: 'USD',
+		showChangeIndicator: true,
+	},
+};
+
+export const ConversionRate: Story = {
+	args: {
+		title: 'Conversion rate',
+		value: 8.42,
+		isPercent: true,
+		showChangeIndicator: true,
+	},
+};
+
+export const NegativeTrend: Story = {
+	args: {
+		title: 'Refund rate',
+		value: 2.18,
+		isPercent: true,
+		showChangeIndicator: true,
+		isNegative: true,
+	},
+};

--- a/src/components/molecules/Pagination/Pagination.stories.tsx
+++ b/src/components/molecules/Pagination/Pagination.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+import Pagination from './Pagination';
+
+const meta: Meta<typeof Pagination> = {
+	title: 'Molecules/Pagination',
+	component: Pagination,
+	parameters: {
+		layout: 'padded',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const RouterWrapper = ({ children, initialEntries = ['/?page=1'] }: { children: ReactNode; initialEntries?: string[] }) => (
+	<MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+);
+
+export const Default: Story = {
+	render: () => (
+		<RouterWrapper>
+			<Pagination totalPages={5} />
+		</RouterWrapper>
+	),
+};
+
+export const WithEllipsis: Story = {
+	render: () => (
+		<RouterWrapper initialEntries={['/?page=8']}>
+			<Pagination totalPages={20} maxPagesBeforeTruncate={7} siblingCount={1} />
+		</RouterWrapper>
+	),
+};

--- a/src/components/molecules/Tabs/CustomTabs.stories.tsx
+++ b/src/components/molecules/Tabs/CustomTabs.stories.tsx
@@ -1,0 +1,35 @@
+/* eslint-disable i18next/no-literal-string */
+import type { Meta, StoryObj } from '@storybook/react';
+import CustomTabs from './CustomTabs';
+
+const meta: Meta<typeof CustomTabs> = {
+	title: 'Molecules/Tabs/CustomTabs',
+	component: CustomTabs,
+	parameters: {
+		layout: 'padded',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const tabs = [
+	{ value: 'overview', label: 'Overview', content: <div className='rounded-md border p-4 text-sm'>Overview content</div> },
+	{ value: 'usage', label: 'Usage', content: <div className='rounded-md border p-4 text-sm'>Usage content</div> },
+	{ value: 'billing', label: 'Billing', content: <div className='rounded-md border p-4 text-sm'>Billing content</div> },
+];
+
+export const Default: Story = {
+	args: {
+		tabs,
+		defaultValue: 'overview',
+	},
+};
+
+export const BillingActive: Story = {
+	args: {
+		tabs,
+		defaultValue: 'billing',
+	},
+};

--- a/src/components/molecules/Tabs/FlatTabs.stories.tsx
+++ b/src/components/molecules/Tabs/FlatTabs.stories.tsx
@@ -1,0 +1,43 @@
+/* eslint-disable i18next/no-literal-string */
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+import FlatTabs from './FlatTabs';
+
+const meta: Meta<typeof FlatTabs> = {
+	title: 'Molecules/Tabs/FlatTabs',
+	component: FlatTabs,
+	parameters: {
+		layout: 'padded',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const tabs = [
+	{ value: 'overview', label: 'Overview', content: <div className='rounded-md border p-4 text-sm'>Overview content</div> },
+	{ value: 'usage', label: 'Usage', content: <div className='rounded-md border p-4 text-sm'>Usage content</div> },
+	{ value: 'billing', label: 'Billing', content: <div className='rounded-md border p-4 text-sm'>Billing content</div> },
+];
+
+const RouterWrapper = ({ children, initialEntries = ['/?tab=overview'] }: { children: ReactNode; initialEntries?: string[] }) => (
+	<MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+);
+
+export const Default: Story = {
+	render: () => (
+		<RouterWrapper>
+			<FlatTabs tabs={tabs} defaultValue='overview' />
+		</RouterWrapper>
+	),
+};
+
+export const UsageActive: Story = {
+	render: () => (
+		<RouterWrapper initialEntries={['/?tab=usage']}>
+			<FlatTabs tabs={tabs} defaultValue='overview' />
+		</RouterWrapper>
+	),
+};

--- a/src/components/molecules/TestimonialCard.stories.tsx
+++ b/src/components/molecules/TestimonialCard.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TestimonialCard from './TestimonialCard/TestimonialCard';
+import type { Testimonial } from '@/types';
+
+const meta: Meta<typeof TestimonialCard> = {
+	title: 'Molecules/TestimonialCard',
+	component: TestimonialCard,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const testimonial: Testimonial = {
+	companyName: 'Acme Inc.',
+	companyTitleLogoUrl:
+		"data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='32' viewBox='0 0 120 32'%3E%3Crect width='120' height='32' rx='6' fill='%23092E44'/%3E%3Ctext x='16' y='21' fill='white' font-size='14' font-family='Arial'%3EACME%3C/text%3E%3C/svg%3E",
+	dpUrl:
+		"data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='32' fill='%23E5E7EB'/%3E%3Ccircle cx='32' cy='26' r='10' fill='%239CA3AF'/%3E%3Cpath d='M16 54c4-10 12-15 16-15s12 5 16 15' fill='%239CA3AF'/%3E%3C/svg%3E",
+	logoUrl: '',
+	testimonial: 'Storybook makes it easy for our team to review UI states before they land in production.',
+	name: 'Jordan Lee',
+	designation: 'Head of Product',
+	label: 'YC 25',
+};
+
+export const Default: Story = {
+	args: {
+		testimonial,
+	},
+};

--- a/src/pages/insights-tools/revenue/Revenue.tsx
+++ b/src/pages/insights-tools/revenue/Revenue.tsx
@@ -211,7 +211,7 @@ const Revenue = () => {
 					<div className={showGlobalEmpty ? 'blur-[3px] select-none pointer-events-none' : ''}>
 						{selectedCurrency === '' ? (
 							// No currency selected yet (or no data) — show per-currency summaries from the "summaries" map.
-							(isLoading || showGlobalEmpty) ? (
+							isLoading || showGlobalEmpty ? (
 								<div className='rounded-xl border border-gray-200 bg-white overflow-hidden'>
 									<div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'>
 										<MetricTile
@@ -327,28 +327,28 @@ const Revenue = () => {
 					)}
 				</div>
 
-					{showGraph && (isLoading || graphCharts.length > 0) && (
-						<div className='pt-2'>
-							<div className={`grid grid-cols-1 gap-4 ${graphCharts.length === 1 ? 'md:grid-cols-1' : 'md:grid-cols-2'}`}>
-								{isLoading
-									? [0, 1].map((i) => (
-											<Card key={i} className='shadow-sm border border-gray-200'>
-												<CardHeader className='pb-2'>
-													<Skeleton className='h-4 w-32' />
-												</CardHeader>
-												<CardContent>
-													<Skeleton className='h-56 w-full' />
-												</CardContent>
-											</Card>
-										))
-									: graphCharts.map((chart) => (
-											<RevenueBarChart key={chart.key} title={chart.title} data={graph![chart.key]!} type={chart.type} />
-										))}
-							</div>
+				{showGraph && (isLoading || graphCharts.length > 0) && (
+					<div className='pt-2'>
+						<div className={`grid grid-cols-1 gap-4 ${graphCharts.length === 1 ? 'md:grid-cols-1' : 'md:grid-cols-2'}`}>
+							{isLoading
+								? [0, 1].map((i) => (
+										<Card key={i} className='shadow-sm border border-gray-200'>
+											<CardHeader className='pb-2'>
+												<Skeleton className='h-4 w-32' />
+											</CardHeader>
+											<CardContent>
+												<Skeleton className='h-56 w-full' />
+											</CardContent>
+										</Card>
+									))
+								: graphCharts.map((chart) => (
+										<RevenueBarChart key={chart.key} title={chart.title} data={graph![chart.key]!} type={chart.type} />
+									))}
 						</div>
-					)}
+					</div>
+				)}
 
-					<div className='pt-8'>
+				<div className='pt-8'>
 					<div className='rounded-md border border-gray-200 bg-white overflow-hidden shadow-sm'>
 						<div className='flex items-center justify-between px-4 py-2.5 border-b border-gray-200 bg-white'>
 							<div className='relative flex items-center w-64'>
@@ -487,7 +487,7 @@ const Revenue = () => {
 							</div>
 						</div>
 					)}
-					</div>
+				</div>
 			</div>
 		</Page>
 	);


### PR DESCRIPTION
Fixes #159 

## Changelog

### Storybook
- Added a shared Storybook preview decorator with `i18n` support so translation-backed components render correctly in isolation.
- Kept Storybook configuration aligned with the existing CSF setup and component co-location pattern.

### New Coverage
Added stories for a first pass of reusable, story-friendly UI components:

- **Atoms**: `Button`, `Chip`, `Checkbox`, `Divider`, `Label`, `Spinner`, `Spacer`, `Progress`, `Stepper`, `ComingSoon`, `Loader`, `CodeBlock`, `CopyIdButton`, `ShortPagination`, `Toggle`, `NoDataCard`
- **Molecules**: `MetricCard`, `DetailsCard`, `Pagination`, `CustomTabs`, `FlatTabs`, `TestimonialCard`

### Story Variants
- Added representative states where applicable:
  - Default / Primary
  - Secondary
  - Disabled
  - Loading
- Used lightweight wrappers for controlled inputs, router-dependent pagination, and tab components.

### Scope
- Focused on reusable atoms and simple molecules.
- Deliberately skipped heavier, data-driven, or app-provider-dependent components for this pass.

### Validation
- TypeScript build passed with `tsc -b`
- Production build passed with `vite build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive interactive Storybook documentation for numerous UI components, including buttons, inputs, checkboxes, toggles, cards, pagination, loaders, spinners, spacers, and dividers with multiple variants that showcase different states and interactive user behaviors.

* **Chores**
  * Configured Storybook with full internationalization support to enable comprehensive multi-language component documentation.

* **Style**
  * Enhanced code formatting in the Revenue analytics page component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->