### PR TITLE
fix: align date picker width in filter popover

### DIFF
--- a/src/components/atoms/DatePicker/DatePicker.tsx
+++ b/src/components/atoms/DatePicker/DatePicker.tsx
@@ -29,6 +29,7 @@ interface DatePickerProps {
 	popoverClassName?: string;
 	popoverTriggerClassName?: string;
 	popoverContentClassName?: string;
+	triggerClassName?: string;
 }
 
 const DatePicker = ({
@@ -44,6 +45,7 @@ const DatePicker = ({
 	popoverClassName,
 	popoverTriggerClassName,
 	popoverContentClassName,
+	triggerClassName,
 }: DatePickerProps) => {
 	const [open, setOpen] = useState(false);
 	const [timezone, setTimezone] = useState<CalendarTimezone>('local');
@@ -79,12 +81,16 @@ const DatePicker = ({
 
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
-			<div className={cn('flex w-full flex-col', popoverTriggerClassName)}>
+			<div className={cn('flex w-full flex-col', className, popoverTriggerClassName)}>
 				{label && <div className={cn('mb-1 w-full text-start text-sm', labelClassName)}>{label}</div>}
 				<PopoverTrigger asChild disabled={disabled}>
 					<Button
 						variant='outline'
-						className={cn('h-10 w-full min-w-0 justify-start text-start font-normal py-1', !date && 'text-muted-foreground', className)}
+						className={cn(
+							'h-10 w-full min-w-0 justify-start text-start font-normal py-1',
+							!date && 'text-muted-foreground',
+							triggerClassName,
+						)}
 						disabled={disabled}
 						type='button'>
 						<CalendarIcon className='me-2 h-4 w-4 shrink-0' />

--- a/src/components/molecules/QueryBuilder/FilterPopover.tsx
+++ b/src/components/molecules/QueryBuilder/FilterPopover.tsx
@@ -179,7 +179,7 @@ const FilterPopover: React.FC<Props> = ({ fields, value = [], onChange, classNam
 						date={filter.valueDate}
 						{...inputProps}
 						popoverContentClassName='w-full !z-[110]'
-						className={cn(inputProps.className, 'h-9 min-w-[182px] text-xs')}
+						className={cn(inputProps.className, 'h-9 text-xs')}
 						placeholder={t('queryBuilder.selectDate')}
 					/>
 				),

--- a/src/components/molecules/QueryBuilder/PropertyFilterPopover.tsx
+++ b/src/components/molecules/QueryBuilder/PropertyFilterPopover.tsx
@@ -179,7 +179,7 @@ const PropertyFilterPopover: React.FC<Props> = ({
 						date={filter.valueDate}
 						{...inputProps}
 						popoverContentClassName='w-full !z-[110]'
-						className={cn(inputProps.className, 'h-9 min-w-[182px] text-xs')}
+						className={cn(inputProps.className, 'h-9 text-xs')}
 						placeholder={t('queryBuilder.selectDate')}
 					/>
 				),


### PR DESCRIPTION
Fixes #852

## Summary
- Fixed date picker width alignment in filter popovers
- Added separate trigger styling support for DatePicker
- Improved spacing and consistency with other filter inputs

## Testing
- Verified Events filter popover locally
- Confirmed date picker no longer overlaps with delete action
- Ran production build successfully 


<img width="1920" height="922" alt="Screenshot (554)" src="https://github.com/user-attachments/assets/f21dd4ea-debd-48ac-a3e5-86bc0948265f" />
<img width="1907" height="898" alt="Screenshot (555)" src="https://github.com/user-attachments/assets/20fb7be6-ab53-41cb-886a-11d572daf83a" />

