### PR TITLE
fix: show feature names in cost sheet charges table

### DIFF
--- a/src/pages/product-catalog/cost-sheets/CostSheetDetails.tsx
+++ b/src/pages/product-catalog/cost-sheets/CostSheetDetails.tsx
@@ -21,6 +21,8 @@ import formatChips from '@/utils/common/format_chips';
 import { ChargeValueCell } from '@/components/molecules';
 import { BILLING_PERIOD } from '@/constants/constants';
 import { DataType, FilterOperator } from '@/types/common/QueryBuilder';
+import { FeatureApi } from '@/api';
+import { Feature } from '@/models';
 
 const formatBillingPeriod = (billingPeriod: string) => {
 	switch (billingPeriod.toUpperCase()) {
@@ -58,7 +60,7 @@ type Params = {
 	id: string;
 };
 
-const getChargeColumns = (naLabel: string): ColumnData<Price>[] => [
+const getChargeColumns = (naLabel: string, features: Feature[]): ColumnData<Price>[] => [
 	{
 		title: 'Charge Type',
 		render: (row) => {
@@ -68,7 +70,13 @@ const getChargeColumns = (naLabel: string): ColumnData<Price>[] => [
 	{
 		title: 'Feature',
 		render(rowData) {
-			return <span>{rowData.meter?.name ?? naLabel}</span>;
+			if (!rowData.meter_id) {
+				return <span>{naLabel}</span>;
+			}
+
+			const feature = features?.find((f) => f.meter_id === rowData.meter_id);
+
+			return <span>{feature?.name ?? naLabel}</span>;
 		},
 	},
 	{
@@ -128,6 +136,15 @@ const CostSheetDetails = () => {
 		prefix: PAGINATION_PREFIX.COST_SHEET_CHARGES,
 	});
 
+	const { data: featureResponse } = useQuery({
+		queryKey: ['features'],
+		queryFn: () =>
+			FeatureApi.listFeatures({
+				status: ENTITY_STATUS.PUBLISHED,
+				limit: 100,
+			}),
+	});
+
 	const { data: pricesResponse, isLoading: pricesLoading } = useQuery({
 		queryKey: ['costSheetCharges', id, limit, offset],
 		queryFn: () =>
@@ -158,7 +175,7 @@ const CostSheetDetails = () => {
 		}
 	}, [costSheetData, updateBreadcrumb]);
 
-	const chargeColumns = useMemo(() => getChargeColumns(t('common:labels.na')), [t]);
+	const chargeColumns = useMemo(() => getChargeColumns(t('common:labels.na'), featureResponse?.items ?? []), [t, featureResponse]);
 
 	if (isLoading) {
 		return <Loader />;


### PR DESCRIPTION
Fixes #850

## Problem

The Feature column in the Cost Sheet Charges table was not displaying feature names.

The Price API response contains only `meter_id` and does not provide an expanded meter object, so the UI could not resolve the associated feature name.

## Root Cause

The existing implementation relied on `rowData.meter?.name`, but `meter` was undefined in the Price API response.

## Solution

* Fetch published features using `FeatureApi.listFeatures`
* Match `price.meter_id` with `feature.meter_id`
* Display the corresponding feature name in the Feature column
* Show the default N/A label when no matching feature exists

## Testing

* Verified usage-based charges display the correct feature name
* Verified charges without a meter display the fallback N/A value
* Confirmed existing billing period, billing timing, and value columns remain unchanged

### Before

Feature column showed `--`
<img width="1556" height="825" alt="Screenshot (611)" src="https://github.com/user-attachments/assets/9f959f36-917b-4892-a8f6-a91f09c65b9c" />


### After

Feature column correctly displays the associated feature name

<img width="1556" height="929" alt="Screenshot (617)" src="https://github.com/user-attachments/assets/905cca63-9831-4ca3-b88f-75950b268723" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed feature name resolution in the cost sheet charges table by properly matching meter IDs to their corresponding features, with fallback display when no match is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->