### PR TITLE
feat(sandbox): add allowed environment types config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,11 @@ VITE_RESTRICTED_ENVS=
 #   VITE_ALLOWED_ENV_TYPES=["development","production"] — all types (same as empty)
 VITE_ALLOWED_ENV_TYPES=
 
+# Production dashboard URL shown as "Go to Production" link when in sandbox mode.
+# Only rendered when VITE_ALLOWED_ENV_TYPES=["development"] (sandbox mode active).
+# Example: VITE_PRODUCTION_URL=https://app.flexprice.io
+VITE_PRODUCTION_URL=
+
 # Typography — optional JSON: {"primary":"…","fallback":"…"} (see src/config/config.ts). Omitted = Qanelas (src/assets/fonts/qanelas) + system UI.
 # VITE_FONT_CONFIG={"primary":"Qanelas","fallback":"ui-sans-serif, system-ui, sans-serif"}
 # Latin / Google stack instead of Qanelas:

--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,11 @@ VITE_GOOGLE_SHEETS_WEB_APP_URL=
 # Restricted Envs (JSON: { [tenant_id]: { [env_id]: ISO date | "suspended" } })
 VITE_RESTRICTED_ENVS=
 
-# Allowed environment types shown in the sidebar switcher (comma-separated: development,production)
-# Empty = all types shown. Sandbox deployments set this to "development".
+# Allowed environment types shown in the sidebar switcher (JSON array of ENVIRONMENT_TYPE values)
+# Empty = all types shown. Examples:
+#   VITE_ALLOWED_ENV_TYPES=["development"]            — sandbox: only dev envs
+#   VITE_ALLOWED_ENV_TYPES=["production"]             — prod-only
+#   VITE_ALLOWED_ENV_TYPES=["development","production"] — all types (same as empty)
 VITE_ALLOWED_ENV_TYPES=
 
 # Typography — optional JSON: {"primary":"…","fallback":"…"} (see src/config/config.ts). Omitted = Qanelas (src/assets/fonts/qanelas) + system UI.

--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,10 @@ VITE_GOOGLE_SHEETS_WEB_APP_URL=
 # Restricted Envs (JSON: { [tenant_id]: { [env_id]: ISO date | "suspended" } })
 VITE_RESTRICTED_ENVS=
 
+# Allowed environment types shown in the sidebar switcher (comma-separated: development,production)
+# Empty = all types shown. Sandbox deployments set this to "development".
+VITE_ALLOWED_ENV_TYPES=
+
 # Typography — optional JSON: {"primary":"…","fallback":"…"} (see src/config/config.ts). Omitted = Qanelas (src/assets/fonts/qanelas) + system UI.
 # VITE_FONT_CONFIG={"primary":"Qanelas","fallback":"ui-sans-serif, system-ui, sans-serif"}
 # Latin / Google stack instead of Qanelas:

