### PR TITLE
Add contact_us platform flag for white-label contact details.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,9 @@ VITE_GOOGLE_SHEETS_WEB_APP_URL=
 # Restricted Envs (JSON: { [tenant_id]: { [env_id]: ISO date | "suspended" } }) This is used to restrict access to certain environments for certain tenants.
 VITE_RESTRICTED_ENVS=
 
-# Platform UI features (JSON). Omitted keys default to enabled: true.
+# Platform UI features (JSON). Omitted keys default to enabled: true (contact_us defaults to false).
 # VITE_PLATFORM_CONFIG={"api_reference":{"enabled":false},"sidebar_documentation":{"enabled":false},"guides":{"enabled":false},"onboarding":{"enabled":false}}
+# White-label contact options (Slack, email, book-a-call): VITE_PLATFORM_CONFIG={"contact_us":true}
 
 # Typography — optional JSON: {"primary":"…","fallback":"…"} (see src/config/config.ts). Omitted = Qanelas (src/assets/fonts/qanelas) + system UI.
 # VITE_FONT_CONFIG={"primary":"Qanelas","fallback":"ui-sans-serif, system-ui, sans-serif"}

--- a/src/components/atoms/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/atoms/ErrorBoundary/ErrorBoundary.tsx
@@ -8,6 +8,7 @@ import { RouteNames } from '@/core/routes/Routes';
 import { Link } from 'react-router';
 import * as Sentry from '@sentry/react';
 import { config } from '@/config/config';
