### PR TITLE
fix: prevent metric card value wrapping in analytics

### DIFF
--- a/src/components/molecules/MetricCard.tsx
+++ b/src/components/molecules/MetricCard.tsx
@@ -34,7 +34,7 @@ const MetricCard: React.FC<MetricCardProps> = ({
 	return (
 		<div className='bg-white border border-[#E5E7EB] p-[25px] flex flex-col gap-3 rounded-md'>
 			<p className='text-[14px] leading-[21px] text-[#4B5563] font-normal'>{title}</p>
-			<p className='text-[24px] leading-[28px] font-medium text-[#111827] flex items-center'>
+			<p className='text-[24px] leading-[28px] font-medium text-[#111827] flex items-center whitespace-nowrap'>
 				{renderValue()}
 				{showChangeIndicator && (
 					<span className={`inline-block ${arrowColor} ms-3`}>{isNegative ? <TrendingDown size={18} /> : <TrendingUp size={18} />}</span>


### PR DESCRIPTION
## Summary

Fixes metric card value wrapping in the Customer Analytics page.

## Changes

- Added `whitespace-nowrap` to metric card values
- Prevented large Margin values from wrapping onto multiple lines
- Ensured consistent layout across Revenue, Cost, Margin, Margin %, and CPM cards

## Testing

- Rendered Customer Analytics page locally
- Verified all metric cards maintain consistent dimensions
- Confirmed Margin values remain on a single line
- Ran production build successfully (`npm run build`)

Fixes #849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text-wrapping in metric cards so values remain on a single line.

* **Style / UI**
  * Adjusted date input sizing in query builder popovers for a more compact appearance.

* **New Features**
  * Date picker gains an optional trigger styling option to allow custom trigger appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->