### PR TITLE
feat: add feature cloning support

### DIFF
--- a/src/api/FeatureApi.ts
+++ b/src/api/FeatureApi.ts
@@ -10,6 +10,7 @@ import {
 	GetFeaturesResponse,
 	GetFeatureByFilterPayload,
 	UpdateFeaturePayload,
+	CloneFeatureRequest,
 } from '@/types/dto';
 
 class FeatureApi {
@@ -99,6 +100,16 @@ class FeatureApi {
 	 */
 	public static async updateFeatureLegacy(id: string, data: UpdateFeaturePayload): Promise<FeatureResponse> {
 		return await AxiosClient.put<FeatureResponse, UpdateFeaturePayload>(`${this.baseUrl}/${id}`, data);
+	}
+
+	/**
+	 * Clone a Feature
+	 * @param id Source feature ID
+	 * @param data Clone payload
+	 * @returns Newly created feature
+	 */
+	public static async cloneFeature(id: string, data: CloneFeatureRequest): Promise<FeatureResponse> {
+		return await AxiosClient.post<FeatureResponse, CloneFeatureRequest>(`${this.baseUrl}/${id}/clone`, data);
 	}
 }
 

--- a/src/components/molecules/DuplicateFeatureDialog/DuplicateFeatureDialog.tsx
+++ b/src/components/molecules/DuplicateFeatureDialog/DuplicateFeatureDialog.tsx
@@ -1,0 +1,184 @@
+import { FeatureApi } from '@/api';
+import { Button, Dialog, Input, Spacer, Textarea } from '@/components/atoms';
+import { RouteNames } from '@/core/routes/Routes';
+import { refetchQueries } from '@/core/services/tanstack/ReactQueryProvider';
+import Feature from '@/models/Feature';
+import { CloneFeatureRequest, FeatureResponse } from '@/types/dto';
+import { useMutation } from '@tanstack/react-query';
+import { FC, useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
+
+interface DuplicateFeatureDialogProps {
+	featureId: string;
+	feature: Feature | FeatureResponse | null;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	refetchQueryKeys?: string | string[];
+}
+
+type FormErrors = Partial<Record<keyof CloneFeatureRequest | 'metadata', string>>;
+
+const DuplicateFeatureDialog: FC<DuplicateFeatureDialogProps> = ({
+	featureId,
+	feature,
+	open,
+	onOpenChange,
+	refetchQueryKeys = ['fetchFeatures'],
+}) => {
+	const { t } = useTranslation(['catalog', 'common']);
+	const navigate = useNavigate();
+	const [name, setName] = useState('');
+	const [lookupKey, setLookupKey] = useState('');
+	const [description, setDescription] = useState('');
+	const [metadataString, setMetadataString] = useState('');
+	const [errors, setErrors] = useState<FormErrors>({});
+
+	// Auto-generate lookup key from name (same as Add Feature dialog)
+	useEffect(() => {
+		if (open) {
+			setLookupKey(`feature-${name?.toLowerCase().replace(/\s/g, '-') || ''}`);
+		}
+	}, [name, open]);
+
+	const validate = (): boolean => {
+		const newErrors: FormErrors = {};
+
+		if (!name?.trim()) {
+			newErrors.name = 'Name is required';
+		} else if (feature && name.trim() === feature.name) {
+			newErrors.name = 'Name must be different from the original feature';
+		}
+
+		if (!lookupKey?.trim()) {
+			newErrors.lookup_key = 'Lookup key is required';
+		} else if (feature && lookupKey.trim() === feature.lookup_key) {
+			newErrors.lookup_key = 'Lookup key must be different from the original feature';
+		}
+
+		if (metadataString.trim()) {
+			try {
+				const parsed = JSON.parse(metadataString);
+				if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+					newErrors.metadata = 'Metadata must be a JSON object';
+				} else {
+					const allStrings = Object.values(parsed).every((val) => typeof val === 'string');
+					if (!allStrings) {
+						newErrors.metadata = 'All metadata values must be strings';
+					}
+				}
+			} catch {
+				newErrors.metadata = 'Invalid Metadata format';
+			}
+		}
+
+		setErrors(newErrors);
+		return Object.keys(newErrors).length === 0;
+	};
+
+	const { mutate: cloneFeature, isPending } = useMutation({
+		mutationFn: (payload: CloneFeatureRequest) => FeatureApi.cloneFeature(featureId, payload),
+		onSuccess: (data) => {
+			toast.success('Feature duplicated successfully');
+			onOpenChange(false);
+			refetchQueries(refetchQueryKeys);
+			navigate(`${RouteNames.featureDetails}/${data.id}`);
+		},
+		onError: (error: Error) => {
+			const message = error.message || 'Failed to duplicate feature. Please try again.';
+			toast.error(message);
+			if (message.toLowerCase().includes('name') || message.toLowerCase().includes('lookup')) {
+				setErrors((prev) => ({ ...prev, name: message, lookup_key: message }));
+			}
+		},
+	});
+
+	const handleSubmit = () => {
+		if (!validate() || !feature) return;
+
+		let metadata: CloneFeatureRequest['metadata'] = {};
+		if (metadataString.trim()) {
+			try {
+				const parsed = JSON.parse(metadataString);
+				metadata = { ...parsed };
+			} catch {
+				return;
+			}
+		}
+
+		const payload: CloneFeatureRequest = {
+			name: name.trim(),
+			lookup_key: lookupKey.trim(),
+			...(description.trim() && { description: description.trim() }),
+			metadata,
+		};
+		cloneFeature(payload);
+	};
+
+	return (
+		<Dialog
+			isOpen={open}
+			onOpenChange={onOpenChange}
+			title={t('catalog:features.duplicate.title')}
+			description={t('catalog:features.duplicate.description')}
+			showCloseButton={true}>
+			<Input
+				label={t('catalog:features.drawer.name')}
+				placeholder={t('catalog:features.drawer.namePlaceholder')}
+				description={t('catalog:features.duplicate.nameHelp')}
+				value={name}
+				error={errors.name}
+				onChange={(e) => {
+					setName(e);
+					if (errors.name) setErrors((prev) => ({ ...prev, name: undefined }));
+				}}
+			/>
+			<Spacer height='20px' />
+			<Input
+				label={t('catalog:shared.lookupKey')}
+				placeholder={t('catalog:features.drawer.lookupPlaceholder')}
+				description={t('catalog:shared.lookupKeyDescription')}
+				value={lookupKey}
+				error={errors.lookup_key}
+				onChange={(e) => {
+					setLookupKey(e);
+					if (errors.lookup_key) setErrors((prev) => ({ ...prev, lookup_key: undefined }));
+				}}
+			/>
+			<Spacer height='20px' />
+			<Textarea
+				value={description}
+				onChange={(e) => setDescription(e)}
+				className='min-h-[100px]'
+				placeholder={t('catalog:shared.enterDescription')}
+				label={t('catalog:features.drawer.descriptionLabel')}
+				description={t('catalog:features.duplicate.descriptionHelp')}
+			/>
+			<Spacer height='20px' />
+			<Textarea
+				value={metadataString}
+				onChange={(e) => {
+					setMetadataString(e);
+					if (errors.metadata) setErrors((prev) => ({ ...prev, metadata: undefined }));
+				}}
+				error={errors.metadata}
+				className='min-h-[100px]'
+				placeholder={t('catalog:shared.metadataPlaceholder')}
+				label={t('catalog:shared.metadataOptional')}
+				description={t('catalog:shared.metadataJsonStringsOnly')}
+			/>
+			<Spacer height='24px' />
+			<div className='flex justify-end gap-2'>
+				<Button variant='outline' onClick={() => onOpenChange(false)} disabled={isPending}>
+					{t('common:actions.cancel')}
+				</Button>
+				<Button onClick={handleSubmit} disabled={isPending || !name?.trim() || !lookupKey?.trim()} isLoading={isPending}>
+					{t('catalog:features.duplicate.duplicate')}
+				</Button>
+			</div>
+		</Dialog>
+	);
+};
+
+export default DuplicateFeatureDialog;

--- a/src/components/molecules/DuplicateFeatureDialog/index.ts
+++ b/src/components/molecules/DuplicateFeatureDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DuplicateFeatureDialog';

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -104,6 +104,7 @@ export { default as CurrencyPriceUnitSelector } from './CurrencyPriceUnitSelecto
 export { AddonTable, AddonModal } from './AddonTable';
 export { default as AddonDrawer } from './AddonDrawer';
 export { default as FeatureTable } from './FeatureTable';
+export { default as DuplicateFeatureDialog } from './DuplicateFeatureDialog';
 export { FeatureAlertDialog } from './FeatureAlertDialog';
 export { FeatureDrawer } from './FeatureDrawer';
 

--- a/src/i18n/locales/en/catalog.json
+++ b/src/i18n/locales/en/catalog.json
@@ -757,6 +757,13 @@
 			"usageReset": "Usage Reset ",
 			"bucketSize": "Bucket Size",
 			"groupBy": "Group by"
+		},
+		"duplicate": {
+			"title": "Duplicate Feature",
+			"description": "Create a copy of this feature.",
+			"duplicate": "Duplicate",
+			"nameHelp": "Use a different name from the original feature.",
+			"descriptionHelp": "Optional description for the duplicated feature."
 		}
 	},
 	"entityChargesPage": {

--- a/src/pages/product-catalog/features/Features.tsx
+++ b/src/pages/product-catalog/features/Features.tsx
@@ -1,5 +1,5 @@
 import { AddButton, Page, ActionButton, Chip } from '@/components/atoms';
-import { ApiDocsContent, FeatureDrawer, RedirectCell } from '@/components/molecules';
+import { ApiDocsContent, DuplicateFeatureDialog, FeatureDrawer, RedirectCell } from '@/components/molecules';
 import { ColumnData } from '@/components/molecules/Table';
 import { QueryableDataArea } from '@/components/organisms';
 import { RouteNames } from '@/core/routes/Routes';
@@ -25,6 +25,7 @@ import { toSentenceCase } from '@/utils/common/helper_functions';
 import formatDate from '@/utils/common/format_date';
 import { getFeatureIcon } from '@/components/atoms/SelectFeature/SelectFeature';
 import { searchGroupsForFilter } from '@/utils/filterSearchHelpers';
+import { Copy } from 'lucide-react';
 
 const initialFilters: FilterCondition[] = [
 	{
@@ -50,6 +51,8 @@ const FeaturesPage = () => {
 	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 	const [selectedFeature, setSelectedFeature] = useState<Feature | null>(null);
 	const navigate = useNavigate();
+	const [isDuplicateOpen, setIsDuplicateOpen] = useState(false);
+	const [selectedFeatureForClone, setSelectedFeatureForClone] = useState<Feature | null>(null);
 
 	const handleEdit = useCallback((feature: Feature) => {
 		setSelectedFeature(feature);
@@ -224,6 +227,17 @@ const FeaturesPage = () => {
 								enabled: true,
 								onClick: () => handleEdit(row),
 							}}
+							customActions={[
+								{
+									text: t('features.duplicate.duplicate'),
+									icon: <Copy size={16} />,
+									enabled: true,
+									onClick: () => {
+										setSelectedFeatureForClone(row);
+										setIsDuplicateOpen(true);
+									},
+								},
+							]}
 						/>
 					);
 				},
@@ -284,6 +298,16 @@ const FeaturesPage = () => {
 			/>
 			{selectedFeature && (
 				<FeatureDrawer data={selectedFeature} open={isDrawerOpen} onOpenChange={setIsDrawerOpen} refetchQueryKeys={['fetchFeatures']} />
+			)}
+
+			{selectedFeatureForClone && (
+				<DuplicateFeatureDialog
+					open={isDuplicateOpen}
+					onOpenChange={setIsDuplicateOpen}
+					featureId={selectedFeatureForClone.id}
+					feature={selectedFeatureForClone}
+					refetchQueryKeys={['fetchFeatures']}
+				/>
 			)}
 		</Page>
 	);

--- a/src/types/dto/Feature.ts
+++ b/src/types/dto/Feature.ts
@@ -108,3 +108,11 @@ export interface GetFeatureByFilterPayload extends Pagination {
 export interface UpdateFeaturePayload extends Partial<Feature> {
 	filters?: MeterFilter[];
 }
+
+// Clone Feature
+export interface CloneFeatureRequest {
+	name: string;
+	lookup_key: string;
+	description?: string;
+	metadata?: Record<string, string>;
+}

--- a/src/types/dto/index.ts
+++ b/src/types/dto/index.ts
@@ -9,6 +9,7 @@ export type {
 	GetFeatureByFilterPayload,
 	UpdateFeaturePayload,
 	ReportingUnit,
+	CloneFeatureRequest,
 } from './Feature';
 
 export type { GetConnectionsPayload, GetConnectionsResponse, CreateConnectionPayload, UpdateConnectionPayload } from './Connection';


### PR DESCRIPTION
## Summary

This PR adds support for cloning features from the Features page.

### What was added
- Clone Feature API integration
- Duplicate Feature dialog
- Clone action in the feature menu
- Basic validation for name and lookup key

### Verified
- Feature cloning works successfully
- Redirects to the newly created feature

<img width="1547" height="907" alt="Screenshot (713)" src="https://github.com/user-attachments/assets/d1d4b03c-f4fa-4f45-a964-f17c8464537b" />
<img width="1550" height="873" alt="Screenshot (714)" src="https://github.com/user-attachments/assets/f5a85cc5-233f-4e22-b028-242f84e5c6c2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Duplicate Feature” action from the feature list.
  * Users can now duplicate an existing feature with a new name, lookup key, optional description, and optional metadata.
  * After duplication, the app takes users to the new feature and refreshes related data.

* **Bug Fixes**
  * Added validation to prevent duplicate names and lookup keys from matching the original feature.
  * Improved feedback when required fields or metadata formatting are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->