### PR TITLE
feat(ServiceAccountDrawer): implement role selection logic to prioritize super_admin and update UI for service account name display

### DIFF
--- a/src/components/molecules/ServiceAccountDrawer/ServiceAccountDrawer.tsx
+++ b/src/components/molecules/ServiceAccountDrawer/ServiceAccountDrawer.tsx
@@ -54,8 +54,19 @@ const ServiceAccountDrawer: FC<Props> = ({ isOpen, onOpenChange, data }) => {
 		}
 	}, [isOpen, data, isEditMode]);
 
+	const isSuperAdminSelected = selectedRoles.includes('super_admin');
+
 	const toggleRole = (roleValue: string) => {
-		setSelectedRoles((prev) => (prev.includes(roleValue) ? prev.filter((r) => r !== roleValue) : [...prev, roleValue]));
+		setSelectedRoles((prev) => {
+			if (prev.includes(roleValue)) {
+				return prev.filter((r) => r !== roleValue);
+			}
+			// Selecting super_admin clears all other roles
+			if (roleValue === 'super_admin') {
+				return ['super_admin'];
+			}
+			return [...prev, roleValue];
+		});
 	};
 
 	// --- Create mutation ---
@@ -159,20 +170,23 @@ const ServiceAccountDrawer: FC<Props> = ({ isOpen, onOpenChange, data }) => {
 							) : roleOptions.length === 0 ? (
 								<p className='text-sm text-gray-500'>{t('developers:serviceAccountDrawer.noRolesAvailable')}</p>
 							) : (
-								roleOptions.map((role) => (
-									<div key={role.value} className='flex items-center space-x-2'>
-										<Checkbox
-											id={`role-${role.value}`}
-											checked={selectedRoles.includes(role.value)}
-											onCheckedChange={() => toggleRole(role.value)}
-										/>
-										<label
-											htmlFor={`role-${role.value}`}
-											className='text-sm font-medium leading-none cursor-pointer peer-disabled:cursor-not-allowed peer-disabled:opacity-70'>
-											{role.label}
-										</label>
-									</div>
-								))
+								roleOptions.map((role) => {
+									const isDisabled = isSuperAdminSelected && role.value !== 'super_admin';
+									return (
+										<div key={role.value} className={`flex items-center space-x-2 ${isDisabled ? 'opacity-40 pointer-events-none' : ''}`}>
+											<Checkbox
+												id={`role-${role.value}`}
+												checked={selectedRoles.includes(role.value)}
+												onCheckedChange={() => toggleRole(role.value)}
+											/>
+											<label
+												htmlFor={`role-${role.value}`}
+												className={`text-sm font-medium leading-none ${isDisabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}>
+												{role.label}
+											</label>
+										</div>
+									);
+								})
 							)}
 						</div>
 					</div>

--- a/src/i18n/locales/en/developers.json
+++ b/src/i18n/locales/en/developers.json
@@ -6,6 +6,7 @@
 		"token": "Token",
 		"type": "Type",
 		"roles": "Roles",
+		"access": "Access",
 		"createdAt": "Created At",
 		"id": "ID",
 		"expiration": "Expiration",

--- a/src/i18n/locales/en/developers.json
+++ b/src/i18n/locales/en/developers.json
@@ -6,7 +6,6 @@
 		"token": "Token",
 		"type": "Type",
 		"roles": "Roles",
-		"access": "Access",
 		"createdAt": "Created At",
 		"id": "ID",
 		"expiration": "Expiration",

--- a/src/models/SecretKey.ts
+++ b/src/models/SecretKey.ts
@@ -9,6 +9,7 @@ export interface SecretKey extends BaseModel {
 	readonly provider: string;
 	readonly type: SECRET_KEY_TYPE;
 	readonly user_id?: string;
+	readonly service_account_name?: string;
 	readonly roles?: string[];
 	readonly user_type?: 'user' | 'service_account';
 }

--- a/src/pages/developer/developer.tsx
+++ b/src/pages/developer/developer.tsx
@@ -99,8 +99,11 @@ const DeveloperPage = () => {
 				title: t('labels.name'),
 				render(rowData: SecretKey) {
 					return (
-						<div className='flex gap-2 items-center font-medium'>
-							<span>{rowData.name}</span>
+						<div className='flex flex-col gap-0.5'>
+							<span className='font-medium text-sm text-gray-900'>{rowData.name}</span>
+							{rowData.user_type === 'service_account' && rowData.service_account_name && (
+								<span className='text-xs text-gray-400'>{rowData.service_account_name}</span>
+							)}
 						</div>
 					);
 				},
@@ -144,9 +147,8 @@ const DeveloperPage = () => {
 				title: t('labels.roles'),
 				render(rowData: SecretKey) {
 					if (!rowData.roles || rowData.roles.length === 0) {
-						return <span className='text-gray-500 text-sm'>{t('apiKeys.roles.fullAccess')}</span>;
+						return <span className='text-sm text-gray-500'>{t('apiKeys.roles.fullAccess')}</span>;
 					}
-
 					return (
 						<div className='flex flex-wrap gap-1'>
 							{rowData.roles.map((role) => (
@@ -160,10 +162,10 @@ const DeveloperPage = () => {
 			},
 			{
 				title: t('labels.createdAt'),
-				width: 150,
+				width: 160,
 				align: 'right',
 				render(rowData) {
-					return <span className='text-gray-600'>{formatDateShort(rowData.created_at)}</span>;
+					return <span className='text-gray-600 pr-6'>{formatDateShort(rowData.created_at)}</span>;
 				},
 			},
 		],
@@ -174,7 +176,7 @@ const DeveloperPage = () => {
 		() => [
 			...baseColumns,
 			{
-				width: '30px',
+				width: '48px',
 				align: 'right',
 				hideOnEmpty: true,
 				render(rowData: SecretKey) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Service account names now displayed alongside secret keys in the secrets table.

* **Improvements**
  * Enhanced role selection behavior: selecting super_admin now disables other role options to enforce exclusivity.
  * Updated secrets table layout with improved column spacing and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->