### PR TITLE
Add tiered and package pricing for fixed charges

### DIFF
--- a/src/components/organisms/PlanForm/RecurringChargePreview.tsx
+++ b/src/components/organisms/PlanForm/RecurringChargePreview.tsx
@@ -2,11 +2,12 @@ import { Trash2 } from 'lucide-react';
 import { formatBillingPeriodForPrice } from '@/utils/common/helper_functions';
 import { getCurrencySymbol } from '@/utils/common/helper_functions';
 import { toSentenceCase } from '@/utils/common/helper_functions';
-import { Price, PRICE_UNIT_TYPE } from '@/models/Price';
+import { BILLING_MODEL, Price, PRICE_UNIT_TYPE } from '@/models/Price';
 import { FC } from 'react';
 import { Pencil } from 'lucide-react';
 import { InternalPrice } from './SetupChargesSection';
 import { formatAmount } from '@/components/atoms/Input/Input';
+import { ChargeValueCell } from '@/components/molecules';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
@@ -48,6 +49,10 @@ const RecurringChargePreview: FC<Props> = ({ charge, onEditClicked, onDeleteClic
 	const displayCurrency =
 		charge.price_unit_type === PRICE_UNIT_TYPE.CUSTOM ? charge.price_unit_config?.price_unit || charge.currency : charge.currency;
 
+	// Flat fee charges render a simple "amount / period" string; package and tiered charges
+	// reuse ChargeValueCell, which knows how to format package sizes and tier summaries.
+	const isFlatFee = !charge.billing_model || charge.billing_model === BILLING_MODEL.FLAT_FEE;
+
 	return (
 		<div className='gap-2 w-full flex justify-between group min-h-9 items-center rounded-md border bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground hover:bg-gray-50 transition-colors mb-2'>
 			<div>
@@ -57,10 +62,14 @@ const RecurringChargePreview: FC<Props> = ({ charge, onEditClicked, onDeleteClic
 					<span>•</span>
 					<span>{toSentenceCase(charge.billing_period || '')}</span>
 					<span>•</span>
-					<span>
-						{displayInfo.symbol}
-						{formatAmount(displayInfo.amount)} / {formatBillingPeriodForPrice(charge.billing_period || '')}
-					</span>
+					{isFlatFee ? (
+						<span>
+							{displayInfo.symbol}
+							{formatAmount(displayInfo.amount)} / {formatBillingPeriodForPrice(charge.billing_period || '')}
+						</span>
+					) : (
+						<ChargeValueCell data={{ ...charge, currency: charge.currency } as any} />
+					)}
 				</div>
 			</div>
 

--- a/src/components/organisms/PlanForm/RecurringChargesForm.tsx
+++ b/src/components/organisms/PlanForm/RecurringChargesForm.tsx
@@ -2,13 +2,14 @@ import { useState, useEffect, useMemo } from 'react';
 import { formatBillingPeriodForPrice, getCurrencySymbol } from '@/utils/common/helper_functions';
 import { billlingPeriodOptions } from '@/constants/constants';
 import { InternalPrice } from './SetupChargesSection';
-import { PriceInternalState } from './UsagePricingForm';
+import { PriceInternalState, PriceTier, billingModels } from './UsagePricingForm';
+import VolumeTieredPricingForm from './VolumeTieredPricingForm';
 import { CheckboxRadioGroup, FormHeader, Input, Spacer, Button, Select, DatePicker } from '@/components/atoms';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import RecurringChargePreview from './RecurringChargePreview';
 import { BILLING_CADENCE, INVOICE_CADENCE } from '@/models/Invoice';
-import { BILLING_PERIOD, PRICE_ENTITY_TYPE, PRICE_TYPE, PRICE_UNIT_TYPE, BILLING_MODEL } from '@/models/Price';
+import { BILLING_PERIOD, PRICE_ENTITY_TYPE, PRICE_TYPE, PRICE_UNIT_TYPE, BILLING_MODEL, TIER_MODE } from '@/models/Price';
 import SelectGroup from './SelectGroup';
 import { Group } from '@/models/Group';
 import { CurrencyPriceUnitSelector } from '@/components/molecules';
@@ -16,6 +17,7 @@ import { CurrencyPriceUnitSelection, isPriceUnitOption } from '@/types/common';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Calculator } from 'lucide-react';
 import { SubscriptionCalculatorContent } from '@/components/organisms/EntityChargesPage/SubscriptionCalculator';
+import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
@@ -28,6 +30,12 @@ interface Props {
 	entityId?: string;
 	entityName?: string;
 }
+
+// Tiers used when a tiered fixed charge form is first opened
+const getDefaultTiers = (): PriceTier[] => [
+	{ from: 0, up_to: 1, unit_amount: '', flat_amount: '0' },
+	{ from: 1, up_to: null, unit_amount: '', flat_amount: '0' },
+];
 
 const RecurringChargesForm = ({
 	price,
@@ -55,6 +63,16 @@ const RecurringChargesForm = ({
 	const [startDate, setStartDate] = useState<Date | undefined>(() => (price.start_date ? new Date(price.start_date) : undefined));
 	const [errors, setErrors] = useState<Partial<Record<keyof InternalPrice, string>>>({});
 	const [calculatorOpen, setCalculatorOpen] = useState(false);
+
+	// Billing-model-specific state. `billingModel` holds the selector value which may be the
+	// frontend-only 'SLAB_TIERED' option (maps to TIERED with SLAB tier_mode on submit).
+	const [billingModel, setBillingModel] = useState<string>(price.billing_model || BILLING_MODEL.FLAT_FEE);
+	const [packagedFee, setPackagedFee] = useState<{ unit: string; price: string }>({
+		unit: price.transform_quantity?.divide_by?.toString() || '',
+		price: price.billing_model === BILLING_MODEL.PACKAGE ? price.amount || '' : '',
+	});
+	const [tieredPrices, setTieredPrices] = useState<PriceTier[]>(getDefaultTiers);
+	const [modelErrors, setModelErrors] = useState({ packagedModelError: '', tieredModelError: '' });
 
 	// Sync localPrice and startDate when price prop or entityName changes
 	useEffect(() => {
@@ -90,7 +108,32 @@ const RecurringChargesForm = ({
 
 			return updated;
 		});
+
+		// Hydrate billing-model-specific state from the price prop
+		setBillingModel(price.billing_model || BILLING_MODEL.FLAT_FEE);
+		if (price.billing_model === BILLING_MODEL.PACKAGE) {
+			setPackagedFee({
+				price: price.amount || '',
+				unit: price.transform_quantity?.divide_by?.toString() || '',
+			});
+		} else if (price.billing_model === BILLING_MODEL.TIERED && Array.isArray(price.tiers) && price.tiers.length > 0) {
+			setTieredPrices(
+				(price.tiers as unknown as PriceTier[]).map((tier) => ({
+					from: tier.from,
+					up_to: tier.up_to,
+					unit_amount: tier.unit_amount,
+					flat_amount: tier.flat_amount,
+				})),
+			);
+			// Surface SLAB tiered as its own selector option
+			setBillingModel(price.tier_mode === TIER_MODE.SLAB ? 'SLAB_TIERED' : BILLING_MODEL.TIERED);
+		}
 	}, [price, entityName]);
+
+	const isPackage = billingModel === BILLING_MODEL.PACKAGE;
+	const isTiered = billingModel === BILLING_MODEL.TIERED || billingModel === 'SLAB_TIERED';
+	const isFlatFee = billingModel === BILLING_MODEL.FLAT_FEE;
+	const isCustomUnit = localPrice.price_unit_type === PRICE_UNIT_TYPE.CUSTOM;
 
 	// Get the current currency/price unit value for the selector
 	const currencyPriceUnitValue = useMemo(() => {
@@ -100,12 +143,10 @@ const RecurringChargesForm = ({
 		return localPrice.currency || '';
 	}, [localPrice.currency, localPrice.price_unit_type, localPrice.price_unit_config]);
 
-	// Get currency symbol for display (from currency or price unit's base_currency)
+	// Get currency symbol for display (currency symbol for FIAT, price unit code for CUSTOM)
 	const displayCurrencySymbol = useMemo(() => {
 		if (localPrice.price_unit_type === PRICE_UNIT_TYPE.CUSTOM && localPrice.price_unit_config?.price_unit) {
-			// For custom price units, we need to get the base_currency from the price unit
-			// This will be set when the price unit is selected
-			return getCurrencySymbol(localPrice.currency || '');
+			return localPrice.price_unit_config.price_unit;
 		}
 		return getCurrencySymbol(localPrice.currency || '');
 	}, [localPrice.currency, localPrice.price_unit_type, localPrice.price_unit_config]);
@@ -135,77 +176,137 @@ const RecurringChargesForm = ({
 
 	const validate = () => {
 		const newErrors: Partial<Record<keyof InternalPrice, string>> = {};
+		const newModelErrors = { packagedModelError: '', tieredModelError: '' };
 
-		if (!localPrice.amount) {
-			newErrors.amount = 'Price is required';
-		}
 		if (!localPrice.billing_period) {
 			newErrors.billing_period = 'Billing Period is required';
 		}
 		if (!localPrice.currency) {
 			newErrors.currency = 'Currency is required';
 		}
-
 		if (localPrice.price_unit_type === PRICE_UNIT_TYPE.CUSTOM && !localPrice.price_unit_config?.price_unit) {
 			newErrors.price_unit_config = 'Price unit is required when using custom price unit';
 		}
-
 		if (!localPrice.invoice_cadence) {
 			newErrors.invoice_cadence = 'Invoice Cadence is required';
 		}
-
 		if (localPrice.isTrialPeriod && !localPrice.trial_period_days) {
 			newErrors.trial_period_days = 'Trial Period is required';
 		}
 
+		if (isFlatFee && !localPrice.amount) {
+			newErrors.amount = 'Price is required';
+		}
+
+		if (isPackage) {
+			if (packagedFee.price === '' || packagedFee.unit === '') {
+				newModelErrors.packagedModelError = 'Invalid package fee';
+			} else {
+				const packagePrice = parseFloat(packagedFee.price);
+				const packageUnit = parseInt(packagedFee.unit);
+				if (isNaN(packagePrice) || packagePrice < 0) {
+					newModelErrors.packagedModelError = 'Package price must be a valid number greater than or equal to 0';
+				} else if (isNaN(packageUnit) || packageUnit <= 0) {
+					newModelErrors.packagedModelError = 'Package unit must be a valid number greater than 0';
+				}
+			}
+		}
+
+		if (isTiered) {
+			if (tieredPrices.length === 0) {
+				newModelErrors.tieredModelError = 'Tiers are required when billing model is TIERED';
+			} else {
+				for (let i = 0; i < tieredPrices.length; i++) {
+					const tier = tieredPrices[i];
+					if (!tier.unit_amount || tier.unit_amount.trim() === '') {
+						newModelErrors.tieredModelError = `Unit amount is required for tier ${i + 1}`;
+						break;
+					}
+					const unitAmount = parseFloat(tier.unit_amount);
+					if (isNaN(unitAmount) || unitAmount < 0) {
+						newModelErrors.tieredModelError = `Unit amount must be greater than or equal to 0 for tier ${i + 1}`;
+						break;
+					}
+					if (tier.flat_amount && tier.flat_amount.trim() !== '') {
+						const flatAmount = parseFloat(tier.flat_amount);
+						if (isNaN(flatAmount) || flatAmount < 0) {
+							newModelErrors.tieredModelError = `Flat amount must be greater than or equal to 0 for tier ${i + 1}`;
+							break;
+						}
+					}
+					if (tier.up_to !== null && tier.from > tier.up_to) {
+						newModelErrors.tieredModelError = `From value cannot be greater than up to in tier ${i + 1}`;
+						break;
+					}
+				}
+			}
+		}
+
 		setErrors(newErrors);
-		return Object.keys(newErrors).length === 0;
+		setModelErrors(newModelErrors);
+
+		const modelError = newModelErrors.packagedModelError || newModelErrors.tieredModelError;
+		if (modelError) toast.error(modelError);
+
+		return Object.keys(newErrors).length === 0 && !modelError;
 	};
 
 	const handleSubmit = () => {
 		if (!validate()) return;
 
-		// Build price_unit_config for custom price units
+		const resolvedBillingModel = isTiered ? BILLING_MODEL.TIERED : (billingModel as BILLING_MODEL);
+
+		// Build the per-model amount / transform_quantity / tiers for FIAT prices
+		const amount = isFlatFee ? localPrice.amount : isPackage ? packagedFee.price : undefined;
+		const transformQuantity = isPackage ? { divide_by: Number(packagedFee.unit) } : undefined;
+		const tiers = isTiered
+			? (tieredPrices.map((tier) => ({
+					from: tier.from,
+					up_to: tier.up_to ?? null,
+					unit_amount: tier.unit_amount || '0',
+					flat_amount: tier.flat_amount || '0',
+				})) as unknown as NonNullable<InternalPrice['tiers']>)
+			: undefined;
+		const tierMode = isTiered ? (billingModel === 'SLAB_TIERED' ? TIER_MODE.SLAB : TIER_MODE.VOLUME) : undefined;
+
+		// Build price_unit_config for custom price units based on billing model
 		let priceUnitConfig = localPrice.price_unit_config;
-		if (localPrice.price_unit_type === PRICE_UNIT_TYPE.CUSTOM && localPrice.price_unit_config) {
-			// For FLAT_FEE billing model with custom price unit, set amount in price_unit_config
-			if (localPrice.billing_model === BILLING_MODEL.FLAT_FEE && localPrice.amount) {
+		if (isCustomUnit && localPrice.price_unit_config) {
+			if (isFlatFee) {
+				priceUnitConfig = { ...localPrice.price_unit_config, amount: localPrice.amount };
+			} else if (isPackage) {
+				priceUnitConfig = { ...localPrice.price_unit_config, amount: packagedFee.price };
+			} else if (isTiered) {
 				priceUnitConfig = {
 					...localPrice.price_unit_config,
-					amount: localPrice.amount,
+					price_unit_tiers: tieredPrices.map((tier) => ({
+						up_to: tier.up_to ?? null,
+						unit_amount: tier.unit_amount || '0',
+						flat_amount: tier.flat_amount || '0',
+					})),
 				};
 			}
 		}
 
-		// Build price object, explicitly excluding amount, tiers, and tier_mode when price_unit_type is CUSTOM
-		const { amount: _, tiers: __, tier_mode: ___, ...localPriceWithoutAmountTiers } = localPrice;
+		// Strip amount/tiers/tier_mode/transform_quantity off the base so we apply them explicitly below
+		const { amount: _, tiers: __, tier_mode: ___, transform_quantity: ____, ...baseLocalPrice } = localPrice;
 
 		const priceWithEntity: Partial<InternalPrice> = {
-			...(localPrice.price_unit_type === PRICE_UNIT_TYPE.CUSTOM ? localPriceWithoutAmountTiers : localPrice),
+			...baseLocalPrice,
+			billing_model: resolvedBillingModel,
 			price_unit_config: priceUnitConfig,
 			entity_type: entityType,
 			entity_id: entityId || '',
 			start_date: startDate ? startDate.toISOString() : undefined,
-			// Sanitize: explicitly set amount, tiers, and tier_mode to undefined when price_unit_type is CUSTOM
-			...(localPrice.price_unit_type === PRICE_UNIT_TYPE.CUSTOM
-				? {
-						amount: undefined,
-						tiers: undefined,
-						tier_mode: undefined,
-					}
-				: {}),
+			transform_quantity: transformQuantity,
+			// For CUSTOM price units, amount/tiers/tier_mode live in price_unit_config and must be omitted from the root
+			...(isCustomUnit ? { amount: undefined, tiers: undefined, tier_mode: undefined } : { amount, tiers, tier_mode: tierMode }),
 		};
 
 		if (price.internal_state === PriceInternalState.EDIT) {
-			onUpdate({
-				...priceWithEntity,
-				isEdit: false,
-			});
+			onUpdate({ ...priceWithEntity, isEdit: false });
 		} else {
-			onAdd({
-				...priceWithEntity,
-				isEdit: false,
-			});
+			onAdd({ ...priceWithEntity, isEdit: false });
 		}
 	};
 
@@ -243,50 +344,109 @@ const RecurringChargesForm = ({
 				error={errors.billing_period}
 			/>
 			<Spacer height={'8px'} />
-			<Input
-				onChange={(value) => setLocalPrice({ ...localPrice, amount: value })}
-				value={localPrice.amount}
-				variant='formatted-number'
-				label={t('catalog:plans.organisms.priceForm.price')}
-				placeholder={t('catalog:plans.organisms.priceForm.amountPlaceholderShort')}
-				error={errors.amount}
-				inputPrefix={displayCurrencySymbol}
-				suffix={
-					<div className='flex items-center gap-1.5'>
-						<span className='text-[#64748B]'>
-							{t('catalog:plans.organisms.recurringForm.perBilling', {
-								period: formatBillingPeriodForPrice(localPrice.billing_period || ''),
-							})}
-						</span>
-						<Popover open={calculatorOpen} onOpenChange={setCalculatorOpen}>
-							<PopoverTrigger asChild>
-								<button
-									type='button'
-									aria-label={t('catalog:plans.organisms.recurringForm.calculatorAria')}
-									className='inline-flex items-center justify-center rounded p-0.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1'
-									onClick={(e) => {
-										e.stopPropagation();
-										setCalculatorOpen(true);
-									}}>
-									<Calculator className='size-4' />
-								</button>
-							</PopoverTrigger>
-							<PopoverContent className='w-[360px]' align='end' sideOffset={8} onOpenAutoFocus={(e) => e.preventDefault()}>
-								<SubscriptionCalculatorContent
-									currency={localPrice.currency || 'USD'}
-									initialAmount={localPrice.amount ?? ''}
-									initialContractTerms='ANNUAL'
-									planPeriod={(localPrice.billing_period as any) || 'ANNUAL'}
-									onApply={(displayAmount) => {
-										setLocalPrice((prev) => ({ ...prev, amount: displayAmount }));
-										setCalculatorOpen(false);
-									}}
-								/>
-							</PopoverContent>
-						</Popover>
-					</div>
-				}
+			<Select
+				value={billingModel}
+				options={billingModels}
+				onChange={setBillingModel}
+				label={t('catalog:plans.organisms.usageForm.billingModel')}
+				placeholder={t('catalog:plans.organisms.usageForm.billingModelPlaceholder')}
 			/>
+			<Spacer height={'8px'} />
+
+			{isFlatFee && (
+				<Input
+					onChange={(value) => setLocalPrice({ ...localPrice, amount: value })}
+					value={localPrice.amount}
+					variant='formatted-number'
+					label={t('catalog:plans.organisms.priceForm.price')}
+					placeholder={t('catalog:plans.organisms.priceForm.amountPlaceholderShort')}
+					error={errors.amount}
+					inputPrefix={displayCurrencySymbol}
+					suffix={
+						<div className='flex items-center gap-1.5'>
+							<span className='text-[#64748B]'>
+								{t('catalog:plans.organisms.recurringForm.perBilling', {
+									period: formatBillingPeriodForPrice(localPrice.billing_period || ''),
+								})}
+							</span>
+							<Popover open={calculatorOpen} onOpenChange={setCalculatorOpen}>
+								<PopoverTrigger asChild>
+									<button
+										type='button'
+										aria-label={t('catalog:plans.organisms.recurringForm.calculatorAria')}
+										className='inline-flex items-center justify-center rounded p-0.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1'
+										onClick={(e) => {
+											e.stopPropagation();
+											setCalculatorOpen(true);
+										}}>
+										<Calculator className='size-4' />
+									</button>
+								</PopoverTrigger>
+								<PopoverContent className='w-[360px]' align='end' sideOffset={8} onOpenAutoFocus={(e) => e.preventDefault()}>
+									<SubscriptionCalculatorContent
+										currency={localPrice.currency || 'USD'}
+										initialAmount={localPrice.amount ?? ''}
+										initialContractTerms='ANNUAL'
+										planPeriod={(localPrice.billing_period as any) || 'ANNUAL'}
+										onApply={(displayAmount) => {
+											setLocalPrice((prev) => ({ ...prev, amount: displayAmount }));
+											setCalculatorOpen(false);
+										}}
+									/>
+								</PopoverContent>
+							</Popover>
+						</div>
+					}
+				/>
+			)}
+
+			{isPackage && (
+				<div className='space-y-1'>
+					<div className='flex w-full gap-2 items-end'>
+						<Input
+							variant='formatted-number'
+							label={t('catalog:plans.organisms.priceForm.price')}
+							placeholder={t('catalog:plans.organisms.usageForm.amountPlaceholder')}
+							value={packagedFee.price}
+							inputPrefix={displayCurrencySymbol}
+							onChange={(e) => {
+								const decimalRegex = /^\d*\.?\d*$/;
+								if (decimalRegex.test(e) || e === '') {
+									setPackagedFee({ ...packagedFee, price: e });
+								}
+							}}
+						/>
+						<div className='h-[50px] items-center flex gap-2'>
+							<p className='text-[#18181B] font-medium'>{t('catalog:plans.organisms.usageForm.per')}</p>
+						</div>
+						<Input
+							value={packagedFee.unit}
+							variant='integer'
+							placeholder='0'
+							onChange={(e) => {
+								const integerRegex = /^\d*$/;
+								if (integerRegex.test(e) || e === '') {
+									setPackagedFee({ ...packagedFee, unit: e });
+								}
+							}}
+							suffix={`/ units / ${formatBillingPeriodForPrice(localPrice.billing_period || '')}`}
+						/>
+					</div>
+					{modelErrors.packagedModelError && <p className='text-red-500 text-sm'>{modelErrors.packagedModelError}</p>}
+				</div>
+			)}
+
+			{isTiered && (
+				<div className='space-y-2'>
+					<VolumeTieredPricingForm
+						setTieredPrices={setTieredPrices}
+						tieredPrices={tieredPrices}
+						currency={isCustomUnit ? localPrice.price_unit_config?.price_unit || localPrice.currency : localPrice.currency}
+						tierMode={billingModel === 'SLAB_TIERED' ? TIER_MODE.SLAB : TIER_MODE.VOLUME}
+					/>
+					{modelErrors.tieredModelError && <p className='text-red-500 text-sm'>{modelErrors.tieredModelError}</p>}
+				</div>
+			)}
 			<Spacer height={'8px'} />
 			<SelectGroup
 				value={localPrice.group_id}

--- a/src/components/organisms/PlanForm/UsagePricingForm.tsx
+++ b/src/components/organisms/PlanForm/UsagePricingForm.tsx
@@ -55,7 +55,7 @@ interface TieredPrice {
 }
 
 // TODO: Remove disabled once the feature is released
-const billingModels: SelectOption[] = [
+export const billingModels: SelectOption[] = [
 	{
 		value: BILLING_MODEL.FLAT_FEE,
 		label: 'Flat Fee',


### PR DESCRIPTION
Fixed charges previously only supported the **Flat Fee** billing model, while usage charges already supported Package and Tiered. This adds the same billing model selector to fixed charges so they can be configured as Flat Fee, Package, Volume Tiered, or Slab Tiered.

**Changes**
- `RecurringChargesForm` now renders the shared billing model selector (reusing `billingModels` exported from `UsagePricingForm`) with package size inputs and the tier table (`VolumeTieredPricingForm`). Validation and submit logic build the correct `amount` / `transform_quantity` / `tiers` + `tier_mode` payloads, including custom price unit (`price_unit_config`) handling, mirroring the usage form.
- `RecurringChargePreview` renders package and tiered fixed charges via `ChargeValueCell` (flat fee keeps its existing `amount / period` summary).

No backend/DTO changes were needed — `EntityChargesPage` already serializes `transform_quantity`, `tiers`, and `tier_mode`, and the price display tables already use `ChargeValueCell`, which handles all billing models.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple billing models (flat fee, packaged fees, tiered pricing) in recurring charge creation and editing.
  * Introduced a billing model selector to choose pricing structure.
  * Enhanced validation with model-specific checks for each pricing type.

* **Improvements**
  * Updated charge preview display to render appropriately based on selected billing model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->