### PR TITLE
fix(features): send custom expression in meter request and tidy help text

### DIFF
--- a/src/i18n/locales/ar/catalog.json
+++ b/src/i18n/locales/ar/catalog.json
@@ -744,7 +744,7 @@
 			"aggregationFieldButton": "حقل التجميع",
 			"customExpression": "تعبير مخصص*",
 			"customExpressionPh": "ceil(duration_ms / 1000)",
-			"customExpressionHelp": "اكتب صيغة CEL تُحسب لكل حدث لحساب الكمية. المتغيرات هي أسماء الخصائص ذات المستوى الأعلى في الأحداث (مثل duration_ms وtokens). الدوال المتاحة: max(a, b)، min(a, b)، abs(x)، ceil(x)، floor(x)، round(x)، pow(x, y)، sqrt(x)، log(x). أمثلة: \"input_tokens + output_tokens\"، \"ceil(duration_ms / 1000)\"، \"min(usage, quota)\". متاح فقط لـ SUM وAVG وMAX وLATEST.",
+			"customExpressionHelp": "اكتب صيغة CEL تُحسب لكل حدث لحساب الكمية. المتغيرات هي أسماء الخصائص ذات المستوى الأعلى في الأحداث (مثل duration_ms وtokens).\n\nالدوال المتاحة: max(a, b)، min(a, b)، abs(x)، ceil(x)، floor(x)، round(x)، pow(x, y)، sqrt(x)، log(x).\n\nأمثلة:\n• input_tokens + output_tokens\n• ceil(duration_ms / 1000)\n• min(usage, quota)\n• max(cores * hours * rate, 0.01)",
 			"aggregationMultiplierPh": "1",
 			"aggregationMultiplierHelp": "حدد المضاعف للتجميع، مثل 1.5 أو 0.25 أو 1000.",
 			"bucketSizeButton": "حجم الدفعة",

--- a/src/i18n/locales/ar/catalog.json
+++ b/src/i18n/locales/ar/catalog.json
@@ -769,6 +769,7 @@
 			"aggregationDetails": "تفاصيل التجميع",
 			"type": "النوع",
 			"value": "القيمة",
+			"customExpression": "تعبير مخصص",
 			"unitName": "اسم الوحدة",
 			"displayUnitName": "اسم وحدة العرض",
 			"usageReset": "إعادة ضبط الاستخدام ",

--- a/src/i18n/locales/en/catalog.json
+++ b/src/i18n/locales/en/catalog.json
@@ -743,7 +743,7 @@
 			"aggregationFieldButton": "Aggregation field",
 			"customExpression": "Custom Expression*",
 			"customExpressionPh": "ceil(duration_ms / 1000)",
-			"customExpressionHelp": "Write a CEL formula evaluated per event to compute the quantity. Variables are top-level property names on your events (e.g. duration_ms, tokens). Available functions: max(a, b), min(a, b), abs(x), ceil(x), floor(x), round(x), pow(x, y), sqrt(x), log(x). Examples: \"input_tokens + output_tokens\", \"ceil(duration_ms / 1000)\", \"min(usage, quota)\", \"max(cores * hours * rate, 0.01)\". Only available for SUM, AVG, MAX and LATEST.",
+			"customExpressionHelp": "Write a CEL formula evaluated per event to compute the quantity. Variables are top-level property names on your events (e.g. duration_ms, tokens).\n\nAvailable functions: max(a, b), min(a, b), abs(x), ceil(x), floor(x), round(x), pow(x, y), sqrt(x), log(x).\n\nExamples:\n• input_tokens + output_tokens\n• ceil(duration_ms / 1000)\n• min(usage, quota)\n• max(cores * hours * rate, 0.01)",
 			"aggregationMultiplier": "Aggregation Multiplier*",
 			"aggregationMultiplierPh": "1",
 			"aggregationMultiplierHelp": "Specify the multiplier for the aggregation. e.g. 1.5, 0.25, or 1000.",

--- a/src/i18n/locales/en/catalog.json
+++ b/src/i18n/locales/en/catalog.json
@@ -769,6 +769,7 @@
 			"aggregationDetails": "Aggregation Details",
 			"type": "Type",
 			"value": "Value",
+				"customExpression": "Custom Expression",
 			"unitName": "Unit Name",
 			"displayUnitName": "Display Unit Name",
 			"usageReset": "Usage Reset ",

