### PR TITLE
fix(EditSubscriptionEntitlementDrawer): add validation for JSON editor input and improve state management

### DIFF
--- a/src/components/molecules/EntitlementOverrides/EditEntitlementDrawer.tsx
+++ b/src/components/molecules/EntitlementOverrides/EditEntitlementDrawer.tsx
@@ -23,6 +23,7 @@ const EditEntitlementDrawer: FC<EditEntitlementDrawerProps> = ({ isOpen, onOpenC
 	const [staticValue, setStaticValue] = useState<string>('');
 	const [isEnabled, setIsEnabled] = useState<boolean>(true);
 	const [configValue, setConfigValue] = useState<JsonObject | null>(null);
+	const [configInvalid, setConfigInvalid] = useState<boolean>(false);
 
 	// Derived synchronously so JsonEditor always mounts with the correct value on first open
 	const initialConfigValue = useMemo((): JsonObject | null => {
@@ -41,6 +42,7 @@ const EditEntitlementDrawer: FC<EditEntitlementDrawerProps> = ({ isOpen, onOpenC
 			setStaticValue(entitlement.displayStaticValue || entitlement.static_value || '');
 			setIsEnabled(entitlement.displayIsEnabled ?? entitlement.is_enabled ?? true);
 			setConfigValue(null);
+			setConfigInvalid(false);
 		}
 	}, [entitlement]);
 
@@ -65,6 +67,10 @@ const EditEntitlementDrawer: FC<EditEntitlementDrawerProps> = ({ isOpen, onOpenC
 		} else if (entitlement.feature_type === FEATURE_TYPE.BOOLEAN) {
 			override.is_enabled = isEnabled;
 		} else if (entitlement.feature_type === FEATURE_TYPE.CONFIG) {
+			if (configInvalid) {
+				toast.error(t('jsonEditor.errorInvalidJson'));
+				return;
+			}
 			const effectiveConfigValue = configValue ?? initialConfigValue;
 			if (!effectiveConfigValue) {
 				toast.error(t('entitlements.addDrawer.configValueRequired'));
@@ -189,7 +195,14 @@ const EditEntitlementDrawer: FC<EditEntitlementDrawerProps> = ({ isOpen, onOpenC
 				{entitlement.feature_type === FEATURE_TYPE.CONFIG && (
 					<div className='space-y-2'>
 						<Label label={t('catalog:jsonEditor.title')} />
-						<JsonEditor key={entitlement.id ?? entitlement.feature_id} value={initialConfigValue} onChange={(val) => setConfigValue(val)} />
+						<JsonEditor
+							key={entitlement.id ?? entitlement.feature_id}
+							value={initialConfigValue}
+							onChange={(val, raw) => {
+								setConfigValue(val);
+								setConfigInvalid(raw.trim() !== '' && raw.trim() !== '{}' && val === null);
+							}}
+						/>
 					</div>
 				)}
 

--- a/src/components/molecules/EntitlementOverrides/EditSubscriptionEntitlementDrawer.tsx
+++ b/src/components/molecules/EntitlementOverrides/EditSubscriptionEntitlementDrawer.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { Sheet, Label, Input, Button, Checkbox } from '@/components/atoms';
 import { Switch } from '@/components/ui/switch';
 import { JsonEditor } from '@/components/molecules/JsonEditor';
@@ -39,6 +39,13 @@ const EditSubscriptionEntitlementDrawer: FC<EditSubscriptionEntitlementDrawerPro
 	const [staticValue, setStaticValue] = useState<string>('');
 	const [isEnabled, setIsEnabled] = useState<boolean>(true);
 	const [configValue, setConfigValue] = useState<JsonObject | null>(null);
+	const [configInvalid, setConfigInvalid] = useState<boolean>(false);
+
+	const initialConfigValue = useMemo((): JsonObject | null => {
+		const raw = getEffectiveConfigValue(entitlement?.sources ?? []);
+		if (raw !== null && typeof raw === 'object' && !Array.isArray(raw)) return raw as JsonObject;
+		return null;
+	}, [entitlement]);
 
 	useEffect(() => {
 		if (entitlement) {
@@ -49,7 +56,8 @@ const EditSubscriptionEntitlementDrawer: FC<EditSubscriptionEntitlementDrawerPro
 			setUsageLimit(isCurrentlyInfinite ? '' : currentLimit?.toString() || '');
 			setStaticValue(getEffectiveStaticValue(entitlement.entitlement) || '');
 			setIsEnabled(entitlement.entitlement?.is_enabled ?? true);
-			setConfigValue(getEffectiveConfigValue(entitlement.sources));
+			setConfigValue(null);
+			setConfigInvalid(false);
 		}
 	}, [entitlement]);
 
@@ -114,12 +122,16 @@ const EditSubscriptionEntitlementDrawer: FC<EditSubscriptionEntitlementDrawerPro
 		} else if (entitlement.feature_type === FEATURE_TYPE.BOOLEAN) {
 			values.is_enabled = isEnabled;
 		} else if (entitlement.feature_type === FEATURE_TYPE.CONFIG) {
-			values.is_enabled = isEnabled;
-			if (!configValue) {
+			if (configInvalid) {
+				toast.error(t('jsonEditor.errorInvalidJson'));
+				return;
+			}
+			const effectiveConfigValue = configValue ?? initialConfigValue;
+			if (!effectiveConfigValue) {
 				toast.error(t('entitlements.addDrawer.configValueRequired'));
 				return;
 			}
-			values.config_value = configValue;
+			values.config_value = effectiveConfigValue;
 		}
 
 		saveOverride(values);
@@ -220,7 +232,7 @@ const EditSubscriptionEntitlementDrawer: FC<EditSubscriptionEntitlementDrawerPro
 					</div>
 				)}
 
-				{(entitlement.feature_type === FEATURE_TYPE.BOOLEAN || entitlement.feature_type === FEATURE_TYPE.CONFIG) && (
+				{entitlement.feature_type === FEATURE_TYPE.BOOLEAN && (
 					<div className='space-y-2'>
 						<Label label={t('entitlements.editDrawer.enabledLabel')} />
 						<div className='flex items-center gap-2'>
@@ -241,8 +253,11 @@ const EditSubscriptionEntitlementDrawer: FC<EditSubscriptionEntitlementDrawerPro
 						<Label label={t('catalog:jsonEditor.title')} />
 						<JsonEditor
 							key={entitlement.entitlement?.id ?? entitlement.feature_id}
-							value={configValue}
-							onChange={(val) => setConfigValue(val)}
+							value={initialConfigValue}
+							onChange={(val, raw) => {
+								setConfigValue(val);
+								setConfigInvalid(raw.trim() !== '' && raw.trim() !== '{}' && val === null);
+							}}
 						/>
 					</div>
 				)}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when editing JSON-based entitlement overrides.
  * Saving is now blocked if the JSON content is invalid, with a clear error message shown to users.
  * The editor now resets correctly when switching entitlements and preserves the appropriate config value during edits.
  * For subscription entitlements, the enabled/disabled view is now shown only for boolean settings, reducing confusing UI states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->