### PR TITLE
feat(invoices): add CLF currency to frontend options

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -34,6 +34,13 @@ export enum TIME_PERIOD {
 	LAST_30_DAYS = 'last-30-days',
 }
 
+/** ISO 4217 codes valid but absent from iso-country-currency (funds, SDRs, etc.). */
+type SupplementalIsoCurrency = { currency: string; symbol: string };
+
+const SUPPLEMENTAL_ISO_CURRENCIES: SupplementalIsoCurrency[] = [
+	{ currency: 'CLF', symbol: 'CLF' },
+];
+
 export const getCurrencyOptions = () => {
 	const codes = getAllISOCodes();
 	const map = new Map();
@@ -59,6 +66,13 @@ export const getCurrencyOptions = () => {
 			});
 		}
 	});
+
+	SUPPLEMENTAL_ISO_CURRENCIES.forEach(({ currency, symbol }) => {
+		if (!map.has(currency)) {
+			map.set(currency, { currency, symbol });
+		}
+	});
+
 	return Array.from(map.values());
 };
 


### PR DESCRIPTION
## Relations
* **Related Issue:** flexprice/flexprice#1941
* **Depends on Backend PR:** flexprice/flexprice#1998

---

## Description
This PR adds support for the **CLF (Unidad de Fomento)** currency code in the frontend UI selectors. 

Since the `iso-country-currency` library does not include CLF by default (as it is a non-circulating, inflation-indexed unit used primarily in Chile), a `SUPPLEMENTAL_ISO_CURRENCIES` array has been introduced to safely inject it into the available currency options.

---

## 🔨 Changes Made
* Introduced a `SupplementalIsoCurrency` type for missing ISO codes.
* Created a `SUPPLEMENTAL_ISO_CURRENCIES` array containing `CLF`.
* Updated the `getCurrencyOptions()` function to merge these supplemental currencies into the main options map, ensuring it becomes selectable in the UI.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

- Expanded currency selection. The application now supports additional currencies including the Chilean Unit of Account (CLF) and other supplemental currencies that were previously missing from the standard dataset, providing users with a more comprehensive list of available currencies for transactions and conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->