### PR TITLE
fix(integration): match delink response to backend SuccessResponse

### DIFF
--- a/src/types/dto/Integration.ts
+++ b/src/types/dto/Integration.ts
@@ -24,6 +24,5 @@ export interface IntegrationDelinkRequest {
 }
 
 export interface IntegrationDelinkResponse {
-	success: boolean;
-	archived: number;
+	message: string;
 }


### PR DESCRIPTION
Backend DELETE /integrations/link now returns { message: string }.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the response structure for integration delink operations to include a message field instead of individual success and archived count indicators. This may affect how confirmation or status information is displayed after unlinking integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->