### PR TITLE
Update AttemptStatus to display 'unknown' for unrecognized statuses a…

### DIFF
--- a/src/components/molecules/Webhooks/AttemptStatus.tsx
+++ b/src/components/molecules/Webhooks/AttemptStatus.tsx
@@ -44,7 +44,7 @@ export const AttemptStatusChip: FC<{ status: MessageStatus }> = ({ status }) => 
 	if (status === MessageStatus.Fail) return <Chip variant='failed' label={t('webhooks.endpoints.attempts.status.failed')} />;
 	if (status === MessageStatus.Sending) return <Chip variant='info' label={t('webhooks.endpoints.attempts.status.sending')} />;
 	if (status === MessageStatus.Pending) return <Chip variant='warning' label={t('webhooks.endpoints.attempts.status.pending')} />;
-	return <Chip variant='default' label={t('webhooks.endpoints.attempts.status.pending')} />;
+	return <Chip variant='default' label={t('webhooks.endpoints.attempts.status.unknown')} />;
 };
 
 export const AttemptReplayAction: FC<{ attempt: MessageAttemptOut; onReplayed: () => void }> = ({ attempt, onReplayed }) => {

--- a/src/components/molecules/Webhooks/EndpointDetail.tsx
+++ b/src/components/molecules/Webhooks/EndpointDetail.tsx
@@ -33,6 +33,11 @@ const SubscribedEventsEditor: FC<{ endpointId: string; filterTypes: string[] | n
 	const [selected, setSelected] = useState<string[]>(filterTypes ?? []);
 	const [isSaving, setIsSaving] = useState(false);
 
+	const handleCancel = () => {
+		setSelected(filterTypes ?? []);
+		setIsEditing(false);
+	};
+
 	const handleSave = async () => {
 		setIsSaving(true);
 		try {
@@ -55,7 +60,7 @@ const SubscribedEventsEditor: FC<{ endpointId: string; filterTypes: string[] | n
 					<Button size='sm' isLoading={isSaving} onClick={handleSave}>
 						{t('common:actions.save')}
 					</Button>
-					<Button size='sm' variant='outline' disabled={isSaving} onClick={() => setIsEditing(false)}>
+					<Button size='sm' variant='outline' disabled={isSaving} onClick={handleCancel}>
 						{t('common:actions.cancel')}
 					</Button>
 				</div>

--- a/src/i18n/locales/en/developers.json
+++ b/src/i18n/locales/en/developers.json
@@ -265,7 +265,8 @@
 					"succeeded": "Succeeded",
 					"failed": "Failed",
 					"sending": "Sending",
-					"pending": "Pending"
+					"pending": "Pending",
+					"unknown": "Unknown"
 				},
 				"empty": {
 					"title": "No messages yet",


### PR DESCRIPTION
…nd enhance SubscribedEventsEditor with acancel handler for better user experience

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook attempt statuses now show **Unknown** for unrecognized states instead of incorrectly appearing as **Pending**.
  * Canceling edits in the subscribed events editor now properly discards unsaved changes and restores the previous selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->