### PR TITLE
fix: polyfill process for svix browser bundle and fix serverUrl handling

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,13 @@ import { DirectionProvider } from '@radix-ui/react-direction';
 import { useLocaleStore } from './store/useLocaleStore.ts';
 import React from 'react';
 
+// svix's browser bundle references the bare `process` identifier (not `typeof process`) inside
+// getUserAgent(), which throws ReferenceError in any browser and breaks every webhook portal request
+// before fetch() is even called. Polyfill just enough to satisfy that check.
+if (typeof process === 'undefined') {
+	(window as unknown as { process: { env: Record<string, string> } }).process = { env: {} };
+}
+
 registerWebMCPTools();
 
 // Reads direction from Zustand store — subscribes so Radix primitives re-render on locale change

--- a/src/pages/webhooks/WebhookDashboard.tsx
+++ b/src/pages/webhooks/WebhookDashboard.tsx
@@ -73,7 +73,9 @@ const WebhookDashboard = () => {
 	// Custom provider (Flexprice or self-hosted Svix): backend returns token/app_id and we
 	// render our own portal. Hosted Svix (default): backend returns a hosted portal `url`.
 	const isCustomProvider = config.webhooks.provider === WEBHOOK_PROVIDER.Custom;
-	const serverUrl = config.webhooks.svixUrl;
+	// svix-react/svix only fall back to the token's regional API when serverUrl is undefined —
+	// an empty string is treated as a literal (relative) base URL and breaks region auto-detection.
+	const serverUrl = config.webhooks.svixUrl || undefined;
 
 	if (isCustomProvider && data?.token && data?.app_id) {
 		return (


### PR DESCRIPTION
## Summary
- Polyfills a minimal `process.env` in `main.tsx` — the `svix` SDK's browser bundle references the bare `process` identifier (not `typeof process`) inside `getUserAgent()`, which throws `ReferenceError` in any browser before `fetch()` is ever called. This silently broke every request from the custom Webhooks portal (Endpoints, Event Catalog, Logs) with zero visible network activity.
- Fixes `serverUrl` handling in `WebhookDashboard.tsx` — an empty `VITE_SVIX_URL` was being passed through as a literal empty-string `serverUrl`, which the Svix SDK treats as a real (relative) base URL instead of falling back to its own token-based regional API detection.

## Test plan
- [x] `npx tsc -b` passes
- [x] `npx eslint` passes (no new errors)
- [ ] Manually verified against a live environment with the custom (`flexprice`) webhook portal enabled: Endpoints / Event Catalog / Logs tabs now fetch data instead of failing silently