--- a/src/pages/product-catalog/features/AddFeature.tsx
+++ b/src/pages/product-catalog/features/AddFeature.tsx
@@ -723,6 +723,7 @@ const AggregationSection = ({
 		(type: string) => {
 			const nextType = type as METER_AGGREGATION_TYPE;
 			const supportsBucketSize = aggregationSupportsBucketSize(nextType);
+			const stillSupportsExpression = EXPRESSION_SUPPORTED_TYPES.includes(nextType);
 			if (!supportsBucketSize) {
 				onUpdateFormState({ showBucketSize: false });
 			}
@@ -733,6 +734,7 @@ const AggregationSection = ({
 						...meter?.aggregation,
 						type: nextType,
 						field: meter?.aggregation?.field ?? '',
+						expression: stillSupportsExpression ? meter?.aggregation?.expression : '',
 						...(supportsBucketSize ? {} : { bucket_size: undefined }),
 					},
 				},
@@ -741,7 +743,7 @@ const AggregationSection = ({
 				onUpdateFormState({ showCustomExpression: false });
 			}
 		},
-		[onUpdateFeature, onUpdateFormState, meter],
+		[onUpdateFeature, onUpdateFormState, meter, formState.showCustomExpression],
 	);
 
 	const handleAggregationFieldChange = useCallback(
@@ -868,9 +870,12 @@ const AggregationSection = ({
 		[onUpdateFeature, meter],
 	);
 
-	const showFieldInput = meter?.aggregation?.type !== METER_AGGREGATION_TYPE.COUNT;
-	const showMultiplierInput = meter?.aggregation?.type === METER_AGGREGATION_TYPE.SUM_WITH_MULTIPLIER;
-	const supportsBucketSize = aggregationSupportsBucketSize(meter?.aggregation?.type);
+	const aggType = meter?.aggregation?.type;
+	const supportsExpression = aggType ? EXPRESSION_SUPPORTED_TYPES.includes(aggType) : false;
+	const showExpressionInput = supportsExpression && formState.showCustomExpression;
+	const showFieldInput = aggType !== METER_AGGREGATION_TYPE.COUNT && !showExpressionInput;
+	const showMultiplierInput = aggType === METER_AGGREGATION_TYPE.SUM_WITH_MULTIPLIER;
+	const supportsBucketSize = aggregationSupportsBucketSize(aggType);
 
 	return (
 		<>

--- a/src/pages/product-catalog/features/AddFeature.tsx
+++ b/src/pages/product-catalog/features/AddFeature.tsx
@@ -904,7 +904,7 @@ const AggregationSection = ({
 						onChange={handleAggregationExpressionChange}
 						label={t('catalog:features.form.customExpression')}
 						placeholder={t('catalog:features.form.customExpressionPh')}
-						description={t('catalog:features.form.customExpressionHelp')}
+						description={<span className='whitespace-pre-line'>{t('catalog:features.form.customExpressionHelp')}</span>}
 						error={meterErrors.aggregation_expression}
 					/>
 				)}
@@ -1047,7 +1047,11 @@ const AddFeaturePage = () => {
 							event_name: featureData.meter.event_name || '',
 							aggregation: {
 								type: featureData.meter.aggregation?.type || METER_AGGREGATION_TYPE.SUM,
-								field: featureData.meter.aggregation?.field || '',
+								// XOR with field — the toggle handler clears the inactive side,
+								// so at most one of these is populated at submit time.
+								...(featureData.meter.aggregation?.expression?.trim()
+									? { expression: featureData.meter.aggregation.expression.trim() }
+									: { field: featureData.meter.aggregation?.field || '' }),
 								multiplier: featureData.meter.aggregation?.multiplier,
 								bucket_size: aggregationSupportsBucketSize(featureData.meter.aggregation?.type)
 									? featureData.meter.aggregation?.bucket_size

--- a/src/pages/product-catalog/features/FeatureDetails.tsx
+++ b/src/pages/product-catalog/features/FeatureDetails.tsx
@@ -460,8 +460,16 @@ const FeatureDetails = () => {
 											</span>
 										</div>
 										<div className='grid grid-cols-[200px_1fr] items-center'>
-											<span className='text-gray-500 text-sm'>{t('catalog:features.details.value')}</span>
-											<span className='text-gray-800 text-sm'>{data?.meter?.aggregation.field || t('common:labels.na')}</span>
+											<span className='text-gray-500 text-sm'>
+												{t(
+													data?.meter?.aggregation?.expression
+														? 'catalog:features.details.customExpression'
+														: 'catalog:features.details.value',
+												)}
+											</span>
+											<span className='text-gray-800 text-sm'>
+												{data?.meter?.aggregation?.expression || data?.meter?.aggregation?.field || t('common:labels.na')}
+											</span>
 										</div>
 
 										<div className='grid grid-cols-[200px_1fr] items-center'>


### PR DESCRIPTION
Meter request was hard-coding `aggregation.field` and dropping `expression`, so meters created in Custom Expression mode were rejected by the backend (neither field nor expression set). Switch to XOR construction: include `expression` when populated, otherwise `field`. UI toggle already clears the inactive side so at most one is set at submit time.

Also restructured the Custom Expression help text into three sections (intro / functions / examples) with line breaks for readability, and dropped the "Only available for SUM, AVG, MAX, LATEST" sentence — the UI already enforces that constraint by hiding the toggle for unsupported types. Description now rendered inside whitespace-pre-line so newlines in the i18n string break visually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the custom expression help text display so formatting, line breaks, and examples render clearly.
  * Adjusted feature submission behavior so custom expressions and fields are handled correctly, preventing both from being sent together.
  * Updated localized help text in English and Arabic for a more consistent in-app experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->