### PR TITLE
fix: display API key name in delete confirmation dialog

### DIFF
--- a/src/pages/developer/developer.tsx
+++ b/src/pages/developer/developer.tsx
@@ -188,7 +188,7 @@ const DeveloperPage = () => {
 									await SecretKeysApi.deleteSecretKey(id);
 								}}
 								refetchQueryKey='secret-keys'
-								entityName={t('apiKeys.entityName')}
+								entityName={rowData?.name}
 								// edit={{
 								// 	enabled: true,
 								// 	onClick: () => {},


### PR DESCRIPTION
## Summary

This PR improves the API key deletion confirmation dialog by displaying the selected API key name instead of the generic "API key" label.

## Changes

- Updated the API Keys page to pass the API key name to the confirmation dialog.
- Kept the existing `ActionButton` component unchanged.
- Aligned the API key deletion confirmation with other entity confirmation dialogs (e.g. Cost Sheets).

## Verification

- Verified the delete confirmation dialog now displays the selected API key name.
- Confirmed API key deletion continues to work as expected.
- Verified no changes to confirmation dialogs for other entities.

##Before
<img width="1556" height="903" alt="Screenshot (666)" src="https://github.com/user-attachments/assets/abc6c795-8d45-4503-9787-6765058f328e" />

##After
<img width="1586" height="902" alt="Screenshot (667)" src="https://github.com/user-attachments/assets/23b22b3e-886f-46ee-b31a-9e7b8c60b8a7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the secret key deletion action to display the actual key name instead of a generic label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->