+import { getContactDetails, isContactEnabled } from '@/config/contact';
 import toast from 'react-hot-toast';
 
 interface ErrorInfo {
@@ -68,6 +69,7 @@ export const ErrorFallback = ({ error, errorInfo, errorId, resetError }: ErrorFa
 	const [showDetails, setShowDetails] = useState(false);
 	const [animateIcon, setAnimateIcon] = useState(true);
 	const isDev = !config.app.isProd;
+	const contact = isContactEnabled() ? getContactDetails() : null;
 
 	const handleRefresh = () => {
 		resetError();
@@ -182,46 +184,50 @@ export const ErrorFallback = ({ error, errorInfo, errorId, resetError }: ErrorFa
 
 					{/* Contact Support Section */}
 					<div className='grid grid-cols-2 gap-4 mb-8'>
-						<a
-							href={`mailto:support@flexprice.io?subject=Error Report: ${errorId}&body=Hello Support Team,%0A%0AI encountered an error with the following reference ID: ${errorId}%0A%0APage URL: ${encodeURIComponent(window.location.href)}%0A%0APlease help resolve this issue.%0A%0AThank you.`}
-							className='flex flex-col items-center gap-3 p-4 rounded-lg border border-muted/20 hover:border-blue-DEFAULT/30 hover:bg-blue-DEFAULT/5 transition-all group'
-							aria-label={t('errorPage.emailSupportAria')}>
-							<div className='p-3 rounded-full bg-blue-DEFAULT/10 group-hover:bg-blue-DEFAULT/20 transition-colors'>
-								<svg
-									xmlns='http://www.w3.org/2000/svg'
-									width='24'
-									height='24'
-									viewBox='0 0 24 24'
-									fill='none'
-									stroke='currentColor'
-									strokeWidth='2'
-									strokeLinecap='round'
-									strokeLinejoin='round'
-									className='text-blue-DEFAULT'>
-									<rect width='20' height='16' x='2' y='4' rx='2' />
-									<path d='m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7' />
-								</svg>
-							</div>
-							<div className='text-center'>
-								<div className='font-medium text-sm'>{t('errorPage.emailSupport')}</div>
-								<div className='text-xs text-muted-foreground'>{t('errorPage.emailSupportSubtitle')}</div>
-							</div>
-						</a>
+						{contact && (
+							<a
+								href={`mailto:${contact.email}?subject=Error Report: ${errorId}&body=Hello Support Team,%0A%0AI encountered an error with the following reference ID: ${errorId}%0A%0APage URL: ${encodeURIComponent(window.location.href)}%0A%0APlease help resolve this issue.%0A%0AThank you.`}
+								className='flex flex-col items-center gap-3 p-4 rounded-lg border border-muted/20 hover:border-blue-DEFAULT/30 hover:bg-blue-DEFAULT/5 transition-all group'
+								aria-label={t('errorPage.emailSupportAria')}>
+								<div className='p-3 rounded-full bg-blue-DEFAULT/10 group-hover:bg-blue-DEFAULT/20 transition-colors'>
+									<svg
+										xmlns='http://www.w3.org/2000/svg'
+										width='24'
+										height='24'
+										viewBox='0 0 24 24'
+										fill='none'
+										stroke='currentColor'
+										strokeWidth='2'
+										strokeLinecap='round'
+										strokeLinejoin='round'
+										className='text-blue-DEFAULT'>
+										<rect width='20' height='16' x='2' y='4' rx='2' />
+										<path d='m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7' />
+									</svg>
+								</div>
+								<div className='text-center'>
+									<div className='font-medium text-sm'>{t('errorPage.emailSupport')}</div>
+									<div className='text-xs text-muted-foreground'>{t('errorPage.emailSupportSubtitle')}</div>
+								</div>
+							</a>
+						)}
 
-						<a
-							href='https://join.slack.com/t/flexpricecommunity/shared_invite/zt-3gnc3stna-sHuXbRb7lwYJgCvEvnw2Jw'
-							target='_blank'
-							rel='noopener noreferrer'
-							className='flex flex-col items-center gap-3 p-4 rounded-lg border border-muted/20 hover:border-blue-DEFAULT/30 hover:bg-blue-DEFAULT/5 transition-all group'
-							aria-label={t('errorPage.slackAria')}>
-							<div className='p-3 rounded-full bg-blue-DEFAULT/10 group-hover:bg-blue-DEFAULT/20 transition-colors'>
-								<MessageSquare size={24} className='text-blue-DEFAULT' />
-							</div>
-							<div className='text-center'>
-								<div className='font-medium text-sm'>{t('errorPage.slackCommunity')}</div>
-								<div className='text-xs text-muted-foreground'>{t('errorPage.slackSubtitle')}</div>
-							</div>
-						</a>
+						{contact && (
+							<a
+								href={contact.slackUrl}
+								target='_blank'
+								rel='noopener noreferrer'
+								className='flex flex-col items-center gap-3 p-4 rounded-lg border border-muted/20 hover:border-blue-DEFAULT/30 hover:bg-blue-DEFAULT/5 transition-all group'
+								aria-label={t('errorPage.slackAria')}>
+								<div className='p-3 rounded-full bg-blue-DEFAULT/10 group-hover:bg-blue-DEFAULT/20 transition-colors'>
+									<MessageSquare size={24} className='text-blue-DEFAULT' />
+								</div>
+								<div className='text-center'>
+									<div className='font-medium text-sm'>{t('errorPage.slackCommunity')}</div>
+									<div className='text-xs text-muted-foreground'>{t('errorPage.slackSubtitle')}</div>
+								</div>
+							</a>
+						)}
 
 						<a
 							href='https://github.com/flexprice/flexprice-front/issues'

--- a/src/components/molecules/ContactUsDialog/ContactUsDialog.tsx
+++ b/src/components/molecules/ContactUsDialog/ContactUsDialog.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 import { Mail, CalendarDays } from 'lucide-react';
 import { Dialog } from '@/components/atoms';
 import { useTranslation } from 'react-i18next';
-import { isFlexpriceContactEnabled } from '@/utils/hostname/isFlexpriceIoHostname';
-
-const SLACK_LINK = 'https://join.slack.com/t/flexpricecommunity/shared_invite/zt-39uat51l0-n8JmSikHZP~bHJNXladeaQ';
-const EMAIL_LINK = 'mailto:support@flexprice.io';
-const CALENDLY_LINK = 'https://calendly.com/nikhil-flexprice/30min';
+import { getContactDetails, isContactEnabled } from '@/config/contact';
 
 const openExternal = (url: string) => {
 	window.open(url, '_blank', 'noopener noreferrer');
@@ -22,9 +18,12 @@ interface ContactUsDialogProps {
 const ContactUsDialog: React.FC<ContactUsDialogProps> = ({ isOpen, onOpenChange, title, description }) => {
 	const { t } = useTranslation('common');
 
-	if (!isFlexpriceContactEnabled()) {
+	if (!isContactEnabled()) {
 		return null;
 	}
+
+	const { slackUrl, email, bookCallUrl } = getContactDetails();
+	const emailLink = `mailto:${email}`;
 
 	const dialogTitle = title ?? t('contactUs.defaultTitle');
 	const dialogDescription = description ?? t('contactUs.defaultDescription');
@@ -34,7 +33,7 @@ const ContactUsDialog: React.FC<ContactUsDialogProps> = ({ isOpen, onOpenChange,
 			<div className='flex gap-8 justify-center items-center px-4 pt-2'>
 				<button
 					type='button'
-					onClick={() => openExternal(SLACK_LINK)}
+					onClick={() => openExternal(slackUrl)}
 					className='flex flex-col items-center gap-2 group transition-transform duration-300 ease-in-out hover:scale-[1.03]'
 					aria-label={t('contactUs.slackAria')}>
 					<div
@@ -48,7 +47,7 @@ const ContactUsDialog: React.FC<ContactUsDialogProps> = ({ isOpen, onOpenChange,
 				</button>
 				<button
 					type='button'
-					onClick={() => openExternal(EMAIL_LINK)}
+					onClick={() => openExternal(emailLink)}
 					className='flex flex-col items-center gap-2 group transition-transform duration-300 ease-in-out hover:scale-[1.03]'
 					aria-label={t('contactUs.emailAria')}>
 					<div
@@ -62,7 +61,7 @@ const ContactUsDialog: React.FC<ContactUsDialogProps> = ({ isOpen, onOpenChange,
 				</button>
 				<button
 					type='button'
-					onClick={() => openExternal(CALENDLY_LINK)}
+					onClick={() => openExternal(bookCallUrl)}
 					className='flex flex-col items-center gap-2 group transition-transform duration-300 ease-in-out hover:scale-[1.03]'
 					aria-label={t('contactUs.bookCallAria')}>
 					<div

--- a/src/components/molecules/EnvironmentCreator/EnvironmentCreator.tsx
+++ b/src/components/molecules/EnvironmentCreator/EnvironmentCreator.tsx
@@ -8,7 +8,7 @@ import EnvironmentApi from '@/api/EnvironmentApi';
 import toast from 'react-hot-toast';
 import { Mail, CalendarDays, AlertTriangle } from 'lucide-react';
 import { SANDBOX_AUTO_CANCELLATION_DAYS } from '@/constants/constants';
-import { isFlexpriceContactEnabled } from '@/utils/hostname/isFlexpriceIoHostname';
+import { isContactEnabled, getContactDetails } from '@/config/contact';
 
 interface Props {
 	isOpen: boolean;
@@ -87,9 +87,8 @@ const EnvironmentCreator: React.FC<Props> = ({ isOpen, onOpenChange, onEnvironme
 	const isProduction = type === ENVIRONMENT_TYPE.PRODUCTION;
 	const isSandbox = type === ENVIRONMENT_TYPE.DEVELOPMENT;
 
-	const calendlyLink = 'https://calendly.com/nikhil-flexprice/30min';
-	const slackLink = 'https://join.slack.com/t/flexpricecommunity/shared_invite/zt-39uat51l0-n8JmSikHZP~bHJNXladeaQ';
-	const emailLink = 'mailto:support@flexprice.io';
+	const { slackUrl, email, bookCallUrl } = getContactDetails();
+	const emailLink = `mailto:${email}`;
 
 	const handleContactClick = (url: string) => {
 		window.open(url, '_blank', 'noopener noreferrer');
@@ -131,7 +130,7 @@ const EnvironmentCreator: React.FC<Props> = ({ isOpen, onOpenChange, onEnvironme
 				)}
 
 				{/* Production Contact Options */}
-				{isProduction && isFlexpriceContactEnabled() && (
+				{isProduction && isContactEnabled() && (
 					<div className='space-y-6 pt-2'>
 						<div className='text-center'>
 							<p className='text-sm text-gray-600 mb-6'>
@@ -143,7 +142,7 @@ const EnvironmentCreator: React.FC<Props> = ({ isOpen, onOpenChange, onEnvironme
 						<div className='flex gap-8 justify-center items-center px-4'>
 							<button
 								type='button'
-								onClick={() => handleContactClick(slackLink)}
+								onClick={() => handleContactClick(slackUrl)}
 								className='flex flex-col items-center gap-2 group transition-transform duration-300 ease-in-out hover:scale-[1.03]'
 								aria-label={t('environment.creator.ariaSlackContact')}>
 								<div
@@ -171,7 +170,7 @@ const EnvironmentCreator: React.FC<Props> = ({ isOpen, onOpenChange, onEnvironme
 							</button>
 							<button
 								type='button'
-								onClick={() => handleContactClick(calendlyLink)}
+								onClick={() => handleContactClick(bookCallUrl)}
 								className='flex flex-col items-center gap-2 group transition-transform duration-300 ease-in-out hover:scale-[1.03]'
 								aria-label={t('environment.creator.ariaBookCall')}>
 								<div

--- a/src/components/molecules/EnvironmentSelector/EnvironmentSelector.tsx
+++ b/src/components/molecules/EnvironmentSelector/EnvironmentSelector.tsx
@@ -17,7 +17,7 @@ import EnvironmentCreator from '../EnvironmentCreator/EnvironmentCreator';
 import EnvironmentCopier from '../EnvironmentCopier/EnvironmentCopier';
 import EnvironmentEditor from '../EnvironmentEditor/EnvironmentEditor';
 import ContactUsDialog from '../ContactUsDialog/ContactUsDialog';
-import { isFlexpriceContactEnabled } from '@/utils/hostname/isFlexpriceIoHostname';
+import { isContactEnabled } from '@/config/contact';
 import Environment, { ENVIRONMENT_TYPE } from '@/models/Environment';
 
 interface Props {
@@ -111,7 +111,7 @@ const EnvironmentSelector: React.FC<Props> = ({ disabled = false, className }) =
 		const restriction = getRestriction(environmentId, user?.tenant?.id);
 		if (restriction.state === EnvRestrictionState.Suspended) {
 			setIsOpen(false);
-			if (isFlexpriceContactEnabled()) {
+			if (isContactEnabled()) {
 				setIsSuspendedDialogOpen(true);
 			}
 			return;
@@ -259,7 +259,7 @@ const EnvironmentSelector: React.FC<Props> = ({ disabled = false, className }) =
 				}}
 			/>
 
-			{isFlexpriceContactEnabled() && (
+			{isContactEnabled() && (
 				<ContactUsDialog
 					isOpen={isSuspendedDialogOpen}
 					onOpenChange={setIsSuspendedDialogOpen}

--- a/src/components/molecules/RestrictedEnvBanner/RestrictedEnvBanner.tsx
+++ b/src/components/molecules/RestrictedEnvBanner/RestrictedEnvBanner.tsx
@@ -6,7 +6,7 @@ import { useRestrictedEnvs, EnvRestrictionState } from '@/hooks/useRestrictedEnv
 import useUser from '@/hooks/useUser';
 import { ENVIRONMENT_TYPE } from '@/models/Environment';
 import ContactUsDialog from '../ContactUsDialog/ContactUsDialog';
-import { isFlexpriceContactEnabled } from '@/utils/hostname/isFlexpriceIoHostname';
+import { isContactEnabled } from '@/config/contact';
 
 function daysLeft(expiresAt: string): number {
 	return Math.max(0, Math.ceil((new Date(expiresAt).getTime() - Date.now()) / (1000 * 60 * 60 * 24)));
@@ -42,7 +42,7 @@ const RestrictedEnvBanner: React.FC = () => {
 	const { environments } = useEnvironment();
 	const { isTenantRestricted, getRestrictionResultsForTenant } = useRestrictedEnvs();
 	const [isContactDialogOpen, setIsContactDialogOpen] = useState(false);
-	const showContactOptions = isFlexpriceContactEnabled();
+	const showContactOptions = isContactEnabled();
 
 	const tenantId = user?.tenant?.id ?? '';
 	const tenantEntries = useMemo(() => getRestrictionResultsForTenant(tenantId), [tenantId, getRestrictionResultsForTenant]);

--- a/src/components/organisms/CommandPalette/CommandPalette.tsx
+++ b/src/components/organisms/CommandPalette/CommandPalette.tsx
@@ -15,7 +15,7 @@ import {
 	isCommandPaletteActionFlexpriceOnly,
 } from '@/core/actions';
 import useEnvironment from '@/hooks/useEnvironment';
-import { isFlexpriceContactEnabled } from '@/utils/hostname/isFlexpriceIoHostname';
+import { isContactEnabled } from '@/config/contact';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import type { CommandPaletteGroupType } from '@/config/command-palette';
@@ -75,10 +75,10 @@ const CommandPalette = () => {
 	};
 
 	const visibleCommands = useMemo(() => {
-		const flexpriceContactEnabled = isFlexpriceContactEnabled();
+		const contactEnabled = isContactEnabled();
 		return commandPaletteCommands.filter((cmd) => {
 			if (cmd.actionId && isCommandPaletteActionDevOnly(cmd.actionId)) return isDevelopment;
-			if (cmd.actionId && isCommandPaletteActionFlexpriceOnly(cmd.actionId) && !flexpriceContactEnabled) {
+			if (cmd.actionId && isCommandPaletteActionFlexpriceOnly(cmd.actionId) && !contactEnabled) {
 				return false;
 			}
 			if (cmd.actionId === CommandPaletteActionId.OpenIntercom && !isIntercomMessengerAvailable()) {

--- a/src/config/config.brand.test.ts
+++ b/src/config/config.brand.test.ts
@@ -190,6 +190,7 @@ describe('config object', () => {
 		expect(typeof config.platform.sidebar_documentation.enabled).toBe('boolean');
 		expect(typeof config.platform.guides.enabled).toBe('boolean');
 		expect(typeof config.platform.onboarding.enabled).toBe('boolean');
+		expect(typeof config.platform.contact_us.enabled).toBe('boolean');
 	});
 });
 
@@ -201,6 +202,7 @@ describe('parsePlatformConfig', () => {
 		expect(result.sidebar_documentation.enabled).toBe(true);
 		expect(result.guides.enabled).toBe(true);
 		expect(result.onboarding.enabled).toBe(true);
+		expect(result.contact_us.enabled).toBe(false);
 	});
 
 	it('applies per-feature overrides from VITE_PLATFORM_CONFIG JSON', async () => {
@@ -228,6 +230,14 @@ describe('parsePlatformConfig', () => {
 		const result = parsePlatformConfig('{not-json');
 		expect(result.guides.enabled).toBe(true);
 		expect(result.onboarding.enabled).toBe(true);
+		expect(result.contact_us.enabled).toBe(false);
+	});
+
+	it('enables contact_us from boolean or enabled object', async () => {
+		const { parsePlatformConfig } = await import('./config');
+		expect(parsePlatformConfig('{"contact_us":true}').contact_us.enabled).toBe(true);
+		expect(parsePlatformConfig('{"contact_us":{"enabled":true}}').contact_us.enabled).toBe(true);
+		expect(parsePlatformConfig('{"contact_us":false}').contact_us.enabled).toBe(false);
 	});
 });
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -81,6 +81,9 @@ export interface PlatformConfig {
 	onboarding: {
 		enabled: boolean;
 	};
+	contact_us: {
+		enabled: boolean;
+	};
 }
 
 const PLATFORM_FEATURE_DEFAULTS = {
@@ -97,6 +100,7 @@ interface PlatformConfigJson {
 	sidebar_documentation?: { enabled?: boolean };
 	guides?: { enabled?: boolean };
 	onboarding?: { enabled?: boolean };
+	contact_us?: boolean | { enabled?: boolean };
 }
 
 function parsePlatformFeatureEnabled(parsed: PlatformConfigJson | undefined, key: PlatformFeatureKey): boolean {
@@ -105,7 +109,14 @@ function parsePlatformFeatureEnabled(parsed: PlatformConfigJson | undefined, key
 	return PLATFORM_FEATURE_DEFAULTS[key];
 }
 
-/** Parse `VITE_PLATFORM_CONFIG` JSON. Keys: api_reference, sidebar_documentation, guides, onboarding. Omitted keys default to `enabled: true`. */
+function parseContactUsEnabled(parsed: PlatformConfigJson | undefined): boolean {
+	const raw = parsed?.contact_us;
+	if (raw === true) return true;
+	if (typeof raw === 'object' && raw !== null && raw.enabled === true) return true;
+	return false;
+}
+
+/** Parse `VITE_PLATFORM_CONFIG` JSON. Keys: api_reference, sidebar_documentation, guides, onboarding, contact_us. Omitted keys default to `enabled: true` (contact_us defaults to false). */
 export function parsePlatformConfig(rawPlatformConfig?: string): PlatformConfig {
 	let parsed: PlatformConfigJson | undefined;
 	const raw = rawPlatformConfig?.trim();
@@ -123,6 +134,7 @@ export function parsePlatformConfig(rawPlatformConfig?: string): PlatformConfig 
 		sidebar_documentation: { enabled: parsePlatformFeatureEnabled(parsed, 'sidebar_documentation') },
 		guides: { enabled: parsePlatformFeatureEnabled(parsed, 'guides') },
 		onboarding: { enabled: parsePlatformFeatureEnabled(parsed, 'onboarding') },
+		contact_us: { enabled: parseContactUsEnabled(parsed) },
 	};
 }
 

--- a/src/config/contact.test.ts
+++ b/src/config/contact.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+describe('contact config', () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it('returns platform contact details when contact_us is enabled', async () => {
+		vi.stubEnv('VITE_PLATFORM_CONFIG', '{"contact_us":true}');
+		const { getContactDetails, isPlatformContactUsEnabled, isContactEnabled } = await import('./contact');
+
+		expect(isPlatformContactUsEnabled()).toBe(true);
+		expect(isContactEnabled()).toBe(true);
+		expect(getContactDetails()).toEqual({
+			slackUrl: 'https://tirdad-community.slack.com',
+			email: 'yaser@tirdad.ai',
+			bookCallUrl: 'https://cal.com/tirdad/demo',
+		});
+	});
+
+	it('returns Flexprice contact details by default', async () => {
+		const { getContactDetails, isPlatformContactUsEnabled } = await import('./contact');
+
+		expect(isPlatformContactUsEnabled()).toBe(false);
+		expect(getContactDetails()).toEqual({
+			slackUrl: 'https://join.slack.com/t/flexpricecommunity/shared_invite/zt-39uat51l0-n8JmSikHZP~bHJNXladeaQ',
+			email: 'support@flexprice.io',
+			bookCallUrl: 'https://calendly.com/nikhil-flexprice/30min',
+		});
+	});
+});

--- a/src/config/contact.ts
+++ b/src/config/contact.ts
@@ -1,0 +1,39 @@
+import { config } from './config';
+import { isFlexpriceIoHostname } from '@/utils/hostname/isFlexpriceIoHostname';
+
+export interface ContactDetails {
+	slackUrl: string;
+	email: string;
+	bookCallUrl: string;
+}
+
+const FLEXPRICE_CONTACT: ContactDetails = {
+	slackUrl: 'https://join.slack.com/t/flexpricecommunity/shared_invite/zt-39uat51l0-n8JmSikHZP~bHJNXladeaQ',
+	email: 'support@flexprice.io',
+	bookCallUrl: 'https://calendly.com/nikhil-flexprice/30min',
+};
+
+/** White-label contact details when `contact_us` is enabled in platform config. */
+const PLATFORM_CONTACT_US: ContactDetails = {
+	slackUrl: 'https://tirdad-community.slack.com',
+	email: 'yaser@tirdad.ai',
+	bookCallUrl: 'https://cal.com/tirdad/demo',
+};
+
+export function isPlatformContactUsEnabled(): boolean {
+	return config.platform.contact_us.enabled;
+}
+
+/** Show contact options on flexprice.io or when `contact_us` is enabled in platform config. */
+export function isContactEnabled(): boolean {
+	if (isPlatformContactUsEnabled()) return true;
+	return typeof window !== 'undefined' && isFlexpriceIoHostname(window.location.hostname);
+}
+
+export function getContactDetails(): ContactDetails {
+	return isPlatformContactUsEnabled() ? PLATFORM_CONTACT_US : FLEXPRICE_CONTACT;
+}
+
+export function getContactEmailMailto(): string {
+	return `mailto:${getContactDetails().email}`;
+}

--- a/src/core/actions/command-palette-actions.ts
+++ b/src/core/actions/command-palette-actions.ts
@@ -7,15 +7,20 @@
  * - Built-in handlers (e.g. open URL) run immediately when dispatching; no subscriber needed.
  */
 
+import { getContactDetails, getContactEmailMailto } from '@/config/contact';
+
 export const COMMAND_PALETTE_ACTION_EVENT_PREFIX = 'command-palette:action:';
 
 /** URLs and mailto used by built-in developer-help actions. */
-export const COMMAND_PALETTE_ACTION_URLS = {
-	documentation: 'https://docs.flexprice.io',
-	contactEmail: 'mailto:support@flexprice.io',
-	bookCall: 'https://calendly.com/nikhil-flexprice/30min',
-	slackCommunity: 'https://join.slack.com/t/flexpricecommunity/shared_invite/zt-39uat51l0-n8JmSikHZP~bHJNXladeaQ',
-} as const;
+export function getCommandPaletteActionUrls() {
+	const contact = getContactDetails();
+	return {
+		documentation: 'https://docs.flexprice.io',
+		contactEmail: getContactEmailMailto(),
+		bookCall: contact.bookCallUrl,
+		slackCommunity: contact.slackUrl,
+	} as const;
+}
 
 /** All executable action IDs. Add new ones here and keep in sync with command config. */
 export const CommandPaletteActionId = {
@@ -43,7 +48,7 @@ export const COMMAND_PALETTE_ACTION_META: Record<
 	{
 		/** Only show this action when isDevelopment is true. */
 		devOnly?: boolean;
-		/** Only show on flexprice.io hostnames (white-label deployments hide Flexprice contact options). */
+		/** Only show on flexprice.io hostnames or when contact_us is enabled (white-label deployments hide Flexprice contact options). */
 		flexpriceOnly?: boolean;
 	}
 > = {
@@ -63,18 +68,19 @@ export function getCommandPaletteActionEventName(actionId: string): string {
 }
 
 function runBuiltInHandler(actionId: string): void {
+	const urls = getCommandPaletteActionUrls();
 	switch (actionId) {
 		case CommandPaletteActionId.OpenDocumentation:
-			window.open(COMMAND_PALETTE_ACTION_URLS.documentation, '_blank', 'noopener,noreferrer');
+			window.open(urls.documentation, '_blank', 'noopener,noreferrer');
 			break;
 		case CommandPaletteActionId.ContactUs:
-			window.open(COMMAND_PALETTE_ACTION_URLS.contactEmail, '_blank', 'noopener,noreferrer');
+			window.open(urls.contactEmail, '_blank', 'noopener,noreferrer');
 			break;
 		case CommandPaletteActionId.BookCall:
-			window.open(COMMAND_PALETTE_ACTION_URLS.bookCall, '_blank', 'noopener,noreferrer');
+			window.open(urls.bookCall, '_blank', 'noopener,noreferrer');
 			break;
 		case CommandPaletteActionId.JoinSlackCommunity:
-			window.open(COMMAND_PALETTE_ACTION_URLS.slackCommunity, '_blank', 'noopener,noreferrer');
+			window.open(urls.slackCommunity, '_blank', 'noopener,noreferrer');
 			break;
 		default:
 			break;
@@ -95,7 +101,7 @@ export function isCommandPaletteActionDevOnly(actionId: string): boolean {
 	return COMMAND_PALETTE_ACTION_META[actionId as CommandPaletteActionIdType]?.devOnly ?? false;
 }
 
-/** Check if an action should be hidden on non-flexprice.io hostnames. */
+/** Check if an action should be hidden when contact options are unavailable. */
 export function isCommandPaletteActionFlexpriceOnly(actionId: string): boolean {
 	return COMMAND_PALETTE_ACTION_META[actionId as CommandPaletteActionIdType]?.flexpriceOnly ?? false;
 }

--- a/src/core/actions/index.ts
+++ b/src/core/actions/index.ts
@@ -2,7 +2,7 @@ export {
 	CommandPaletteActionId,
 	COMMAND_PALETTE_ACTION_EVENT_PREFIX,
 	COMMAND_PALETTE_ACTION_META,
-	COMMAND_PALETTE_ACTION_URLS,
+	getCommandPaletteActionUrls,
 	dispatchCommandPaletteAction,
 	getCommandPaletteActionEventName,
 	isCommandPaletteActionDevOnly,

--- a/src/i18n/locales/ar/settings.json
+++ b/src/i18n/locales/ar/settings.json
@@ -685,15 +685,11 @@
 					"sections": {
 						"overview": {
 							"title": "نظرة عامة",
-							"paragraphs": [
-								"يتيح تطبيق {{brandName}} لـ Stripe إصدار الفواتير وتحصيل الضريبة والدفع عبر Stripe."
-							]
+							"paragraphs": ["يتيح تطبيق {{brandName}} لـ Stripe إصدار الفواتير وتحصيل الضريبة والدفع عبر Stripe."]
 						},
 						"stripeInvoicing": {
 							"title": "الفوترة عبر Stripe",
-							"paragraphs": [
-								"أنشئ الفواتير وأرسلها عبر Stripe Invoicing مباشرةً من {{brandName}}، وحصّل المدفوعات تلقائياً."
-							]
+							"paragraphs": ["أنشئ الفواتير وأرسلها عبر Stripe Invoicing مباشرةً من {{brandName}}، وحصّل المدفوعات تلقائياً."]
 						},
 						"automaticTax": {
 							"title": "حساب الضريبة تلقائياً",
@@ -751,15 +747,11 @@
 						},
 						"invoiceSync": {
 							"title": "مزامنة الفواتير",
-							"paragraphs": [
-								"زامن الفواتير من {{brandName}} إلى Chargebee لضمان بقاء نظام الفوترة لديك محدّثاً بأحدث بيانات الفواتير."
-							]
+							"paragraphs": ["زامن الفواتير من {{brandName}} إلى Chargebee لضمان بقاء نظام الفوترة لديك محدّثاً بأحدث بيانات الفواتير."]
 						},
 						"chargePriceSync": {
 							"title": "مزامنة الرسوم والأسعار",
-							"paragraphs": [
-								"زامن الرسوم والأسعار بين {{brandName}} وChargebee للحفاظ على الاتساق عبر منصة الفوترة لديك."
-							]
+							"paragraphs": ["زامن الرسوم والأسعار بين {{brandName}} وChargebee للحفاظ على الاتساق عبر منصة الفوترة لديك."]
 						}
 					}
 				},
@@ -775,33 +767,23 @@
 						},
 						"dealLineItems": {
 							"title": "مزامنة بنود الصفقة",
-							"paragraphs": [
-								"زامن بنود الصفقات تلقائياً من HubSpot إلى {{brandName}} لضمان دقة تتبّع الإيرادات والفوترة."
-							]
+							"paragraphs": ["زامن بنود الصفقات تلقائياً من HubSpot إلى {{brandName}} لضمان دقة تتبّع الإيرادات والفوترة."]
 						},
 						"invoiceSync": {
 							"title": "مزامنة الفواتير",
-							"paragraphs": [
-								"ادفع الفواتير من {{brandName}} إلى HubSpot ليبقى نظام إدارة علاقات العملاء لديك محدّثاً بمعلومات الفوترة."
-							]
+							"paragraphs": ["ادفع الفواتير من {{brandName}} إلى HubSpot ليبقى نظام إدارة علاقات العملاء لديك محدّثاً بمعلومات الفوترة."]
 						},
 						"customerSync": {
 							"title": "مزامنة العملاء",
-							"paragraphs": [
-								"زامن بيانات العملاء بين HubSpot و{{brandName}} للحفاظ على مصدر واحد موثوق لمعلومات العملاء."
-							]
+							"paragraphs": ["زامن بيانات العملاء بين HubSpot و{{brandName}} للحفاظ على مصدر واحد موثوق لمعلومات العملاء."]
 						},
 						"paymentsSync": {
 							"title": "مزامنة المدفوعات",
-							"paragraphs": [
-								"حافظ على تزامن سجلات المدفوعات بين المنصتين لإعداد تقارير مالية دقيقة."
-							]
+							"paragraphs": ["حافظ على تزامن سجلات المدفوعات بين المنصتين لإعداد تقارير مالية دقيقة."]
 						},
 						"revenueReporting": {
 							"title": "حسابات الإيرادات في HubSpot",
-							"paragraphs": [
-								"استفد من إمكانات إعداد التقارير في HubSpot مع بيانات إيرادات دقيقة مزامنة من {{brandName}}."
-							]
+							"paragraphs": ["استفد من إمكانات إعداد التقارير في HubSpot مع بيانات إيرادات دقيقة مزامنة من {{brandName}}."]
 						}
 					}
 				},
@@ -819,9 +801,7 @@
 					"sections": {
 						"createCustomer": {
 							"title": "إنشاء عميل في Zoho Books",
-							"paragraphs": [
-								"أنشئ العملاء أو حدّثهم تلقائياً في Zoho Books عند إضافة عميل جديد أو تعديله في {{brandName}}."
-							]
+							"paragraphs": ["أنشئ العملاء أو حدّثهم تلقائياً في Zoho Books عند إضافة عميل جديد أو تعديله في {{brandName}}."]
 						},
 						"createInvoice": {
 							"title": "إنشاء فاتورة في Zoho Books",
@@ -831,9 +811,7 @@
 						},
 						"transformInvoice": {
 							"title": "تحويل فاتورة {{brandName}} إلى فاتورة Zoho Books",
-							"paragraphs": [
-								"حوّل كائن فاتورة {{brandName}} إلى تنسيق فاتورة Zoho Books — لتبسيط تدفق البيانات وضمان الدقة."
-							]
+							"paragraphs": ["حوّل كائن فاتورة {{brandName}} إلى تنسيق فاتورة Zoho Books — لتبسيط تدفق البيانات وضمان الدقة."]
 						}
 					}
 				},
@@ -927,9 +905,7 @@
 						},
 						"webhooks": {
 							"title": "تكامل Webhook",
-							"paragraphs": [
-								"استقبل إشعارات فورية عن أحداث الدفع عبر Webhooks. اشترك في حدث payment_paid لتبقى على اطّلاع على حالة الدفع."
-							]
+							"paragraphs": ["استقبل إشعارات فورية عن أحداث الدفع عبر Webhooks. اشترك في حدث payment_paid لتبقى على اطّلاع على حالة الدفع."]
 						}
 					}
 				},


### PR DESCRIPTION
Centralize contact config so deployments can enable Slack, email, and book-a-call links via VITE_PLATFORM_CONFIG without relying on flexprice.io hostname checks.