--- a/docs/superpowers/plans/2026-06-13-sandbox-allowed-env-types.md
+++ b/docs/superpowers/plans/2026-06-13-sandbox-allowed-env-types.md
@@ -1,0 +1,245 @@
+# Sandbox: Allowed Environment Types Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `VITE_ALLOWED_ENV_TYPES` config that filters which environment types appear in the sidebar environment switcher, so the sandbox deployment (`sandbox.flexprice.io`) can be configured to only show `development` environments.
+
+**Architecture:** A pure `parseAllowedEnvTypes()` function reads the env var and returns a typed array; this gets wired into `config.restrictions.allowedEnvTypes`. The `useEnvironment` hook applies the filter after fetching from the API. Empty = show all (backwards compatible).
+
+**Tech Stack:** React 18, TypeScript, Vite (`import.meta.env`), TanStack Query, Vitest
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/config/config.ts` | Add `allowedEnvTypes` to `RestrictionsConfig`, add + export `parseAllowedEnvTypes()` |
+| `src/config/config.allowedEnvTypes.test.ts` | New — unit tests for `parseAllowedEnvTypes()` |
+| `src/hooks/useEnvironment.ts` | Filter fetched environments by `config.restrictions.allowedEnvTypes` |
+| `.env.example` | Add `VITE_ALLOWED_ENV_TYPES=` with comment |
+
+---
+
+## Task 1: Add `parseAllowedEnvTypes` to config
+
+**Files:**
+- Modify: `src/config/config.ts`
+
+The `ENVIRONMENT_TYPE` enum lives in `src/models/Environment.ts` and is already imported via the `useEnvironment` hook. Import it in config.ts too, then add the interface field and parser.
+
+- [ ] **Step 1: Update `RestrictionsConfig` interface**
+
+In `src/config/config.ts`, find the `RestrictionsConfig` interface (currently has one field `rawEnvs: string`) and add the new field. Also add the import for `ENVIRONMENT_TYPE` at the top of the file:
+
+```ts
+// Add this import near the top of config.ts (after existing imports)
+import { ENVIRONMENT_TYPE } from '@/models/Environment';
+```
+
+Update the interface:
+
+```ts
+interface RestrictionsConfig {
+  rawEnvs: string;
+  allowedEnvTypes: ENVIRONMENT_TYPE[];  // [] means "show all"
+}
+```
+
+- [ ] **Step 2: Add `parseAllowedEnvTypes` function**
+
+Add this function in `src/config/config.ts`, right before the `export const config` block. Export it so it can be unit-tested:
+
+```ts
+export function parseAllowedEnvTypes(raw?: string): ENVIRONMENT_TYPE[] {
+  if (!raw?.trim()) return [];
+  const valid = new Set(Object.values(ENVIRONMENT_TYPE));
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => valid.has(s as ENVIRONMENT_TYPE)) as ENVIRONMENT_TYPE[];
+}
+```
+
+- [ ] **Step 3: Wire into `config.restrictions`**
+
+In the `export const config` block, update the `restrictions` field:
+
+```ts
+restrictions: {
+  rawEnvs: import.meta.env.VITE_RESTRICTED_ENVS ?? '',
+  allowedEnvTypes: parseAllowedEnvTypes(import.meta.env.VITE_ALLOWED_ENV_TYPES),
+},
+```
+
+---
+
+## Task 2: Unit tests for `parseAllowedEnvTypes`
+
+**Files:**
+- Create: `src/config/config.allowedEnvTypes.test.ts`
+
+- [ ] **Step 1: Write the tests**
+
+Create `src/config/config.allowedEnvTypes.test.ts` with this content:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { parseAllowedEnvTypes } from './config';
+import { ENVIRONMENT_TYPE } from '@/models/Environment';
+
+describe('parseAllowedEnvTypes', () => {
+  it('returns [] when raw is undefined', () => {
+    expect(parseAllowedEnvTypes(undefined)).toEqual([]);
+  });
+
+  it('returns [] when raw is empty string', () => {
+    expect(parseAllowedEnvTypes('')).toEqual([]);
+  });
+
+  it('returns [] when raw is only whitespace', () => {
+    expect(parseAllowedEnvTypes('   ')).toEqual([]);
+  });
+
+  it('parses a single valid type', () => {
+    expect(parseAllowedEnvTypes('development')).toEqual([ENVIRONMENT_TYPE.DEVELOPMENT]);
+  });
+
+  it('parses two valid types', () => {
+    const result = parseAllowedEnvTypes('development,production');
+    expect(result).toContain(ENVIRONMENT_TYPE.DEVELOPMENT);
+    expect(result).toContain(ENVIRONMENT_TYPE.PRODUCTION);
+    expect(result).toHaveLength(2);
+  });
+
+  it('trims whitespace around values', () => {
+    expect(parseAllowedEnvTypes(' development , production ')).toHaveLength(2);
+  });
+
+  it('silently drops unknown values', () => {
+    expect(parseAllowedEnvTypes('development,sandbox,unknown')).toEqual([ENVIRONMENT_TYPE.DEVELOPMENT]);
+  });
+
+  it('returns [] when all values are unknown', () => {
+    expect(parseAllowedEnvTypes('sandbox,bogus')).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect FAIL (function not yet exported or not yet written if doing TDD order)**
+
+```bash
+npx vitest run src/config/config.allowedEnvTypes.test.ts
+```
+
+If Task 1 is already done, they should PASS. If not, expect import errors.
+
+- [ ] **Step 3: Run tests — expect PASS**
+
+After Task 1 is complete:
+
+```bash
+npx vitest run src/config/config.allowedEnvTypes.test.ts
+```
+
+Expected output: all 8 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/config/config.ts src/config/config.allowedEnvTypes.test.ts
+git commit -m "feat(config): add parseAllowedEnvTypes and VITE_ALLOWED_ENV_TYPES support"
+```
+
+---
+
+## Task 3: Filter environments in `useEnvironment`
+
+**Files:**
+- Modify: `src/hooks/useEnvironment.ts`
+
+The hook currently returns all environments from the API. We filter by `config.restrictions.allowedEnvTypes` before deriving any state from the list. The active-env fallback (auto-select first) must also use the filtered list.
+
+- [ ] **Step 1: Add config import**
+
+At the top of `src/hooks/useEnvironment.ts`, add:
+
+```ts
+import { config } from '@/config/config';
+```
+
+(The `ENVIRONMENT_TYPE` import is already present via `import Environment, { ENVIRONMENT_TYPE } from '@/models/Environment';`)
+
+- [ ] **Step 2: Apply filter after fetching**
+
+In the `useQuery` block, the query function currently returns `res.environments`. Change the `queryFn` to filter before returning:
+
+```ts
+queryFn: async () => {
+  const res = await EnvironmentApi.getAllEnvironments();
+  const allowed = config.restrictions.allowedEnvTypes;
+  if (allowed.length === 0) return res.environments;
+  return res.environments.filter((env) => allowed.includes(env.type));
+},
+```
+
+This means `data` throughout the hook already contains only visible environments, so the `activeEnvId` fallback (`data[0].id`) and all derived values automatically use the filtered set. No other changes needed in the hook.
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useEnvironment.ts
+git commit -m "feat(environments): filter by allowedEnvTypes config"
+```
+
+---
+
+## Task 4: Update `.env.example`
+
+**Files:**
+- Modify: `.env.example`
+
+- [ ] **Step 1: Add the new variable**
+
+Open `.env.example` and add after the `VITE_RESTRICTED_ENVS` line:
+
+```bash
+# Allowed environment types shown in the sidebar switcher (comma-separated: development,production)
+# Empty = all types shown. Sandbox deployments set this to "development".
+VITE_ALLOWED_ENV_TYPES=
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .env.example
+git commit -m "chore(env): document VITE_ALLOWED_ENV_TYPES"
+```
+
+---
+
+## Verification
+
+- [ ] **Manual: prod-like (no filter)**
+
+  Set `VITE_ALLOWED_ENV_TYPES=` in your local `.env`. Start dev server (`npm run dev`). Open the sidebar environment switcher — both development and production environments should appear.
+
+- [ ] **Manual: sandbox mode**
+
+  Set `VITE_ALLOWED_ENV_TYPES=development` in your local `.env`. Restart dev server. Open the switcher — only `development`-type environments should appear. If your account only has production environments, the switcher should be empty (or show the "none available" message).
+
+- [ ] **Run full test suite**
+
+  ```bash
+  npx vitest run
+  ```
+
+  Expected: all existing tests pass plus the 8 new `parseAllowedEnvTypes` tests.

--- a/docs/superpowers/plans/2026-06-13-sandbox-ux.md
+++ b/docs/superpowers/plans/2026-06-13-sandbox-ux.md
@@ -1,0 +1,352 @@
+# Sandbox UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add sandbox mode UX (badge, production link, creator restriction) that activates automatically when `VITE_ALLOWED_ENV_TYPES=["development"]` and is completely invisible to all existing deployments.
+
+**Architecture:** A pure `isSandboxDeployment()` helper derives a boolean from the already-parsed `allowedEnvTypes` array; this boolean + `productionUrl` are stored in `config.restrictions` and consumed directly by the two UI components that need them. No new context, no new hooks.
+
+**Tech Stack:** React 18, TypeScript, Vite (`import.meta.env`), Tailwind CSS, Radix UI Select, Vitest
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/config/config.ts` | Add `isSandboxDeployment()` helper, extend `RestrictionsConfig`, wire into `config.restrictions` |
+| `src/config/config.allowedEnvTypes.test.ts` | Add `isSandboxDeployment` tests |
+| `src/components/molecules/EnvironmentSelector/EnvironmentSelector.tsx` | Sandbox badge + "Go to Production" link |
+| `src/components/molecules/EnvironmentCreator/EnvironmentCreator.tsx` | Filter type options to `allowedEnvTypes` in sandbox mode |
+| `.env.example` | Document `VITE_PRODUCTION_URL` |
+
+---
+
+## Task 1: `isSandboxDeployment` helper + config fields
+
+**Files:**
+- Modify: `src/config/config.ts`
+- Modify: `src/config/config.allowedEnvTypes.test.ts`
+
+### Step 1 — Add tests for `isSandboxDeployment`
+
+Add a new `describe` block at the bottom of `src/config/config.allowedEnvTypes.test.ts`. Update the import line to also import `isSandboxDeployment`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { parseAllowedEnvTypes, isSandboxDeployment } from './config';
+import { ENVIRONMENT_TYPE } from '@/models/Environment';
+```
+
+Append this block after the existing `parseAllowedEnvTypes` describe:
+
+```ts
+describe('isSandboxDeployment', () => {
+	it('returns false for empty array', () => {
+		expect(isSandboxDeployment([])).toBe(false);
+	});
+
+	it('returns true when only development', () => {
+		expect(isSandboxDeployment([ENVIRONMENT_TYPE.DEVELOPMENT])).toBe(true);
+	});
+
+	it('returns false when both types present', () => {
+		expect(isSandboxDeployment([ENVIRONMENT_TYPE.DEVELOPMENT, ENVIRONMENT_TYPE.PRODUCTION])).toBe(false);
+	});
+
+	it('returns false when only production', () => {
+		expect(isSandboxDeployment([ENVIRONMENT_TYPE.PRODUCTION])).toBe(false);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests — expect FAIL** (function not exported yet)
+
+```bash
+cd /Users/omkar/Developer/source-code/flexprice/flexprice-front && npx vitest run src/config/config.allowedEnvTypes.test.ts 2>&1 | tail -10
+```
+
+Expected: import error — `isSandboxDeployment` is not exported from `./config`.
+
+- [ ] **Step 3: Add `isSandboxDeployment` to `src/config/config.ts`**
+
+Add the exported helper immediately after the `parseAllowedEnvTypes` function (before `export const config`):
+
+```ts
+export function isSandboxDeployment(allowedEnvTypes: ENVIRONMENT_TYPE[]): boolean {
+	return allowedEnvTypes.length > 0 && allowedEnvTypes.every((t) => t === ENVIRONMENT_TYPE.DEVELOPMENT);
+}
+```
+
+- [ ] **Step 4: Extend `RestrictionsConfig` interface**
+
+Find the `RestrictionsConfig` interface (currently has `rawEnvs` and `allowedEnvTypes`) and add the two new fields:
+
+```ts
+interface RestrictionsConfig {
+	rawEnvs: string;
+	allowedEnvTypes: ENVIRONMENT_TYPE[]; // [] means "show all"
+	isSandboxMode: boolean; // true only when allowedEnvTypes === ["development"]
+	productionUrl: string; // from VITE_PRODUCTION_URL; '' when unset
+}
+```
+
+- [ ] **Step 5: Extract `allowedEnvTypes` const and wire into `config.restrictions`**
+
+The current `restrictions` block in `export const config` calls `parseAllowedEnvTypes` inline. Extract it to a module-level const (like `appEnv` above) so it can be reused without calling the function twice, then add the two new fields:
+
+Replace the current `restrictions` block:
+```ts
+// Before the export const config block, add:
+const allowedEnvTypes = parseAllowedEnvTypes(import.meta.env.VITE_ALLOWED_ENV_TYPES);
+```
+
+Update the `restrictions` field in `export const config`:
+```ts
+restrictions: {
+	rawEnvs: import.meta.env.VITE_RESTRICTED_ENVS ?? '',
+	allowedEnvTypes,
+	isSandboxMode: isSandboxDeployment(allowedEnvTypes),
+	productionUrl: import.meta.env.VITE_PRODUCTION_URL ?? '',
+},
+```
+
+- [ ] **Step 6: Run tests — expect all pass**
+
+```bash
+cd /Users/omkar/Developer/source-code/flexprice/flexprice-front && npx vitest run src/config/config.allowedEnvTypes.test.ts 2>&1 | tail -10
+```
+
+Expected: 13 tests pass (9 existing + 4 new).
+
+- [ ] **Step 7: Verify TypeScript**
+
+```bash
+cd /Users/omkar/Developer/source-code/flexprice/flexprice-front && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/omkar/Developer/source-code/flexprice/flexprice-front && git add src/config/config.ts src/config/config.allowedEnvTypes.test.ts && git commit -m "feat(config): add isSandboxDeployment helper and isSandboxMode/productionUrl to config"
+```
+
+---
+
+## Task 2: Sandbox badge + "Go to Production" link in `EnvironmentSelector`
+
+**Files:**
+- Modify: `src/components/molecules/EnvironmentSelector/EnvironmentSelector.tsx`
+
+The component already imports `config` indirectly via `useEnvironment`. Add a direct import and read `isSandboxMode` and `productionUrl` from it. Then add two conditional renders — no structural changes to existing JSX.
+
+- [ ] **Step 1: Add `config` import**
+
+At the top of `src/components/molecules/EnvironmentSelector/EnvironmentSelector.tsx`, add after the existing imports:
+
+```ts
+import { config } from '@/config/config';
+```
+
+- [ ] **Step 2: Read sandbox config at top of component**
+
+Inside `EnvironmentSelector` (after the existing `const { environments, ... } = useEnvironment()` line), add:
+
+```ts
+const { isSandboxMode, productionUrl } = config.restrictions;
+```
+
+- [ ] **Step 3: Add the sandbox badge**
+
+The badge goes between the closing `</div>` of the tenant row and the opening `<Select>` tag. The current JSX structure is:
+
+```tsx
+{/* Tenant */}
+<div className='w-full mt-2 flex items-center justify-between gap-2'>
+  ...
+</div>
+
+{/* Environment picker (colored box) */}
+<Select ...>
+```
+
+Insert the badge between them:
+
+```tsx
+{/* Sandbox mode badge */}
+{isSandboxMode && sidebarOpen && (
+  <div className='mt-2 flex items-center gap-1.5 px-1'>
+    <span className='h-1.5 w-1.5 rounded-full bg-amber-500 shrink-0' />
+    <span className='text-[11px] font-semibold uppercase tracking-widest text-amber-700'>Sandbox</span>
+  </div>
+)}
+```
+
+`sidebarOpen` is already destructured from `useSidebar()` at the top of the component — hide the badge when the sidebar is collapsed (icon-only mode) to avoid layout overflow.
+
+- [ ] **Step 4: Add the "Go to Production" link**
+
+Inside `SelectContent`, after the closing `</div>` of the Add/Copy buttons block (the `<div className='flex flex-col gap-1.5 m-2 ...'>` block), add:
+
+```tsx
+{isSandboxMode && productionUrl && (
+  <a
+    href={productionUrl}
+    className='flex items-center justify-center gap-1.5 mx-2 mb-2 text-xs text-muted-foreground hover:text-foreground transition-colors py-1.5 border-t border-border pt-2'
+  >
+    <ExternalLink className='h-3 w-3' />
+    Go to Production
+  </a>
+)}
+```
+
+Add `ExternalLink` to the existing lucide-react import line:
+
+```ts
+import { Blocks, Rocket, Server, ChevronsUpDown, Plus, Copy, Pencil, ExternalLink } from 'lucide-react';
+```
+
+- [ ] **Step 5: Verify TypeScript**
+
+```bash
+cd /Users/omkar/Developer/source-code/flexprice/flexprice-front && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/omkar/Developer/source-code/flexprice/flexprice-front && git add src/components/molecules/EnvironmentSelector/EnvironmentSelector.tsx && git commit -m "feat(sandbox): add sandbox badge and production link to EnvironmentSelector"
+```
+
+---
+
+## Task 3: Filter `EnvironmentCreator` type options in sandbox mode
+
+**Files:**
+- Modify: `src/components/molecules/EnvironmentCreator/EnvironmentCreator.tsx`
+
+When `isSandboxMode` is true, filter the type options to only those in `allowedEnvTypes`. If only one type remains, hide the `<Select>` entirely (the type state already defaults to `ENVIRONMENT_TYPE.DEVELOPMENT` which is correct for sandbox).
+
+- [ ] **Step 1: Add `config` import**
+
+Add after existing imports in `src/components/molecules/EnvironmentCreator/EnvironmentCreator.tsx`:
+
+```ts
+import { config } from '@/config/config';
+```
+
+- [ ] **Step 2: Read sandbox config at top of component**
+
+Inside `EnvironmentCreator`, after the `const queryClient = useQueryClient();` line, add:
+
+```ts
+const { isSandboxMode, allowedEnvTypes } = config.restrictions;
+```
+
+- [ ] **Step 3: Update `environmentTypeOptions` useMemo to filter by `allowedEnvTypes`**
+
+The current `useMemo` always returns both options. Replace it with a version that filters when `isSandboxMode`:
+
+```ts
+const environmentTypeOptions = useMemo(() => {
+	const allOptions = [
+		{
+			value: ENVIRONMENT_TYPE.DEVELOPMENT,
+			label: t('environment.types.sandbox'),
+			description: t('environment.types.sandboxDescription'),
+		},
+		{
+			value: ENVIRONMENT_TYPE.PRODUCTION,
+			label: t('environment.types.production'),
+			description: t('environment.types.productionDescription'),
+		},
+	];
+	if (!isSandboxMode || allowedEnvTypes.length === 0) return allOptions;
+	return allOptions.filter((opt) => allowedEnvTypes.includes(opt.value as ENVIRONMENT_TYPE));
+}, [isSandboxMode, allowedEnvTypes, t]);
+```
+
+- [ ] **Step 4: Hide type `<Select>` when only one option**
+
+Find the `<Select>` for the environment type (the one with `label={t('environment.creator.typeLabel')}`). Wrap it in a conditional so it only renders when there are multiple choices:
+
+```tsx
+{environmentTypeOptions.length > 1 && (
+  <Select
+    label={t('environment.creator.typeLabel')}
+    placeholder={t('environment.creator.typePlaceholder')}
+    options={environmentTypeOptions}
+    value={type}
+    onChange={(value) => setType(value as ENVIRONMENT_TYPE)}
+    disabled={isPending}
+  />
+)}
+```
+
+- [ ] **Step 5: Verify TypeScript**
+
+```bash
+cd /Users/omkar/Developer/source-code/flexprice/flexprice-front && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/omkar/Developer/source-code/flexprice/flexprice-front && git add src/components/molecules/EnvironmentCreator/EnvironmentCreator.tsx && git commit -m "feat(sandbox): restrict EnvironmentCreator type options to allowedEnvTypes in sandbox mode"
+```
+
+---
+
+## Task 4: Document `VITE_PRODUCTION_URL` in `.env.example`
+
+**Files:**
+- Modify: `.env.example`
+
+- [ ] **Step 1: Add the new variable**
+
+Open `.env.example` and find the `VITE_ALLOWED_ENV_TYPES=` block. Add the following immediately after it:
+
+```bash
+# Production dashboard URL shown as "Go to Production" link when in sandbox mode.
+# Only rendered when VITE_ALLOWED_ENV_TYPES=["development"] (sandbox mode active).
+# Example: VITE_PRODUCTION_URL=https://app.flexprice.io
+VITE_PRODUCTION_URL=
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/omkar/Developer/source-code/flexprice/flexprice-front && git add .env.example && git commit -m "chore(env): document VITE_PRODUCTION_URL"
+```
+
+---
+
+## Verification
+
+- [ ] **Run full test suite**
+
+```bash
+cd /Users/omkar/Developer/source-code/flexprice/flexprice-front && npx vitest run 2>&1 | tail -8
+```
+
+Expected: 13 tests pass in `config.allowedEnvTypes.test.ts`; no new failures introduced.
+
+- [ ] **Manual: sandbox mode on**
+
+In your local `.env`, set:
+```
+VITE_ALLOWED_ENV_TYPES=["development"]
+VITE_PRODUCTION_URL=https://app.flexprice.io
+```
+
+Restart dev server (`npm run dev`). Open sidebar — amber "Sandbox" dot + label should appear below the tenant name. Open the env picker dropdown — "Go to Production" link should appear at the bottom. Open "Add Environment" — the type selector should be hidden (development is the only option, silently selected).
+
+- [ ] **Manual: sandbox mode off (backwards compat)**
+
+Set `VITE_ALLOWED_ENV_TYPES=` (empty). Restart. No badge, no production link, type selector shows both options as before.

--- a/docs/superpowers/specs/2026-06-13-sandbox-allowed-env-types-design.md
+++ b/docs/superpowers/specs/2026-06-13-sandbox-allowed-env-types-design.md
@@ -1,0 +1,63 @@
+# Sandbox: Allowed Environment Types Config
+
+**Date:** 2026-06-13  
+**Branch:** feat/sandbox  
+**Status:** Approved
+
+## Problem
+
+Flexprice is introducing a sandbox deployment at `sandbox.flexprice.io` (API: `sandbox.api.flexprice.io`). The sandbox deployment should only surface `development`-type environments in the environment switcher — production environments must not appear there. The production deployment continues to show all environment types.
+
+## Solution
+
+A new build-time env var `VITE_ALLOWED_ENV_TYPES` declares which `ENVIRONMENT_TYPE` values are visible in the UI. If unset or empty, all types are shown (fully backwards-compatible). The filter is applied once in `useEnvironment` so every consumer automatically sees the filtered list.
+
+## Config
+
+**`VITE_ALLOWED_ENV_TYPES`** — comma-separated list of `ENVIRONMENT_TYPE` values.
+
+| Deployment | Value |
+|------------|-------|
+| Sandbox (`sandbox.flexprice.io`) | `development` |
+| Production | `` (empty — show all) |
+
+Parsing: split on `,`, trim whitespace, cast to `ENVIRONMENT_TYPE[]`. Invalid values are silently dropped.
+
+## Changes
+
+### `src/config/config.ts`
+
+- Add `allowedEnvTypes: ENVIRONMENT_TYPE[]` to `RestrictionsConfig`.
+- Add `parseAllowedEnvTypes()` that reads `VITE_ALLOWED_ENV_TYPES`. Returns `[]` (allow all) when the var is absent or empty.
+- Wire into `config.restrictions.allowedEnvTypes`.
+
+### `src/hooks/useEnvironment.ts`
+
+- After fetching environments from the API, apply the filter:
+  ```ts
+  const allowed = config.restrictions.allowedEnvTypes;
+  const visible = allowed.length === 0
+    ? data
+    : data.filter(env => allowed.includes(env.type));
+  ```
+- The `activeEnvId` fallback (auto-select first env on load / when stored id is invalid) runs against `visible`, not the raw list — prevents a sandbox deployment from ever activating a prod environment.
+- All return values (`environments`, `activeEnvironment`, `isDevelopment`, `isProduction`) are derived from the filtered set.
+
+### `.env.example`
+
+Add the new variable with a comment:
+```bash
+# Allowed environment types (comma-separated: development,production)
+# Empty = all types shown. Sandbox deployments set this to "development".
+VITE_ALLOWED_ENV_TYPES=
+```
+
+## Out of Scope
+
+- `EnvironmentCopier` — intentionally unchanged; it continues to show all environment types regardless of the allowed-types config.
+- API URL routing — `VITE_API_URL` is set per-deployment in infrastructure config, not managed here.
+- Backend enforcement — the backend validates that sandbox API calls don't hit prod environments; that is a backend concern.
+
+## Backwards Compatibility
+
+`VITE_ALLOWED_ENV_TYPES` defaults to empty → all environments shown → zero behaviour change for existing deployments.

--- a/docs/superpowers/specs/2026-06-13-sandbox-ux-design.md
+++ b/docs/superpowers/specs/2026-06-13-sandbox-ux-design.md
@@ -1,0 +1,105 @@
+# Sandbox UX Features Design
+
+**Date:** 2026-06-13
+**Branch:** feat/sandbox
+**Status:** Approved
+
+## Problem
+
+`sandbox.flexprice.io` users have no visual signal they are in sandbox mode, can accidentally try to create production environments, and have no one-click path back to production. All UX changes must be zero-impact for existing prod deployments.
+
+## Activation
+
+Sandbox UX is **derived automatically** from `VITE_ALLOWED_ENV_TYPES`. No extra flag needed.
+
+```
+isSandboxMode = allowedEnvTypes.length > 0
+             && allowedEnvTypes.every(t => t === ENVIRONMENT_TYPE.DEVELOPMENT)
+```
+
+| `VITE_ALLOWED_ENV_TYPES` | `isSandboxMode` | Effect |
+|---|---|---|
+| *(empty / unset)* | `false` | no change — existing behaviour |
+| `["development","production"]` | `false` | no change |
+| `["production"]` | `false` | no change |
+| `["development"]` | `true` | sandbox UX active |
+
+Existing deployments that do not set `VITE_ALLOWED_ENV_TYPES` are completely unaffected.
+
+## Config Changes — `src/config/config.ts`
+
+Add two fields to `RestrictionsConfig`:
+
+```ts
+interface RestrictionsConfig {
+  rawEnvs: string;
+  allowedEnvTypes: ENVIRONMENT_TYPE[];
+  isSandboxMode: boolean;   // derived — true only when allowedEnvTypes === ["development"]
+  productionUrl: string;    // from VITE_PRODUCTION_URL; empty string when unset
+}
+```
+
+Wire in `config.restrictions`:
+```ts
+restrictions: {
+  rawEnvs: ...,
+  allowedEnvTypes: parseAllowedEnvTypes(import.meta.env.VITE_ALLOWED_ENV_TYPES),
+  isSandboxMode: isSandboxDeployment(parseAllowedEnvTypes(import.meta.env.VITE_ALLOWED_ENV_TYPES)),
+  productionUrl: import.meta.env.VITE_PRODUCTION_URL ?? '',
+},
+```
+
+Add pure helper (export for testing):
+```ts
+export function isSandboxDeployment(allowedEnvTypes: ENVIRONMENT_TYPE[]): boolean {
+  return allowedEnvTypes.length > 0 &&
+    allowedEnvTypes.every((t) => t === ENVIRONMENT_TYPE.DEVELOPMENT);
+}
+```
+
+## Feature 1 — Sandbox Badge (`EnvironmentSelector`)
+
+When `config.restrictions.isSandboxMode` is `true`, render an amber chip between the tenant row and the env picker inside `EnvironmentSelector`. When `false`, render nothing (no DOM node).
+
+Placement (within existing component layout):
+```
+[FP] Flexprice          ← existing tenant row
+● SANDBOX               ← new amber chip, isSandboxMode only
+[⬡ My Dev Env    ⌄]   ← existing env picker
+```
+
+Chip style: small amber pill consistent with the existing dev-environment yellow palette (`text-amber-700 bg-amber-50 border-amber-300`).
+
+## Feature 2 — "Go to Production" Link (`EnvironmentSelector`)
+
+When `isSandboxMode === true` AND `config.restrictions.productionUrl` is non-empty, render a subtle "Go to Production →" anchor at the bottom of the env picker `SelectContent` dropdown (below the existing Add / Copy buttons).
+
+Clicking navigates to `productionUrl` in the **same tab** (`window.location.href = productionUrl`) — it is a domain switch, not a supplementary page.
+
+If either condition is false, the link does not render. No broken or loading state needed.
+
+## Feature 3 — `EnvironmentCreator` Type Selector Filtered
+
+When `isSandboxMode === true`, filter `environmentTypeOptions` to only include types present in `config.restrictions.allowedEnvTypes`. If only one type remains after filtering, hide the type `<Select>` entirely and keep the internal state defaulted to that single type.
+
+When `isSandboxMode === false`: no change — full type list as today.
+
+## `.env.example`
+
+Add after `VITE_ALLOWED_ENV_TYPES`:
+```bash
+# Production dashboard URL shown as "Go to Production" link in sandbox mode.
+# Only used when VITE_ALLOWED_ENV_TYPES=["development"] (sandbox mode active).
+VITE_PRODUCTION_URL=
+```
+
+## Out of Scope
+
+- `EnvironmentCopier` — intentionally unchanged (shows all types regardless of mode)
+- Page `<title>` prefix — left for a future iteration
+- Analytics isolation — already handled by `config.app.isProd` in `MainLayout`
+- Any routing or API changes
+
+## Backwards Compatibility
+
+All three features are guarded by `isSandboxMode`, which is `false` whenever `VITE_ALLOWED_ENV_TYPES` is absent or contains more than just `["development"]`. Existing prod deployments see zero change.

--- a/src/components/molecules/EnvironmentCreator/EnvironmentCreator.tsx
+++ b/src/components/molecules/EnvironmentCreator/EnvironmentCreator.tsx
@@ -8,6 +8,7 @@ import EnvironmentApi from '@/api/EnvironmentApi';
 import toast from 'react-hot-toast';
 import { Mail, CalendarDays, AlertTriangle } from 'lucide-react';
 import { SANDBOX_AUTO_CANCELLATION_DAYS } from '@/constants/constants';
+import { config } from '@/config/config';
 
 interface Props {
 	isOpen: boolean;
@@ -20,6 +21,7 @@ const EnvironmentCreator: React.FC<Props> = ({ isOpen, onOpenChange, onEnvironme
 	const [name, setName] = useState('');
 	const [type, setType] = useState<ENVIRONMENT_TYPE>(ENVIRONMENT_TYPE.DEVELOPMENT);
 	const queryClient = useQueryClient();
+	const { isSandboxMode, allowedEnvTypes } = config.restrictions;
 
 	useEffect(() => {
 		if (isOpen) {
@@ -28,8 +30,8 @@ const EnvironmentCreator: React.FC<Props> = ({ isOpen, onOpenChange, onEnvironme
 		}
 	}, [isOpen, t]);
 
-	const environmentTypeOptions = useMemo(
-		() => [
+	const environmentTypeOptions = useMemo(() => {
+		const allOptions = [
 			{
 				value: ENVIRONMENT_TYPE.DEVELOPMENT,
 				label: t('environment.types.sandbox'),
@@ -40,9 +42,10 @@ const EnvironmentCreator: React.FC<Props> = ({ isOpen, onOpenChange, onEnvironme
 				label: t('environment.types.production'),
 				description: t('environment.types.productionDescription'),
 			},
-		],
-		[t],
-	);
+		];
+		if (!isSandboxMode || allowedEnvTypes.length === 0) return allOptions;
+		return allOptions.filter((opt) => allowedEnvTypes.includes(opt.value as ENVIRONMENT_TYPE));
+	}, [isSandboxMode, allowedEnvTypes, t]);
 
 	const { mutate: createEnvironment, isPending } = useMutation({
 		mutationFn: async (payload: CreateEnvironmentPayload) => {
@@ -110,14 +113,16 @@ const EnvironmentCreator: React.FC<Props> = ({ isOpen, onOpenChange, onEnvironme
 					disabled={isPending || isProduction}
 				/>
 
-				<Select
-					label={t('environment.creator.typeLabel')}
-					placeholder={t('environment.creator.typePlaceholder')}
-					options={environmentTypeOptions}
-					value={type}
-					onChange={(value) => setType(value as ENVIRONMENT_TYPE)}
-					disabled={isPending}
-				/>
+				{environmentTypeOptions.length > 1 && (
+					<Select
+						label={t('environment.creator.typeLabel')}
+						placeholder={t('environment.creator.typePlaceholder')}
+						options={environmentTypeOptions}
+						value={type}
+						onChange={(value) => setType(value as ENVIRONMENT_TYPE)}
+						disabled={isPending}
+					/>
+				)}
 
 				{/* Sandbox Note */}
 				{isSandbox && (

--- a/src/components/molecules/EnvironmentSelector/EnvironmentSelector.tsx
+++ b/src/components/molecules/EnvironmentSelector/EnvironmentSelector.tsx
@@ -152,7 +152,7 @@ const EnvironmentSelector: React.FC<Props> = ({ disabled = false, className }) =
 			{isSandboxMode && sidebarOpen && (
 				<div className='mt-2 flex items-center gap-1.5 px-1'>
 					<span className='h-1.5 w-1.5 rounded-full bg-amber-500 shrink-0' />
-					<span className='text-[11px] font-semibold uppercase tracking-widest text-amber-700'>Sandbox</span>
+					<span className='text-[11px] font-semibold uppercase tracking-widest text-amber-700'>{t('environment.types.sandbox')}</span>
 				</div>
 			)}
 
@@ -234,10 +234,9 @@ const EnvironmentSelector: React.FC<Props> = ({ disabled = false, className }) =
 					{isSandboxMode && productionUrl && (
 						<a
 							href={productionUrl}
-							className='flex items-center justify-center gap-1.5 mx-2 mb-2 text-xs text-muted-foreground hover:text-foreground transition-colors py-1.5 border-t border-border pt-2'
-						>
+							className='flex items-center justify-center gap-1.5 mx-2 mb-2 text-xs text-muted-foreground hover:text-foreground transition-colors py-1.5 border-t border-border pt-2'>
 							<ExternalLink className='h-3 w-3' />
-							Go to Production
+							{t('environment.selector.goToProduction')}
 						</a>
 					)}
 				</SelectContent>

--- a/src/components/molecules/EnvironmentSelector/EnvironmentSelector.tsx
+++ b/src/components/molecules/EnvironmentSelector/EnvironmentSelector.tsx
@@ -2,7 +2,7 @@ import { cn } from '@/lib/utils';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Skeleton } from '@/components/ui';
-import { Blocks, Rocket, Server, ChevronsUpDown, Plus, Copy, Pencil } from 'lucide-react';
+import { Blocks, Rocket, Server, ChevronsUpDown, Plus, Copy, Pencil, ExternalLink } from 'lucide-react';
 import { useGlobalLoading } from '@/core/services/tanstack/ReactQueryProvider';
 import useUser from '@/hooks/useUser';
 import { Select, SelectContent, useSidebar } from '@/components/ui';
@@ -18,6 +18,7 @@ import EnvironmentCopier from '../EnvironmentCopier/EnvironmentCopier';
 import EnvironmentEditor from '../EnvironmentEditor/EnvironmentEditor';
 import ContactUsDialog from '../ContactUsDialog/ContactUsDialog';
 import Environment, { ENVIRONMENT_TYPE } from '@/models/Environment';
+import { config } from '@/config/config';
 
 interface Props {
 	disabled?: boolean;
@@ -73,6 +74,7 @@ const EnvironmentSelector: React.FC<Props> = ({ disabled = false, className }) =
 
 	const { environments, activeEnvironment, changeActiveEnvironment, refetchEnvironments, isDevelopment, isProduction } = useEnvironment();
 	const { getRestriction } = useRestrictedEnvs();
+	const { isSandboxMode, productionUrl } = config.restrictions;
 
 	const [isOpen, setIsOpen] = useState(false);
 	const [isCreatorOpen, setIsCreatorOpen] = useState(false);
@@ -145,6 +147,14 @@ const EnvironmentSelector: React.FC<Props> = ({ disabled = false, className }) =
 					</div>
 				</div>
 			</div>
+
+			{/* Sandbox mode badge */}
+			{isSandboxMode && sidebarOpen && (
+				<div className='mt-2 flex items-center gap-1.5 px-1'>
+					<span className='h-1.5 w-1.5 rounded-full bg-amber-500 shrink-0' />
+					<span className='text-[11px] font-semibold uppercase tracking-widest text-amber-700'>Sandbox</span>
+				</div>
+			)}
 
 			{/* Environment picker (colored box) */}
 			<Select open={isOpen} onOpenChange={setIsOpen} value={activeEnvironment?.id} onValueChange={handleChange} disabled={disabled}>
@@ -221,6 +231,15 @@ const EnvironmentSelector: React.FC<Props> = ({ disabled = false, className }) =
 							{t('environment.selector.copyEnvironment')}
 						</Button>
 					</div>
+					{isSandboxMode && productionUrl && (
+						<a
+							href={productionUrl}
+							className='flex items-center justify-center gap-1.5 mx-2 mb-2 text-xs text-muted-foreground hover:text-foreground transition-colors py-1.5 border-t border-border pt-2'
+						>
+							<ExternalLink className='h-3 w-3' />
+							Go to Production
+						</a>
+					)}
 				</SelectContent>
 			</Select>
 

--- a/src/config/config.allowedEnvTypes.test.ts
+++ b/src/config/config.allowedEnvTypes.test.ts
@@ -31,7 +31,7 @@ describe('parseAllowedEnvTypes', () => {
 	});
 
 	it('silently drops unknown values', () => {
-		expect(parseAllowedEnvTypes('development,sandbox,unknown')).toEqual([ENVIRONMENT_TYPE.DEVELOPMENT]);
+		expect(parseAllowedEnvTypes('development,bogus,invalid')).toEqual([ENVIRONMENT_TYPE.DEVELOPMENT]);
 	});
 
 	it('returns [] when all values are unknown', () => {

--- a/src/config/config.allowedEnvTypes.test.ts
+++ b/src/config/config.allowedEnvTypes.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { parseAllowedEnvTypes } from './config';
+import { ENVIRONMENT_TYPE } from '@/models/Environment';
+
+describe('parseAllowedEnvTypes', () => {
+	it('returns [] when raw is undefined', () => {
+		expect(parseAllowedEnvTypes(undefined)).toEqual([]);
+	});
+
+	it('returns [] when raw is empty string', () => {
+		expect(parseAllowedEnvTypes('')).toEqual([]);
+	});
+
+	it('returns [] when raw is only whitespace', () => {
+		expect(parseAllowedEnvTypes('   ')).toEqual([]);
+	});
+
+	it('parses a single valid type', () => {
+		expect(parseAllowedEnvTypes('development')).toEqual([ENVIRONMENT_TYPE.DEVELOPMENT]);
+	});
+
+	it('parses two valid types', () => {
+		const result = parseAllowedEnvTypes('development,production');
+		expect(result).toContain(ENVIRONMENT_TYPE.DEVELOPMENT);
+		expect(result).toContain(ENVIRONMENT_TYPE.PRODUCTION);
+		expect(result).toHaveLength(2);
+	});
+
+	it('trims whitespace around values', () => {
+		expect(parseAllowedEnvTypes(' development , production ')).toHaveLength(2);
+	});
+
+	it('silently drops unknown values', () => {
+		expect(parseAllowedEnvTypes('development,sandbox,unknown')).toEqual([ENVIRONMENT_TYPE.DEVELOPMENT]);
+	});
+
+	it('returns [] when all values are unknown', () => {
+		expect(parseAllowedEnvTypes('sandbox,bogus')).toEqual([]);
+	});
+});

--- a/src/config/config.allowedEnvTypes.test.ts
+++ b/src/config/config.allowedEnvTypes.test.ts
@@ -16,25 +16,29 @@ describe('parseAllowedEnvTypes', () => {
 	});
 
 	it('parses a single valid type', () => {
-		expect(parseAllowedEnvTypes('development')).toEqual([ENVIRONMENT_TYPE.DEVELOPMENT]);
+		expect(parseAllowedEnvTypes('["development"]')).toEqual([ENVIRONMENT_TYPE.DEVELOPMENT]);
 	});
 
 	it('parses two valid types', () => {
-		const result = parseAllowedEnvTypes('development,production');
+		const result = parseAllowedEnvTypes('["development","production"]');
 		expect(result).toContain(ENVIRONMENT_TYPE.DEVELOPMENT);
 		expect(result).toContain(ENVIRONMENT_TYPE.PRODUCTION);
 		expect(result).toHaveLength(2);
 	});
 
-	it('trims whitespace around values', () => {
-		expect(parseAllowedEnvTypes(' development , production ')).toHaveLength(2);
-	});
-
 	it('silently drops unknown values', () => {
-		expect(parseAllowedEnvTypes('development,bogus,invalid')).toEqual([ENVIRONMENT_TYPE.DEVELOPMENT]);
+		expect(parseAllowedEnvTypes('["development","bogus","invalid"]')).toEqual([ENVIRONMENT_TYPE.DEVELOPMENT]);
 	});
 
 	it('returns [] when all values are unknown', () => {
-		expect(parseAllowedEnvTypes('sandbox,bogus')).toEqual([]);
+		expect(parseAllowedEnvTypes('["sandbox","bogus"]')).toEqual([]);
+	});
+
+	it('returns [] for invalid JSON', () => {
+		expect(parseAllowedEnvTypes('development,production')).toEqual([]);
+	});
+
+	it('returns [] when JSON is not an array', () => {
+		expect(parseAllowedEnvTypes('"development"')).toEqual([]);
 	});
 });

--- a/src/config/config.allowedEnvTypes.test.ts
+++ b/src/config/config.allowedEnvTypes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseAllowedEnvTypes } from './config';
+import { parseAllowedEnvTypes, isSandboxDeployment } from './config';
 import { ENVIRONMENT_TYPE } from '@/models/Environment';
 
 describe('parseAllowedEnvTypes', () => {
@@ -40,5 +40,23 @@ describe('parseAllowedEnvTypes', () => {
 
 	it('returns [] when JSON is not an array', () => {
 		expect(parseAllowedEnvTypes('"development"')).toEqual([]);
+	});
+});
+
+describe('isSandboxDeployment', () => {
+	it('returns false for empty array', () => {
+		expect(isSandboxDeployment([])).toBe(false);
+	});
+
+	it('returns true when only development', () => {
+		expect(isSandboxDeployment([ENVIRONMENT_TYPE.DEVELOPMENT])).toBe(true);
+	});
+
+	it('returns false when both types present', () => {
+		expect(isSandboxDeployment([ENVIRONMENT_TYPE.DEVELOPMENT, ENVIRONMENT_TYPE.PRODUCTION])).toBe(false);
+	});
+
+	it('returns false when only production', () => {
+		expect(isSandboxDeployment([ENVIRONMENT_TYPE.PRODUCTION])).toBe(false);
 	});
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -11,6 +11,7 @@ import {
 	Locale,
 } from './branding';
 import { RegionsConfig } from './authTemplates';
+import { ENVIRONMENT_TYPE } from '@/models/Environment';
 
 export type { BrandConfig, AuthPageConfig, I18nConfig };
 
@@ -66,6 +67,7 @@ interface IntegrationsConfig {
 }
 interface RestrictionsConfig {
 	rawEnvs: string;
+	allowedEnvTypes: ENVIRONMENT_TYPE[]; // [] means "show all"
 }
 
 /** Primary defaults to **Geist** (Google Fonts in `src/index.css`). Override via `VITE_FONT_CONFIG`. */
@@ -141,6 +143,15 @@ function parseAppEnv(): APP_ENV {
 
 const appEnv = parseAppEnv();
 
+export function parseAllowedEnvTypes(raw?: string): ENVIRONMENT_TYPE[] {
+	if (!raw?.trim()) return [];
+	const valid = new Set(Object.values(ENVIRONMENT_TYPE));
+	return raw
+		.split(',')
+		.map((s) => s.trim())
+		.filter((s) => valid.has(s as ENVIRONMENT_TYPE)) as ENVIRONMENT_TYPE[];
+}
+
 export const config: Config = {
 	app: {
 		env: appEnv,
@@ -182,6 +193,7 @@ export const config: Config = {
 	},
 	restrictions: {
 		rawEnvs: import.meta.env.VITE_RESTRICTED_ENVS ?? '',
+		allowedEnvTypes: parseAllowedEnvTypes(import.meta.env.VITE_ALLOWED_ENV_TYPES),
 	},
 	brand: brandConfig,
 	authPage: authPageConfig,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -145,11 +145,14 @@ const appEnv = parseAppEnv();
 
 export function parseAllowedEnvTypes(raw?: string): ENVIRONMENT_TYPE[] {
 	if (!raw?.trim()) return [];
-	const valid = new Set(Object.values(ENVIRONMENT_TYPE));
-	return raw
-		.split(',')
-		.map((s) => s.trim())
-		.filter((s): s is ENVIRONMENT_TYPE => valid.has(s as ENVIRONMENT_TYPE));
+	try {
+		const parsed = JSON.parse(raw) as unknown;
+		if (!Array.isArray(parsed)) return [];
+		const valid = new Set(Object.values(ENVIRONMENT_TYPE));
+		return parsed.filter((s): s is ENVIRONMENT_TYPE => typeof s === 'string' && valid.has(s as ENVIRONMENT_TYPE));
+	} catch {
+		return [];
+	}
 }
 
 export const config: Config = {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -68,6 +68,8 @@ interface IntegrationsConfig {
 interface RestrictionsConfig {
 	rawEnvs: string;
 	allowedEnvTypes: ENVIRONMENT_TYPE[]; // [] means "show all"
+	isSandboxMode: boolean; // true only when allowedEnvTypes === ["development"]
+	productionUrl: string; // from VITE_PRODUCTION_URL; '' when unset
 }
 
 /** Primary defaults to **Geist** (Google Fonts in `src/index.css`). Override via `VITE_FONT_CONFIG`. */
@@ -155,6 +157,12 @@ export function parseAllowedEnvTypes(raw?: string): ENVIRONMENT_TYPE[] {
 	}
 }
 
+export function isSandboxDeployment(allowedEnvTypes: ENVIRONMENT_TYPE[]): boolean {
+	return allowedEnvTypes.length > 0 && allowedEnvTypes.every((t) => t === ENVIRONMENT_TYPE.DEVELOPMENT);
+}
+
+const allowedEnvTypes = parseAllowedEnvTypes(import.meta.env.VITE_ALLOWED_ENV_TYPES);
+
 export const config: Config = {
 	app: {
 		env: appEnv,
@@ -196,7 +204,9 @@ export const config: Config = {
 	},
 	restrictions: {
 		rawEnvs: import.meta.env.VITE_RESTRICTED_ENVS ?? '',
-		allowedEnvTypes: parseAllowedEnvTypes(import.meta.env.VITE_ALLOWED_ENV_TYPES),
+		allowedEnvTypes,
+		isSandboxMode: isSandboxDeployment(allowedEnvTypes),
+		productionUrl: import.meta.env.VITE_PRODUCTION_URL ?? '',
 	},
 	brand: brandConfig,
 	authPage: authPageConfig,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -149,7 +149,7 @@ export function parseAllowedEnvTypes(raw?: string): ENVIRONMENT_TYPE[] {
 	return raw
 		.split(',')
 		.map((s) => s.trim())
-		.filter((s) => valid.has(s as ENVIRONMENT_TYPE)) as ENVIRONMENT_TYPE[];
+		.filter((s): s is ENVIRONMENT_TYPE => valid.has(s as ENVIRONMENT_TYPE));
 }
 
 export const config: Config = {

--- a/src/hooks/useEnvironment.ts
+++ b/src/hooks/useEnvironment.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import Environment, { ENVIRONMENT_TYPE } from '@/models/Environment';
 import EnvironmentApi from '@/api/EnvironmentApi';
+import { config } from '@/config/config';
 
 export const ACTIVE_ENVIRONMENT_ID_KEY = 'active_environment_id';
 
@@ -26,7 +27,9 @@ export const useEnvironment = (pollingInterval: number = 1000): UseEnvironment =
 		queryKey: ['environments'],
 		queryFn: async () => {
 			const res = await EnvironmentApi.getAllEnvironments();
-			return res.environments;
+			const allowed = config.restrictions.allowedEnvTypes;
+			if (allowed.length === 0) return res.environments;
+			return res.environments.filter((env) => allowed.includes(env.type));
 		},
 		staleTime: 5 * 60 * 1000, // 5 minutes
 	});

--- a/src/i18n/locales/ar/settings.json
+++ b/src/i18n/locales/ar/settings.json
@@ -1039,6 +1039,7 @@
 			"unknownTenant": "مستأجر غير معروف",
 			"addEnvironment": "إضافة بيئة",
 			"copyEnvironment": "نسخ البيئة",
+			"goToProduction": "الانتقال إلى الإنتاج",
 			"renameAria": "إعادة تسمية البيئة {{name}}",
 			"suspendedTitle": "تم تعليق البيئة",
 			"suspendedDescription": "هذه البيئة معلقة حاليًا. يرجى التواصل مع الدعم."

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -1110,6 +1110,7 @@
 			"unknownTenant": "Unknown",
 			"addEnvironment": "Add Environment",
 			"copyEnvironment": "Copy Environment",
+			"goToProduction": "Go to Production",
 			"renameAria": "Rename {{name}}",
 			"suspendedTitle": "Environment suspended",
 			"suspendedDescription": "This environment is temporarily closed. Contact us to continue."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `VITE_ALLOWED_ENV_TYPES` to control which environment types are shown (empty/unset shows all).
  * Added sandbox UX behavior: environment filtering in the selector/creator, a sandbox badge, and an optional “Go to Production” external link via `VITE_PRODUCTION_URL`.
* **Tests**
  * Added unit tests covering parsing, sandbox mode detection, and filtering behavior.
* **Documentation**
  * Added implementation plan/spec and updated `.env.example` plus new UI copy for the “Go to Production” action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->