### PR TITLE
feat: add copy ID action to table row menus

### DIFF
--- a/src/components/atoms/ActionButton/ActionButton.test.tsx
+++ b/src/components/atoms/ActionButton/ActionButton.test.tsx
@@ -90,6 +90,7 @@ const defaultProps = {
 describe('ActionButton Component', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
 	});
 
 	describe('Basic Rendering', () => {
@@ -427,6 +428,77 @@ describe('ActionButton Component', () => {
 
 			await waitFor(() => {
 				expect(screen.getByText('Legacy Archive')).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe('Copy ID Action', () => {
+		it('should not render Copy ID when copyId prop is omitted', async () => {
+			render(
+				<TestWrapper>
+					<ActionButton {...defaultProps} edit={{ enabled: true }} />
+				</TestWrapper>,
+			);
+
+			const triggerButton = screen.getByRole('button');
+			fireEvent.click(triggerButton);
+
+			await waitFor(() => {
+				expect(screen.getByText('Edit')).toBeInTheDocument();
+			});
+			expect(screen.queryByText('Copy ID')).not.toBeInTheDocument();
+		});
+
+		it('should render the generic "Copy ID" label and copy the id when no entityType is given', async () => {
+			render(
+				<TestWrapper>
+					<ActionButton {...defaultProps} copyId={{}} />
+				</TestWrapper>,
+			);
+
+			const triggerButton = screen.getByRole('button');
+			fireEvent.click(triggerButton);
+
+			await waitFor(() => {
+				const copyIdButton = screen.getByText('Copy ID');
+				fireEvent.click(copyIdButton);
+			});
+
+			expect(navigator.clipboard.writeText).toHaveBeenCalledWith('test-id');
+		});
+
+		it('should show an entity-specific toast message when entityType is given', async () => {
+			render(
+				<TestWrapper>
+					<ActionButton {...defaultProps} copyId={{ entityType: 'Plan' }} />
+				</TestWrapper>,
+			);
+
+			const triggerButton = screen.getByRole('button');
+			fireEvent.click(triggerButton);
+
+			await waitFor(() => {
+				const copyIdButton = screen.getByText('Copy ID');
+				fireEvent.click(copyIdButton);
+			});
+
+			await waitFor(() => {
+				expect(toast.success).toHaveBeenCalledWith('Plan ID copied to clipboard');
+			});
+		});
+
+		it('should render a custom label when provided', async () => {
+			render(
+				<TestWrapper>
+					<ActionButton {...defaultProps} copyId={{ label: 'Copy Plan ID' }} />
+				</TestWrapper>,
+			);
+
+			const triggerButton = screen.getByRole('button');
+			fireEvent.click(triggerButton);
+
+			await waitFor(() => {
+				expect(screen.getByText('Copy Plan ID')).toBeInTheDocument();
 			});
 		});
 	});

--- a/src/components/atoms/ActionButton/ActionButton.tsx
+++ b/src/components/atoms/ActionButton/ActionButton.tsx
@@ -4,10 +4,11 @@ import { FC, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { useMutation } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
-import { Button, Dialog } from '@/components/atoms';
-import { EyeOff, Pencil } from 'lucide-react';
-import { refetchQueries } from '@/core/services/tanstack/ReactQueryProvider';
 import { useTranslation } from 'react-i18next';
+import { Button, Dialog } from '@/components/atoms';
+import { Copy, EyeOff, Pencil } from 'lucide-react';
+import { refetchQueries } from '@/core/services/tanstack/ReactQueryProvider';
+import { copyToClipboard } from '@/utils/common/helper_functions';
 
 interface EditActionConfig {
 	enabled?: boolean;
@@ -30,6 +31,13 @@ interface CustomAction {
 	enabled?: boolean;
 }
 
+interface CopyIdActionConfig {
+	enabled?: boolean;
+	/** e.g. "Plan" — renders the menu label/toast as "Copy Plan ID" via the copyId i18n keys. Omit for the generic "Copy ID" label. */
+	entityType?: string;
+	label?: string;
+}
+
 interface ActionProps {
 	id: string;
 	deleteMutationFn: (id: string) => Promise<void>;
@@ -39,6 +47,8 @@ interface ActionProps {
 	edit?: EditActionConfig;
 	archive?: ArchiveActionConfig;
 	customActions?: CustomAction[];
+	/** Opt-in "Copy ID" menu item, rendered first. Omit to leave the menu unchanged. */
+	copyId?: CopyIdActionConfig;
 	disableToast?: boolean;
 	// Legacy props for backward compatibility
 	row?: unknown;
@@ -61,6 +71,7 @@ const ActionButton: FC<ActionProps> = ({
 	edit,
 	archive,
 	customActions,
+	copyId,
 	disableToast = false,
 	// Legacy props
 	editPath,
@@ -139,6 +150,21 @@ const ActionButton: FC<ActionProps> = ({
 						<button>{trigger}</button>
 					</DropdownMenuTrigger>
 					<DropdownMenuContent align='end'>
+						{copyId && copyId.enabled !== false && (
+							<DropdownMenuItem
+								onSelect={(event) => {
+									event.preventDefault();
+									setIsOpen(false);
+									void copyToClipboard(
+										id,
+										copyId.entityType ? t('copyId.toastWithType', { type: copyId.entityType }) : t('copyId.toastFallback'),
+									);
+								}}
+								className='flex gap-2 items-center w-full cursor-pointer'>
+								<Copy />
+								<span>{copyId.label || t('copyId.genericLabel')}</span>
+							</DropdownMenuItem>
+						)}
 						{editConfig.enabled !== false && (
 							<DropdownMenuItem
 								onSelect={(event) => {

--- a/src/components/molecules/AddonTable/AddonTable.tsx
+++ b/src/components/molecules/AddonTable/AddonTable.tsx
@@ -47,6 +47,7 @@ const AddonTable: FC<Props> = ({ data, onEdit }) => {
 				return (
 					<ActionButton
 						id={row?.id}
+						copyId={{ entityType: 'Addon' }}
 						deleteMutationFn={async () => {
 							return await AddonApi.Delete(row?.id);
 						}}

--- a/src/components/molecules/CostSheetTable/CostSheetTable.tsx
+++ b/src/components/molecules/CostSheetTable/CostSheetTable.tsx
@@ -51,6 +51,7 @@ const CostSheetTable: FC<Props> = ({ data, onEdit }) => {
 				return (
 					<ActionButton
 						id={row?.id}
+						copyId={{ entityType: 'Cost Sheet' }}
 						deleteMutationFn={async () => {
 							return await CostSheetApi.DeleteCostSheet(row?.id);
 						}}

--- a/src/components/molecules/CouponAssociationTable/CouponAssociationTable.tsx
+++ b/src/components/molecules/CouponAssociationTable/CouponAssociationTable.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import CouponApi from '@/api/CouponApi';
 import FlexpriceTable, { ColumnData } from '../Table';
-import { DropdownMenu } from '@/components/molecules';
+import { DropdownMenu, getCopyIdOption } from '@/components/molecules';
 import { Chip, Card, CardHeader, AddButton, NoDataCard } from '@/components/atoms';
 import { formatDateShort, getCurrencySymbol } from '@/utils/common/helper_functions';
 import { RouteNames } from '@/core/routes/Routes';
@@ -44,6 +44,7 @@ const RowActions: FC<RowActionsProps> = ({ row, onRemove }) => {
 				isOpen={isOpen}
 				onOpenChange={setIsOpen}
 				options={[
+					getCopyIdOption(row.id, t, { entityType: 'Coupon Association' }),
 					{
 						label: t('form.remove'),
 						icon: <TrashIcon />,

--- a/src/components/molecules/CouponTable/CouponTable.tsx
+++ b/src/components/molecules/CouponTable/CouponTable.tsx
@@ -82,6 +82,7 @@ const CouponTable: FC<CouponTableProps> = ({ data, onEdit }) => {
 			render: (row) => (
 				<ActionButton
 					id={row.id}
+					copyId={{ entityType: 'Coupon' }}
 					deleteMutationFn={(id) => CouponApi.deleteCoupon(id)}
 					refetchQueryKey='fetchCoupons'
 					entityName={t('coupons.table.entityName')}

--- a/src/components/molecules/CreditGrant/CreditGrantsTable.tsx
+++ b/src/components/molecules/CreditGrant/CreditGrantsTable.tsx
@@ -70,6 +70,7 @@ const CreditGrantsTable: React.FC<CreditGrantsTableProps> = ({ data, onDelete, s
 				return (
 					<ActionButton
 						id={row.id}
+						copyId={{ entityType: 'Credit Grant' }}
 						deleteMutationFn={async () => {
 							await handleDelete(row);
 						}}

--- a/src/components/molecules/CreditGrant/SubscriptionCreditGrantTable.tsx
+++ b/src/components/molecules/CreditGrant/SubscriptionCreditGrantTable.tsx
@@ -113,6 +113,7 @@ const SubscriptionCreditGrantTable: React.FC<Props> = ({
 				return (
 					<ActionButton
 						id={row.id}
+						copyId={{ entityType: 'Credit Grant' }}
 						deleteMutationFn={() => handleDelete(row.id)}
 						refetchQueryKey='credit_grants'
 						entityName={row.name}

--- a/src/components/molecules/Customer/CustomerTable.tsx
+++ b/src/components/molecules/Customer/CustomerTable.tsx
@@ -19,6 +19,7 @@ const ActionButtonWithPortal: FC<{ customer: Customer; onEdit: (customer: Custom
 	return (
 		<ActionButton
 			id={customer.id}
+			copyId={{ entityType: 'Customer' }}
 			deleteMutationFn={(id) => CustomerApi.deleteCustomerById(id)}
 			refetchQueryKey='fetchCustomers'
 			entityName={t('list.entityName')}

--- a/src/components/molecules/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/molecules/DropdownMenu/DropdownMenu.tsx
@@ -9,8 +9,10 @@ import {
 	DropdownMenuLabel,
 	DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Copy } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import type { TFunction } from 'i18next';
+import { copyToClipboard } from '@/utils/common/helper_functions';
 
 interface DropdownMenuProps {
 	options: DropdownMenuOption[];
@@ -31,6 +33,19 @@ export interface DropdownMenuOption {
 	className?: string;
 	group?: string;
 }
+
+/**
+ * Builds a "Copy ID" DropdownMenuOption backed by the shared copyToClipboard util.
+ * Pass `entityType` (e.g. "Plan") once labels are ready to move off the generic "Copy ID" text.
+ */
+export const getCopyIdOption = (id: string, t: TFunction, opts?: { entityType?: string; label?: string }): DropdownMenuOption => ({
+	label: opts?.label ?? t('copyId.genericLabel'),
+	icon: <Copy className='w-4 h-4' />,
+	onSelect: (e: Event) => {
+		e.preventDefault();
+		void copyToClipboard(id, opts?.entityType ? t('copyId.toastWithType', { type: opts.entityType }) : t('copyId.toastFallback'));
+	},
+});
 
 const DropdownMenu: React.FC<DropdownMenuProps> = ({ options, trigger, isOpen, onOpenChange, dir = 'ltr', className, align = 'end' }) => {
 	// Internal state for uncontrolled mode

--- a/src/components/molecules/DropdownMenu/index.ts
+++ b/src/components/molecules/DropdownMenu/index.ts
@@ -1,2 +1,2 @@
-export { default } from './DropdownMenu';
+export { default, getCopyIdOption } from './DropdownMenu';
 export type { DropdownMenuOption } from './DropdownMenu';

--- a/src/components/molecules/EntitlementOverrides/EntitlementOverridesTable.tsx
+++ b/src/components/molecules/EntitlementOverrides/EntitlementOverridesTable.tsx
@@ -3,7 +3,7 @@ import { Chip, Sheet } from '@/components/atoms';
 import { FlexpriceTable, ColumnData } from '@/components/molecules';
 import JsonCodeBlock from '@/components/molecules/Events/JsonCodeBlock';
 import { FEATURE_TYPE } from '@/models';
-import { Pencil, Info } from 'lucide-react';
+import { Pencil, Info, Copy } from 'lucide-react';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui';
 import { BsThreeDotsVertical } from 'react-icons/bs';
@@ -11,6 +11,7 @@ import { EntitlementOverrideRequest } from '@/types/dto/Subscription';
 import { JsonObject } from '@/types/common';
 import EditEntitlementDrawer from './EditEntitlementDrawer';
 import { useTranslation } from 'react-i18next';
+import { copyToClipboard } from '@/utils/common/helper_functions';
 
 interface EntitlementOverridesTableProps {
 	entitlements: any[];
@@ -277,6 +278,15 @@ const EntitlementOverridesTable: FC<EntitlementOverridesTableProps> = ({ entitle
 								</button>
 							</DropdownMenuTrigger>
 							<DropdownMenuContent align='end'>
+								<DropdownMenuItem
+									onSelect={(e) => {
+										e.preventDefault();
+										void copyToClipboard(row.id, tc('copyId.toastWithType', { type: 'Entitlement' }));
+									}}
+									className='flex gap-2 items-center cursor-pointer'>
+									<Copy className='h-4 w-4' />
+									<span>{tc('copyId.genericLabel')}</span>
+								</DropdownMenuItem>
 								<DropdownMenuItem
 									onSelect={(e) => {
 										e.preventDefault();

--- a/src/components/molecules/FeatureTable/FeatureTable.tsx
+++ b/src/components/molecules/FeatureTable/FeatureTable.tsx
@@ -75,6 +75,7 @@ const FeatureTable: FC<Props> = ({ data, onEdit }) => {
 					return (
 						<ActionButton
 							id={row?.id}
+							copyId={{ entityType: 'Feature' }}
 							deleteMutationFn={async () => {
 								return await FeatureApi.deleteFeature(row?.id);
 							}}

--- a/src/components/molecules/GroupsTable/GroupsTable.tsx
+++ b/src/components/molecules/GroupsTable/GroupsTable.tsx
@@ -48,6 +48,7 @@ const GroupsTable: FC<GroupsTableProps> = ({ data, onEdit }) => {
 			render: (row) => (
 				<ActionButton
 					id={row.id}
+					copyId={{ entityType: 'Group' }}
 					deleteMutationFn={(id) => GroupApi.deleteGroup(id)}
 					refetchQueryKey='fetchGroups'
 					entityName={t('catalog:groups.table.entityName')}

--- a/src/components/molecules/InvoicePaymentsTable/InvoicePaymentsTable.tsx
+++ b/src/components/molecules/InvoicePaymentsTable/InvoicePaymentsTable.tsx
@@ -8,7 +8,7 @@ import { CreditCard, Banknote, Receipt, CircleDollarSign, ExternalLink, Copy, Ey
 import { RouteNames } from '@/core/routes/Routes';
 import { RedirectCell } from '../Table';
 import { PAYMENT_METHOD_TYPE } from '@/constants';
-import DropdownMenu, { DropdownMenuOption } from '../DropdownMenu';
+import DropdownMenu, { DropdownMenuOption, getCopyIdOption } from '../DropdownMenu';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router';
 
@@ -55,6 +55,7 @@ const PAYMENT_STATUS_CONFIG = {
 
 const PaymentTableMenu: FC<PaymentTableMenuProps> = ({ payment }) => {
 	const navigate = useNavigate();
+	const { t: tc } = useTranslation('common');
 	const handleCopyPaymentLink = useCallback(async () => {
 		if (!payment.payment_url) return;
 
@@ -73,6 +74,7 @@ const PaymentTableMenu: FC<PaymentTableMenuProps> = ({ payment }) => {
 		const isEnabled = isPaymentLink && hasPaymentUrl;
 
 		const options = [
+			getCopyIdOption(payment.id, tc, { entityType: 'Payment' }),
 			{
 				label: 'View Invoice',
 				icon: <Eye className='w-4 h-4' />,
@@ -93,7 +95,16 @@ const PaymentTableMenu: FC<PaymentTableMenuProps> = ({ payment }) => {
 		}
 
 		return options;
-	}, [payment.payment_method_type, payment.payment_url, handleCopyPaymentLink, navigate, payment.destination_id, payment.destination_type]);
+	}, [
+		payment.payment_method_type,
+		payment.payment_url,
+		handleCopyPaymentLink,
+		navigate,
+		payment.destination_id,
+		payment.destination_type,
+		payment.id,
+		tc,
+	]);
 
 	return <DropdownMenu options={menuOptions} />;
 };

--- a/src/components/molecules/InvoiceTable/InvoiceTableMenu.tsx
+++ b/src/components/molecules/InvoiceTable/InvoiceTableMenu.tsx
@@ -1,8 +1,9 @@
 import { Invoice, INVOICE_STATUS, INVOICE_TYPE } from '@/models/Invoice';
 import { FC, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { DropdownMenu, RecordPaymentTopup } from '..';
 import InvoiceDownloadFormatDialog from '../InvoiceDownloadFormatDialog/InvoiceDownloadFormatDialog';
-import { DropdownMenuOption } from '../DropdownMenu/DropdownMenu';
+import { DropdownMenuOption, getCopyIdOption } from '../DropdownMenu/DropdownMenu';
 import { useMutation } from '@tanstack/react-query';
 import InvoiceApi from '@/api/InvoiceApi';
 import toast from 'react-hot-toast';
@@ -20,6 +21,7 @@ interface Props {
 
 const InvoiceTableMenu: FC<Props> = ({ data }) => {
 	const navigate = useNavigate();
+	const { t: tc } = useTranslation('common');
 
 	const { mutate: triggerCommunication } = useMutation({
 		mutationFn: async (invoice_id: string) => {
@@ -77,6 +79,7 @@ const InvoiceTableMenu: FC<Props> = ({ data }) => {
 	});
 
 	const menuOptions: DropdownMenuOption[] = [
+		getCopyIdOption(data.id, tc, { entityType: 'Invoice' }),
 		{
 			label: 'Download Invoice',
 			group: 'Actions',

--- a/src/components/molecules/InvoiceTaxAssociationTable/InvoiceTaxAssociationTable.tsx
+++ b/src/components/molecules/InvoiceTaxAssociationTable/InvoiceTaxAssociationTable.tsx
@@ -69,6 +69,7 @@ const InvoiceTaxAssociationTable: FC<Props> = ({ data, onChange, disabled, defau
 			render: (row) => (
 				<ActionButton
 					id={row.tax_rate_code}
+					copyId={{ entityType: 'Tax Rate' }}
 					deleteMutationFn={() => handleDelete(row.tax_rate_code)}
 					refetchQueryKey='invoice_tax_overrides'
 					entityName={`Tax Override ${row.tax_rate_code}`}

--- a/src/components/molecules/PlansTable/PlansTable.tsx
+++ b/src/components/molecules/PlansTable/PlansTable.tsx
@@ -46,6 +46,7 @@ const PlansTable: FC<PlansTableProps> = ({ data, onEdit }) => {
 				render: (row) => (
 					<ActionButton
 						id={row.id}
+						copyId={{ entityType: 'Plan' }}
 						deleteMutationFn={(id) => PlanApi.deletePlan(id)}
 						refetchQueryKey='fetchPlans'
 						entityName={t('plans.listPage.entityName')}

--- a/src/components/molecules/PriceUnitTable/PriceUnitTable.tsx
+++ b/src/components/molecules/PriceUnitTable/PriceUnitTable.tsx
@@ -74,6 +74,7 @@ const PriceUnitTable: FC<Props> = ({ data, onEdit }) => {
 				return (
 					<ActionButton
 						id={row?.id}
+						copyId={{ entityType: 'Price Unit' }}
 						deleteMutationFn={async () => {
 							return await PriceUnitApi.DeletePriceUnit(row?.id);
 						}}

--- a/src/components/molecules/Subscription/SubscriptionEditCreditGrantsSection.tsx
+++ b/src/components/molecules/Subscription/SubscriptionEditCreditGrantsSection.tsx
@@ -84,6 +84,7 @@ const SubscriptionEditCreditGrantsSection: FC<SubscriptionEditCreditGrantsSectio
 				render: (row) => (
 					<ActionButton
 						id={row.id}
+						copyId={{ entityType: 'Credit Grant' }}
 						deleteMutationFn={async () => {}}
 						refetchQueryKey='creditGrants'
 						entityName={row.name}

--- a/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonTable.tsx
+++ b/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonTable.tsx
@@ -166,6 +166,7 @@ const SubscriptionAddonTable: React.FC<Props> = ({
 					return (
 						<ActionButton
 							id={row.addon_id}
+							copyId={{ entityType: 'Addon' }}
 							deleteMutationFn={() => handleDelete(row.internal_id)}
 							refetchQueryKey='addons'
 							entityName={addonDetails?.name || row.addon_id}

--- a/src/components/molecules/SubscriptionAddonsSection/SubscriptionAddonsSection.tsx
+++ b/src/components/molecules/SubscriptionAddonsSection/SubscriptionAddonsSection.tsx
@@ -2,7 +2,7 @@ import { FC, useState, useMemo, useCallback, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
-import { Trash2 } from 'lucide-react';
+import { Trash2, Copy } from 'lucide-react';
 import { Button, Card, CardHeader, Chip, DatePicker, Dialog, AddButton, Select, Tooltip, NoDataCard } from '@/components/atoms';
 import { FlexpriceTable, ColumnData } from '@/components/molecules';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
@@ -12,7 +12,7 @@ import { ADDON_ASSOCIATION_STATUS } from '@/models/AddonAssociation';
 import { AddonAssociationResponse } from '@/types/dto/Subscription';
 import { ADDON_PRORATION_BEHAVIOR } from '@/types/dto/Addon';
 import { BILLING_PERIOD } from '@/constants/constants';
-import { toSentenceCase } from '@/utils/common/helper_functions';
+import { toSentenceCase, copyToClipboard } from '@/utils/common/helper_functions';
 import { Price, PRICE_TYPE } from '@/models/Price';
 import { getCurrentPriceAmount } from '@/utils/common/price_override_helpers';
 import { getTotalPayableTextWithCoupons } from '@/utils/common/helper_functions';
@@ -327,6 +327,15 @@ const SubscriptionAddonsSection: FC<SubscriptionAddonsSectionProps> = ({
 									</button>
 								</DropdownMenuTrigger>
 								<DropdownMenuContent align='end'>
+									<DropdownMenuItem
+										onSelect={(e) => {
+											e.preventDefault();
+											void copyToClipboard(row.id, t('copyId.toastWithType', { type: 'Addon' }));
+										}}
+										className='flex gap-2 items-center cursor-pointer'>
+										<Copy className='h-4 w-4' />
+										<span>{t('copyId.genericLabel')}</span>
+									</DropdownMenuItem>
 									<DropdownMenuItem
 										disabled={hasEndDate}
 										onSelect={(e) => {

--- a/src/components/molecules/SubscriptionDiscountTable/SubscriptionDiscountTable.tsx
+++ b/src/components/molecules/SubscriptionDiscountTable/SubscriptionDiscountTable.tsx
@@ -142,6 +142,7 @@ const SubscriptionDiscountTable: FC<Props> = ({ coupon, onChange, disabled, curr
 			render: (row) => (
 				<ActionButton
 					id={row.id}
+					copyId={{ entityType: 'Discount' }}
 					deleteMutationFn={handleDelete}
 					refetchQueryKey='subscription_discount'
 					entityName={`Discount ${formatCouponName(row)}`}

--- a/src/components/molecules/SubscriptionTable/SubscriptionTable.tsx
+++ b/src/components/molecules/SubscriptionTable/SubscriptionTable.tsx
@@ -79,6 +79,7 @@ const SubscriptionTable: FC<Props> = ({ data, onEdit }) => {
 					return (
 						<ActionButton
 							id={row.id}
+							copyId={{ entityType: 'Subscription' }}
 							deleteMutationFn={async () => Promise.resolve()}
 							refetchQueryKey='fetchSubscriptions'
 							entityName={t('subscriptions.listPage.entityNameForActions')}

--- a/src/components/molecules/SubscriptionTaxAssociationTable/SubscriptionTaxAssociationTable.tsx
+++ b/src/components/molecules/SubscriptionTaxAssociationTable/SubscriptionTaxAssociationTable.tsx
@@ -71,6 +71,7 @@ const SubscriptionTaxAssociationTable: FC<Props> = ({ data, onChange, disabled }
 			render: (row) => (
 				<ActionButton
 					id={row.tax_rate_code}
+					copyId={{ entityType: 'Tax Rate' }}
 					deleteMutationFn={() => handleDelete(row.tax_rate_code)}
 					refetchQueryKey='subscription_tax_overrides'
 					entityName={`Tax Override ${row.tax_rate_code}`}

--- a/src/components/molecules/TaskRunsTable/TaskRunsTable.tsx
+++ b/src/components/molecules/TaskRunsTable/TaskRunsTable.tsx
@@ -199,6 +199,7 @@ const TaskRunsTable: FC<TaskRunsTableProps> = ({ scheduledTaskId, taskType = 'EX
 					return (
 						<ActionButton
 							id={row.id}
+							copyId={{ entityType: 'Task Run' }}
 							deleteMutationFn={async () => {}}
 							refetchQueryKey='task-runs'
 							entityName={t('taskRunsTable.entityTask')}

--- a/src/components/molecules/TaxAssociationTable/TaxAssociationTable.tsx
+++ b/src/components/molecules/TaxAssociationTable/TaxAssociationTable.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import FlexpriceTable, { ColumnData, RedirectCell } from '../Table';
 import { TaxAssociationResponse } from '@/types/dto/tax';
 import { Chip, ActionButton, Card, CardHeader, AddButton, NoDataCard } from '@/components/atoms';
-import { DropdownMenu } from '@/components/molecules';
+import { DropdownMenu, getCopyIdOption } from '@/components/molecules';
 import { formatDateShort } from '@/utils/common/helper_functions';
 import TaxApi from '@/api/TaxApi';
 import { RouteNames } from '@/core/routes/Routes';
@@ -36,6 +36,7 @@ const RowActions: FC<RowActionsProps> = ({ row, onRemove }) => {
 				isOpen={isOpen}
 				onOpenChange={setIsOpen}
 				options={[
+					getCopyIdOption(row.id, t, { entityType: 'Tax Association' }),
 					{
 						label: t('form.remove'),
 						icon: <TrashIcon />,
@@ -95,6 +96,7 @@ const TaxAssociationTable: FC<Props> = ({ data, onAdd, showDelete = true, refetc
 				return (
 					<ActionButton
 						id={row?.id}
+						copyId={{ entityType: 'Tax Association' }}
 						deleteMutationFn={async () => {
 							return await TaxApi.deleteTaxAssociation(row?.id);
 						}}

--- a/src/components/molecules/TaxTable/TaxTable.tsx
+++ b/src/components/molecules/TaxTable/TaxTable.tsx
@@ -87,6 +87,7 @@ const TaxTable: FC<Props> = ({ data, onEdit }) => {
 					return (
 						<ActionButton
 							id={row?.id}
+							copyId={{ entityType: 'Tax Rate' }}
 							deleteMutationFn={async () => {
 								return await TaxApi.deleteTaxRate(row?.id);
 							}}

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -155,7 +155,7 @@ export { MetadataModal } from './MetadataModal';
 // Form Controls & UI Components
 export { default as RectangleRadiogroup } from './RectangleRadiogroup';
 export type { RectangleRadiogroupOption } from './RectangleRadiogroup';
-export { default as DropdownMenu } from './DropdownMenu';
+export { default as DropdownMenu, getCopyIdOption } from './DropdownMenu';
 export type { DropdownMenuOption } from './DropdownMenu';
 export { ChargeValueCell } from './ChargeValueCell';
 

--- a/src/components/organisms/Subscription/SubscriptionActionButton.tsx
+++ b/src/components/organisms/Subscription/SubscriptionActionButton.tsx
@@ -11,7 +11,7 @@ import React, { useState, useMemo } from 'react';
 import SubscriptionApi from '@/api/SubscriptionApi';
 import { DatePicker, Label, Modal, Input, Button, FormHeader, Spacer, Select, Toggle } from '@/components/atoms';
 import { toast } from 'react-hot-toast';
-import DropdownMenu, { DropdownMenuOption } from '@/components/molecules/DropdownMenu/DropdownMenu';
+import DropdownMenu, { DropdownMenuOption, getCopyIdOption } from '@/components/molecules/DropdownMenu/DropdownMenu';
 import { AlertSettingsDialog } from '@/components/molecules';
 import { ALERT_ENTITY_TYPE } from '@/models/AlertSetting';
 import { refetchQueries } from '@/core/services/tanstack/ReactQueryProvider';
@@ -27,6 +27,7 @@ interface Props {
 const SubscriptionActionButton: React.FC<Props> = ({ subscription }) => {
 	const navigate = useNavigate();
 	const { t } = useTranslation(['customers', 'common']);
+	const { t: tc } = useTranslation('common');
 	const [state, setState] = useState({
 		// isPauseModalOpen: false,
 		// isResumeModalOpen: false,
@@ -152,6 +153,7 @@ const SubscriptionActionButton: React.FC<Props> = ({ subscription }) => {
 	const readOnly = isInheritedSubscription(subscription);
 
 	const menuOptions: DropdownMenuOption[] = [
+		getCopyIdOption(subscription.id, tc, { entityType: 'Subscription' }),
 		...(isDraft
 			? [
 					{

--- a/src/components/organisms/Subscription/SubscriptionPriceTable.tsx
+++ b/src/components/organisms/Subscription/SubscriptionPriceTable.tsx
@@ -4,7 +4,7 @@ import { ColumnData, FlexpriceTable, LineItemCoupon } from '@/components/molecul
 import PriceOverrideDialog from '@/components/molecules/PriceOverrideDialog/PriceOverrideDialog';
 import CommitmentConfigDialog from '@/components/molecules/CommitmentConfigDialog';
 import { Price, PRICE_TYPE, PRICE_UNIT_TYPE } from '@/models';
-import { ChevronDownIcon, ChevronUpIcon, Pencil, RotateCcw, Tag, Target, Trash2 } from 'lucide-react';
+import { ChevronDownIcon, ChevronUpIcon, Copy, Pencil, RotateCcw, Tag, Target, Trash2 } from 'lucide-react';
 import { FormHeader, DecimalUsageInput, AddButton } from '@/components/atoms';
 import { ChargeValueCell } from '@/components/molecules';
 import { capitalize } from 'es-toolkit';
@@ -16,7 +16,7 @@ import { ExtendedPriceOverride } from '@/utils';
 import { LineItemCommitmentConfig } from '@/types/dto/LineItemCommitmentConfig';
 import type { CommitmentTimeBucket } from '@/types/dto/CommitmentTimeBucket';
 import type { AddedSubscriptionLineItem } from './AddSubscriptionChargeDialog';
-import { getCurrencySymbol } from '@/utils/common/helper_functions';
+import { getCurrencySymbol, copyToClipboard } from '@/utils/common/helper_functions';
 import { formatBillingPeriodForPrice } from '@/utils/common/helper_functions';
 import { formatAmount } from '@/components/atoms/Input/Input';
 import { BILLING_PERIOD } from '@/constants/constants';
@@ -54,6 +54,7 @@ const PriceActionMenu: FC<PriceActionMenuProps> = ({
 	onOpenCoupon,
 }) => {
 	const { t } = useTranslation('customers');
+	const { t: tc } = useTranslation('common');
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
 	return (
@@ -71,6 +72,13 @@ const PriceActionMenu: FC<PriceActionMenuProps> = ({
 					</button>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align='end' className='w-48'>
+					<DropdownMenuItem
+						onClick={() => {
+							void copyToClipboard(price.id, tc('copyId.toastWithType', { type: 'Price' }));
+						}}>
+						<Copy className='me-2 h-4 w-4' />
+						{tc('copyId.genericLabel')}
+					</DropdownMenuItem>
 					<DropdownMenuItem onClick={() => onOverride(price)}>
 						<Pencil className='me-2 h-4 w-4' />
 						{isOverridden ? t('organisms.subscriptionPriceTable.editOverride') : t('organisms.subscriptionPriceTable.overridePrice')}

--- a/src/i18n/locales/ar/common.json
+++ b/src/i18n/locales/ar/common.json
@@ -233,6 +233,7 @@
 		"notFoundBackToHome": "العودة إلى الرئيسية"
 	},
 	"copyId": {
+		"genericLabel": "نسخ المعرّف",
 		"toastFallback": "تم نسخ المعرّف إلى الحافظة",
 		"toastWithType": "تم نسخ معرّف {{type}} إلى الحافظة",
 		"titleWithType": "نسخ معرّف {{type}}",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -251,6 +251,7 @@
 		"notFoundBackToHome": "Back to Home"
 	},
 	"copyId": {
+		"genericLabel": "Copy ID",
 		"toastFallback": "ID copied to clipboard",
 		"toastWithType": "{{type}} ID copied to clipboard",
 		"titleWithType": "Copy {{type}} ID",

--- a/src/pages/customer/customers/CustomerListPage.tsx
+++ b/src/pages/customer/customers/CustomerListPage.tsx
@@ -35,6 +35,7 @@ const ActionButtonWithPortal: FC<{ customer: Customer; onEdit: (customer: Custom
 	return (
 		<ActionButton
 			id={customer.id}
+			copyId={{ entityType: 'Customer' }}
 			deleteMutationFn={(id) => CustomerApi.deleteCustomerById(id)}
 			refetchQueryKey='fetchCustomers'
 			entityName={t('list.entityName')}

--- a/src/pages/customer/subscriptions/Subscriptions.tsx
+++ b/src/pages/customer/subscriptions/Subscriptions.tsx
@@ -226,6 +226,7 @@ const SubscriptionsPage = () => {
 					return (
 						<ActionButton
 							id={row.id}
+							copyId={{ entityType: 'Subscription' }}
 							deleteMutationFn={async () => Promise.resolve()}
 							refetchQueryKey='fetchSubscriptions'
 							isArchiveDisabled={true}

--- a/src/pages/developer/ServiceAccounts.tsx
+++ b/src/pages/developer/ServiceAccounts.tsx
@@ -98,6 +98,7 @@ const ServiceAccountsPage = () => {
 				render: (row: User) => (
 					<ActionButton
 						id={row.id}
+						copyId={{ entityType: 'Service Account' }}
 						entityName={row.name || row.id}
 						deleteMutationFn={async () => UserApi.deleteUser(row.id)}
 						refetchQueryKey='service-accounts'

--- a/src/pages/developer/developer.tsx
+++ b/src/pages/developer/developer.tsx
@@ -182,6 +182,7 @@ const DeveloperPage = () => {
 						<div className='flex justify-end'>
 							<ActionButton
 								id={rowData.id}
+								copyId={{ entityType: 'Secret Key' }}
 								deleteMutationFn={async (id: string) => {
 									await SecretKeysApi.deleteSecretKey(id);
 								}}

--- a/src/pages/product-catalog/addons/AddonDetails.tsx
+++ b/src/pages/product-catalog/addons/AddonDetails.tsx
@@ -158,6 +158,7 @@ const getEntitlementColumns = (
 			return (
 				<ActionButton
 					id={row?.id}
+					copyId={{ entityType: 'Entitlement' }}
 					deleteMutationFn={async () => {
 						return await EntitlementApi.delete(row?.id);
 					}}

--- a/src/pages/product-catalog/addons/Addons.tsx
+++ b/src/pages/product-catalog/addons/Addons.tsx
@@ -158,6 +158,7 @@ const AddonsPage = () => {
 					return (
 						<ActionButton
 							id={row?.id}
+							copyId={{ entityType: 'Addon' }}
 							deleteMutationFn={async () => {
 								return await AddonApi.Delete(row?.id);
 							}}

--- a/src/pages/product-catalog/cost-sheets/CostSheets.tsx
+++ b/src/pages/product-catalog/cost-sheets/CostSheets.tsx
@@ -158,6 +158,7 @@ const CostSheetsPage = () => {
 					return (
 						<ActionButton
 							id={row?.id}
+							copyId={{ entityType: 'Cost Sheet' }}
 							deleteMutationFn={async () => {
 								return await CostSheetApi.DeleteCostSheet(row?.id);
 							}}

--- a/src/pages/product-catalog/coupons/Coupons.tsx
+++ b/src/pages/product-catalog/coupons/Coupons.tsx
@@ -184,6 +184,7 @@ const CouponsPage = () => {
 				render: (row) => (
 					<ActionButton
 						id={row.id}
+						copyId={{ entityType: 'Coupon' }}
 						deleteMutationFn={(id) => CouponApi.deleteCoupon(id)}
 						refetchQueryKey='fetchCoupons'
 						entityName={t('coupons.table.entityName')}

--- a/src/pages/product-catalog/features/Features.tsx
+++ b/src/pages/product-catalog/features/Features.tsx
@@ -216,6 +216,7 @@ const FeaturesPage = () => {
 					return (
 						<ActionButton
 							id={row?.id}
+							copyId={{ entityType: 'Feature' }}
 							deleteMutationFn={async () => {
 								return await FeatureApi.deleteFeature(row?.id);
 							}}

--- a/src/pages/product-catalog/groups/Groups.tsx
+++ b/src/pages/product-catalog/groups/Groups.tsx
@@ -72,6 +72,7 @@ const GroupsPage = () => {
 				render: (row) => (
 					<ActionButton
 						id={row.id}
+						copyId={{ entityType: 'Group' }}
 						deleteMutationFn={(id) => GroupApi.deleteGroup(id)}
 						refetchQueryKey='fetchGroups'
 						entityName={t('groups.table.entityName')}

--- a/src/pages/product-catalog/plans/Plans.tsx
+++ b/src/pages/product-catalog/plans/Plans.tsx
@@ -1,5 +1,5 @@
 import { AddButton, Button, Dialog, Page, Chip } from '@/components/atoms';
-import { ApiDocsContent, DropdownMenu, DuplicatePlanDialog, PlanDrawer } from '@/components/molecules';
+import { ApiDocsContent, DropdownMenu, DuplicatePlanDialog, PlanDrawer, getCopyIdOption } from '@/components/molecules';
 import type { DropdownMenuOption } from '@/components/molecules';
 import { ColumnData } from '@/components/molecules/Table';
 import { Plan } from '@/models/Plan';
@@ -55,6 +55,7 @@ const initialFilters: FilterCondition[] = [
 const PlansPage = () => {
 	const { t, i18n } = useTranslation(['catalog', 'common']);
 	const { t: tGuide } = useTranslation('guides');
+	const { t: tc } = useTranslation('common');
 	const guides = useMemo(() => buildGuides(tGuide), [tGuide]);
 	const [activePlan, setActivePlan] = useState<Plan | null>(null);
 	const [planDrawerOpen, setPlanDrawerOpen] = useState(false);
@@ -175,6 +176,7 @@ const PlansPage = () => {
 
 	const getRowDropdownOptions = useCallback(
 		(row: Plan): DropdownMenuOption[] => [
+			getCopyIdOption(row.id, tc, { entityType: 'Plan' }),
 			{
 				label: t('plans.listPage.rowActions.edit'),
 				icon: <Pencil />,
@@ -195,7 +197,7 @@ const PlansPage = () => {
 				disabled: row.status !== ENTITY_STATUS.PUBLISHED,
 			},
 		],
-		[t, handleEdit, handleDuplicate],
+		[t, tc, handleEdit, handleDuplicate],
 	);
 
 	const columns: ColumnData<Plan>[] = useMemo(

--- a/src/pages/product-catalog/plans/tabs/PlanEntitlementsTab.tsx
+++ b/src/pages/product-catalog/plans/tabs/PlanEntitlementsTab.tsx
@@ -124,6 +124,7 @@ const PlanEntitlementsTab = () => {
 				return (
 					<ActionButton
 						id={row?.id}
+						copyId={{ entityType: 'Entitlement' }}
 						deleteMutationFn={async () => {
 							return await EntitlementApi.delete(row?.id);
 						}}

--- a/src/pages/product-catalog/price-units/PriceUnits.tsx
+++ b/src/pages/product-catalog/price-units/PriceUnits.tsx
@@ -197,6 +197,7 @@ const PriceUnitsPage = () => {
 					return (
 						<ActionButton
 							id={row?.id}
+							copyId={{ entityType: 'Price Unit' }}
 							deleteMutationFn={async () => {
 								return await PriceUnitApi.DeletePriceUnit(row?.id);
 							}}


### PR DESCRIPTION
Expose a reusable copy-ID option across table dropdown menus so users can quickly copy entity IDs from list views.