### PR TITLE
feat(PersistedOrgTypeFilter): add custom hook for persisting org type

### DIFF
--- a/src/components/organisms/QueryableDataArea/QueryableDataArea.tsx
+++ b/src/components/organisms/QueryableDataArea/QueryableDataArea.tsx
@@ -4,6 +4,7 @@ import OrgTypeMetadataFilter from '@/components/molecules/Customer/OrgTypeMetada
 import { ColumnData } from '@/components/molecules/Table';
 import usePagination from '@/hooks/usePagination';
 import { usePaginationReset } from '@/hooks/usePaginationReset';
+import { readPageFromSession, writePageToSession } from '@/utils/filterPersistence';
 import useFilterSortingWithPersistence from '@/hooks/useFilterSortingWithPersistence';
 import { useQueryWithEmptyState } from '@/hooks/useQueryWithEmptyState';
 import { CustomerOrgTypeFilterValue } from '@/constants/customerOrgTypeFilter';
@@ -180,11 +181,8 @@ QueryBuilderWrapper.displayName = 'QueryBuilderWrapper';
 
 // Data area component - re-renders when query params change
 const DataArea = <T,>({
-	sanitizedFilters,
-	sanitizedSorts,
 	tableConfig,
 	paginationConfig,
-	reset,
 	emptyStateConfig,
 	onError,
 	data,
@@ -193,11 +191,8 @@ const DataArea = <T,>({
 	showEmptyPage,
 	shouldShowLoading,
 }: {
-	sanitizedFilters: any[];
-	sanitizedSorts: any[];
 	tableConfig: TableConfig<T>;
 	paginationConfig?: PaginationConfig;
-	reset: () => void;
 	emptyStateConfig?: EmptyStateConfig;
 	onError?: (error: any) => void;
 	data: { items: T[]; pagination: { total?: number } } | undefined;
@@ -206,9 +201,6 @@ const DataArea = <T,>({
 	showEmptyPage: boolean;
 	shouldShowLoading: boolean;
 }) => {
-	// Reset pagination when filters or sorts change
-	usePaginationReset(reset, sanitizedFilters, sanitizedSorts);
-
 	// Loading state - prioritize showing loading during transitions
 	if (shouldShowLoading) {
 		return <LoadingState />;
@@ -278,11 +270,20 @@ const QueryableDataArea = <T = any,>({
 	const [isInitialMount, setIsInitialMount] = useState(true);
 	const [isTransitionLoading, setIsTransitionLoading] = useState(false);
 	const prevQueryKeyRef = useRef<string>('');
+	const persistenceKey = queryConfig.filterPersistenceKey ?? dataConfig.queryKey;
+	const pagePrefix = (paginationConfig?.prefix ?? persistenceKey) as string;
+	const initialPageFromSession = useMemo(() => {
+		if (typeof window === 'undefined' || !persistenceKey) return undefined;
+		const pageKey = pagePrefix ? `${pagePrefix}_page` : 'page';
+		if (new URLSearchParams(window.location.search).get(pageKey)) return undefined;
+		return readPageFromSession(persistenceKey) ?? undefined;
+	}, [pagePrefix, persistenceKey]);
 
 	// Pagination
 	const { limit, offset, page, reset } = usePagination({
 		initialLimit: paginationConfig?.initialLimit ?? 10,
-		prefix: paginationConfig?.prefix as any,
+		prefix: pagePrefix,
+		initialPage: initialPageFromSession,
 	});
 
 	// Filter and sort state
@@ -350,6 +351,13 @@ const QueryableDataArea = <T = any,>({
 		[page, sanitizedFilters, sanitizedSorts, additionalQueryParamsKey],
 	);
 
+	usePaginationReset(reset, sanitizedFilters, sanitizedSorts, additionalQueryParamsKey);
+
+	useEffect(() => {
+		if (!persistenceKey) return;
+		writePageToSession(persistenceKey, page);
+	}, [persistenceKey, page]);
+
 	// Create fetch function with all params
 	const fetchData = useCallback(async () => {
 		return await dataConfig.fetchFn({
@@ -396,10 +404,6 @@ const QueryableDataArea = <T = any,>({
 
 	const onMainDataChangeRef = useRef(dataConfig.onMainDataChange);
 	onMainDataChangeRef.current = dataConfig.onMainDataChange;
-
-	useEffect(() => {
-		reset();
-	}, [filters, sorts, additionalQueryParamsKey]);
 
 	useLayoutEffect(() => {
 		onMainDataChangeRef.current?.(data);
@@ -468,11 +472,8 @@ const QueryableDataArea = <T = any,>({
 
 			{/* Data area - re-renders when query params change */}
 			<DataArea<T>
-				sanitizedFilters={sanitizedFilters}
-				sanitizedSorts={sanitizedSorts}
 				tableConfig={tableConfig}
 				paginationConfig={paginationConfig}
-				reset={reset}
 				emptyStateConfig={emptyStateConfig}
 				onError={onError}
 				data={data}

--- a/src/hooks/usePagination.tsx
+++ b/src/hooks/usePagination.tsx
@@ -4,6 +4,8 @@ import { useEffect, useCallback } from 'react';
 interface UsePaginationProps {
 	initialLimit?: number;
 	prefix?: PAGINATION_PREFIX | string;
+	/** Used when the page query param is absent (e.g. restored from session). */
+	initialPage?: number;
 }
 
 export enum PAGINATION_PREFIX {
@@ -15,14 +17,16 @@ export enum PAGINATION_PREFIX {
 	CUSTOMER_SUBSCRIPTIONS = 'customer_subscriptions',
 	SUBSCRIPTION_LINE_ITEMS = 'subscription_line_items',
 	TASK_RUNS = 'task_runs',
+	FETCH_CUSTOMERS = 'fetchCustomers',
 }
 
-const usePagination = ({ initialLimit = 10, prefix }: UsePaginationProps = {}) => {
+const usePagination = ({ initialLimit = 10, prefix, initialPage }: UsePaginationProps = {}) => {
 	const [searchParams, setSearchParams] = useSearchParams();
 
 	// Determine the query parameter key based on prefix
 	const pageKey = prefix ? `${prefix}_page` : 'page';
-	const page = Number(searchParams.get(pageKey) || '1');
+	const pageParam = searchParams.get(pageKey);
+	const page = pageParam ? Number(pageParam) : (initialPage ?? 1);
 
 	const reset = useCallback(() => {
 		setSearchParams((prev) => {
@@ -45,17 +49,16 @@ const usePagination = ({ initialLimit = 10, prefix }: UsePaginationProps = {}) =
 
 	// Ensure `page` is set in the query parameters
 	useEffect(() => {
-		if (!searchParams.get(pageKey)) {
-			setSearchParams(
-				(prev) => {
-					const next = new URLSearchParams(prev);
-					next.set(pageKey, '1');
-					return next;
-				},
-				{ replace: true },
-			);
-		}
-	}, [searchParams, setSearchParams, pageKey]);
+		if (searchParams.get(pageKey)) return;
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				next.set(pageKey, String(initialPage ?? 1));
+				return next;
+			},
+			{ replace: true },
+		);
+	}, [searchParams, setSearchParams, pageKey, initialPage]);
 
 	const limit = initialLimit;
 	const offset = limit > 0 ? Math.max((page - 1) * limit, 0) : 0;

--- a/src/hooks/usePaginationReset.tsx
+++ b/src/hooks/usePaginationReset.tsx
@@ -10,34 +10,41 @@ import { TypedBackendSort } from '@/types/formatters/QueryBuilder';
  * @param filters - Current sanitized filters
  * @param sorts - Current sanitized sorts
  */
-export const usePaginationReset = (reset: () => void, filters: TypedBackendFilter[], sorts: TypedBackendSort[]) => {
+export const usePaginationReset = (
+	reset: () => void,
+	filters: TypedBackendFilter[],
+	sorts: TypedBackendSort[],
+	additionalQueryKey?: string,
+) => {
 	const prevFiltersRef = useRef<string | null>(null);
 	const prevSortsRef = useRef<string | null>(null);
+	const prevAdditionalQueryKeyRef = useRef<string | null>(null);
 	const isInitialMount = useRef(true);
 
 	useEffect(() => {
+		const currentFiltersKey = JSON.stringify(filters);
+		const currentSortsKey = JSON.stringify(sorts);
+		const currentAdditionalQueryKey = additionalQueryKey ?? '';
+
 		// Skip on initial mount - don't reset pagination when component first loads
 		if (isInitialMount.current) {
 			isInitialMount.current = false;
-			// Store initial values
-			prevFiltersRef.current = JSON.stringify(filters);
-			prevSortsRef.current = JSON.stringify(sorts);
+			prevFiltersRef.current = currentFiltersKey;
+			prevSortsRef.current = currentSortsKey;
+			prevAdditionalQueryKeyRef.current = currentAdditionalQueryKey;
 			return;
 		}
 
-		// Only stringify when we need to compare (not on every render)
-		const currentFiltersKey = JSON.stringify(filters);
-		const currentSortsKey = JSON.stringify(sorts);
-
-		// Only reset if filters or sorts actually changed
 		const filtersChanged = prevFiltersRef.current !== currentFiltersKey;
 		const sortsChanged = prevSortsRef.current !== currentSortsKey;
+		const additionalQueryChanged = prevAdditionalQueryKeyRef.current !== currentAdditionalQueryKey;
 
-		if (filtersChanged || sortsChanged) {
+		if (filtersChanged || sortsChanged || additionalQueryChanged) {
 			reset();
 			prevFiltersRef.current = currentFiltersKey;
 			prevSortsRef.current = currentSortsKey;
+			prevAdditionalQueryKeyRef.current = currentAdditionalQueryKey;
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [filters, sorts]); // Dependencies are arrays, but we compare by value
+	}, [filters, sorts, additionalQueryKey]); // Dependencies are arrays, but we compare by value
 };

--- a/src/hooks/usePersistedOrgTypeFilter.ts
+++ b/src/hooks/usePersistedOrgTypeFilter.ts
@@ -1,0 +1,35 @@
+import { useCallback, useState } from 'react';
+import { useSearchParams } from 'react-router';
+import { CustomerOrgTypeFilterValue } from '@/constants/customerOrgTypeFilter';
+import { getOrgTypeParamKey, parsePersistedOrgTypeFilter } from '@/utils/filterPersistence';
+
+/** Persists parent/child org_type selection in the URL (`{key}_org_type`), matching list filter params. */
+export function usePersistedOrgTypeFilter(persistenceKey: string) {
+	const [searchParams, setSearchParams] = useSearchParams();
+	const paramKey = getOrgTypeParamKey(persistenceKey);
+
+	const [orgTypeFilter, setOrgTypeFilterState] = useState<CustomerOrgTypeFilterValue | null>(() => {
+		if (typeof window === 'undefined') return null;
+		const fromUrl = parsePersistedOrgTypeFilter(new URLSearchParams(window.location.search).get(paramKey));
+		if (fromUrl) return fromUrl;
+		return parsePersistedOrgTypeFilter(searchParams.get(paramKey));
+	});
+
+	const setOrgTypeFilter = useCallback(
+		(value: CustomerOrgTypeFilterValue | null) => {
+			setOrgTypeFilterState(value);
+			setSearchParams(
+				(prev) => {
+					const next = new URLSearchParams(prev);
+					if (value) next.set(paramKey, value);
+					else next.delete(paramKey);
+					return next;
+				},
+				{ replace: true },
+			);
+		},
+		[paramKey, setSearchParams],
+	);
+
+	return [orgTypeFilter, setOrgTypeFilter] as const;
+}

--- a/src/pages/customer/customers/CustomerListPage.tsx
+++ b/src/pages/customer/customers/CustomerListPage.tsx
@@ -2,12 +2,13 @@ import { AddButton, Page, ActionButton, Chip } from '@/components/atoms';
 import { CreateCustomerDrawer, ApiDocsContent } from '@/components/molecules';
 import { ColumnData } from '@/components/molecules/Table';
 import { QueryableDataArea } from '@/components/organisms';
+import { PAGINATION_PREFIX } from '@/hooks/usePagination';
 import { buildGuides } from '@/constants/guides';
 import { API_DOCS_TAGS } from '@/constants/apiDocsTags';
-import { CustomerOrgTypeFilterValue } from '@/constants/customerOrgTypeFilter';
 import Customer from '@/models/Customer';
 import CustomerApi from '@/api/CustomerApi';
 import { useState, useMemo, useCallback, FC } from 'react';
+import { usePersistedOrgTypeFilter } from '@/hooks/usePersistedOrgTypeFilter';
 import {
 	FilterField,
 	FilterFieldType,
@@ -63,7 +64,7 @@ const CustomerListPage = () => {
 	const guides = useMemo(() => buildGuides(tGuide), [tGuide]);
 	const [activeCustomer, setactiveCustomer] = useState<Customer>();
 	const [customerDrawerOpen, setcustomerDrawerOpen] = useState(false);
-	const [orgTypeFilter, setOrgTypeFilter] = useState<CustomerOrgTypeFilterValue | null>(null);
+	const [orgTypeFilter, setOrgTypeFilter] = usePersistedOrgTypeFilter('fetchCustomers');
 	const showOrgTypeFilter = useTenantFeatureAllowlist();
 	const navigate = useNavigate();
 
@@ -290,6 +291,7 @@ const CustomerListPage = () => {
 				}}
 				paginationConfig={{
 					unit: t('list.paginationUnit'),
+					prefix: PAGINATION_PREFIX.FETCH_CUSTOMERS,
 				}}
 				emptyStateConfig={{
 					heading: t('list.emptyHeading'),

--- a/src/utils/filterPersistence.ts
+++ b/src/utils/filterPersistence.ts
@@ -1,4 +1,5 @@
 import type { FilterCondition, SortOption } from '@/types/common/QueryBuilder';
+import type { CustomerOrgTypeFilterValue } from '@/constants/customerOrgTypeFilter';
 
 /** FilterCondition with valueDate as ISO string for JSON serialization */
 type SerializedFilterCondition = Omit<FilterCondition, 'valueDate'> & { valueDate?: string };
@@ -79,9 +80,55 @@ export function getSortsParamKey(key: string): string {
 	return `${key}_sorts`;
 }
 
+/** URL param key for customer org_type toolbar filter */
+export function getOrgTypeParamKey(key: string): string {
+	return `${key}_org_type`;
+}
+
+export function parsePersistedOrgTypeFilter(value: string | null): CustomerOrgTypeFilterValue | null {
+	return value === 'parent' || value === 'child' ? value : null;
+}
+
 /** SessionStorage key for a list's filter/sort state (survives tab switch, cleared when tab closes) */
 export function getFilterStateSessionKey(key: string): string {
 	return `filter_state_${key}`;
+}
+
+/** URL param key for pagination (matches usePagination prefix convention). */
+export function getPageParamKey(prefix: string): string {
+	return `${prefix}_page`;
+}
+
+function readRawSessionState(key: string): Record<string, string> {
+	if (typeof window === 'undefined') return {};
+	try {
+		const raw = sessionStorage.getItem(getFilterStateSessionKey(key));
+		if (!raw?.trim()) return {};
+		const parsed = JSON.parse(raw) as Record<string, string>;
+		return parsed && typeof parsed === 'object' ? parsed : {};
+	} catch {
+		return {};
+	}
+}
+
+export function readPageFromSession(key: string): number | null {
+	const page = Number(readRawSessionState(key).page);
+	return Number.isFinite(page) && page > 0 ? page : null;
+}
+
+export function writePageToSession(key: string, page: number): void {
+	if (typeof window === 'undefined') return;
+	try {
+		sessionStorage.setItem(
+			getFilterStateSessionKey(key),
+			JSON.stringify({
+				...readRawSessionState(key),
+				page: String(page),
+			}),
+		);
+	} catch {
+		// ignore quota or disabled storage
+	}
 }
 
 const EMPTY_FILTER_STATE: { filters: FilterCondition[] | null; sorts: SortOption[] | null } = {
@@ -121,6 +168,7 @@ export function writeFiltersAndSortsToSession(key: string, filters: FilterCondit
 		sessionStorage.setItem(
 			getFilterStateSessionKey(key),
 			JSON.stringify({
+				...readRawSessionState(key),
 				filters: serializeFilters(filters),
 				sorts: serializeSorts(sorts),
 			}),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pagination state now persists across browser sessions, automatically restoring your current page position when you return
  * Organization type filter selections are preserved in the URL for easy sharing and bookmarking of filtered views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->