### PR TITLE
fix: update broken onboarding documentation links

### DIFF
--- a/src/pages/onboarding/onboarding.tsx
+++ b/src/pages/onboarding/onboarding.tsx
@@ -23,7 +23,7 @@ const tutorials: TutorialItem[] = [
 	{
 		title: 'Set Up Pricing Plans',
 		description: 'Create and configure your first pricing plan',
-		onClick: () => window.open('https://docs.flexprice.io/guides/plan/pricing-plan-create', '_blank'),
+		onClick: () => window.open('https://docs.flexprice.io/docs/product-catalogue/plans/pricing', '_blank'),
 	},
 	{
 		title: 'Define Usage Metering',
@@ -33,7 +33,7 @@ const tutorials: TutorialItem[] = [
 	{
 		title: 'Configure Credits & Wallets',
 		description: 'Manage prepaid wallets, free credits, and top-ups',
-		onClick: () => window.open('https://docs.flexprice.io/guides/wallet/customers-wallet', '_blank'),
+		onClick: () => window.open('https://docs.flexprice.io/docs/wallet/create', '_blank'),
 	},
 	{
 		title: 'Billing',
@@ -43,7 +43,7 @@ const tutorials: TutorialItem[] = [
 	{
 		title: 'Self-Hosting & Configuration',
 		description: 'Set up and deploy Flexprice on your own infrastructure',
-		onClick: () => window.open('https://docs.flexprice.io/guides/self-hosted/guide', '_blank'),
+		onClick: () => window.open('https://docs.flexprice.io/docs/getting-started/self-hosting-guide', '_blank'),
 	},
 ];
 


### PR DESCRIPTION
## Summary

This PR fixes broken documentation links on the onboarding page.

Although the onboarding cards have changed since the issue was opened, I verified the current onboarding tutorial links and updated the three broken documentation URLs.

### Changes
- Updated the "Set Up Pricing Plans" documentation link.
- Updated the "Configure Credits & Wallets" documentation link.
- Updated the "Self-Hosting & Configuration" documentation link.

### Verification
- Verified all onboarding tutorial cards locally.
- Confirmed every documentation link now opens the correct page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Quick Start tutorial links to direct to current documentation pages for pricing plan setup, wallet/credits, and self-hosting guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->