### PR TITLE
feat: implement formatPayableAmount function and update related tests…

### DIFF
--- a/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonTable.tsx
+++ b/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonTable.tsx
@@ -12,6 +12,7 @@ import { Price, PRICE_TYPE } from '@/models/Price';
 import { BILLING_PERIOD } from '@/constants/constants';
 import { getCurrentPriceAmount, ExtendedPriceOverride } from '@/utils/common/price_override_helpers';
 import { Coupon } from '@/models/Coupon';
+import { filterAddonPricesForSubscription } from '@/utils/subscription/addon_commitment_helpers';
 
 interface Props {
 	data: AddAddonToSubscriptionRequest[];
@@ -146,7 +147,7 @@ const SubscriptionAddonTable: React.FC<Props> = ({
 				title: t('subscriptionAddon.columnCharges'),
 				render: (row) => {
 					const addonDetails = getAddonDetails(row.addon_id);
-					const prices = addonDetails?.prices || [];
+					const prices = filterAddonPricesForSubscription(addonDetails?.prices || [], billingPeriod, currency);
 					return <span>{formatAddonCharges(prices, priceOverrides, coupons, t)}</span>;
 				},
 			},
@@ -183,7 +184,7 @@ const SubscriptionAddonTable: React.FC<Props> = ({
 				},
 			},
 		],
-		[disabled, getAddonDetails, handleDelete, handleEdit, priceOverrides, coupons, t],
+		[disabled, getAddonDetails, handleDelete, handleEdit, priceOverrides, coupons, billingPeriod, currency, t],
 	);
 
 	return (

--- a/src/utils/common/formatPayableAmount.test.ts
+++ b/src/utils/common/formatPayableAmount.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { formatPayableAmount, getTotalPayableTextWithCoupons } from './helper_functions';
+import { PRICE_TYPE, type Price } from '@/models/Price';
+
+describe('formatPayableAmount', () => {
+	it('keeps two decimals for typical amounts', () => {
+		expect(formatPayableAmount(10)).toBe('10.00');
+		expect(formatPayableAmount(10.5)).toBe('10.50');
+		expect(formatPayableAmount(0.01)).toBe('0.01');
+	});
+
+	it('preserves sub-cent precision instead of rounding', () => {
+		expect(formatPayableAmount(0.0003)).toBe('0.0003');
+		// toFixed(2) would incorrectly round this to "0.01"
+		expect(formatPayableAmount(0.005)).toBe('0.005');
+	});
+
+	it('formats zero as 0.00', () => {
+		expect(formatPayableAmount(0)).toBe('0.00');
+	});
+});
+
+describe('getTotalPayableTextWithCoupons', () => {
+	it('shows sub-cent fixed addon charges correctly', () => {
+		const fixedCharges = [
+			{
+				type: PRICE_TYPE.FIXED,
+				currency: 'usd',
+				amount: '0.0003',
+			} as Price,
+		];
+
+		expect(getTotalPayableTextWithCoupons(fixedCharges, [], 0.0003, [])).toBe('$0.0003');
+	});
+
+	it('does not round 0.005 up to 0.01', () => {
+		const fixedCharges = [
+			{
+				type: PRICE_TYPE.FIXED,
+				currency: 'usd',
+				amount: '0.005',
+			} as Price,
+		];
+
+		expect(getTotalPayableTextWithCoupons(fixedCharges, [], 0.005, [])).toBe('$0.005');
+	});
+});

--- a/src/utils/common/helper_functions.ts
+++ b/src/utils/common/helper_functions.ts
@@ -208,6 +208,16 @@ export const calculateTotalCouponDiscount = (
 	}, 0);
 };
 
+export const formatPayableAmount = (amount: number): string => {
+	if (!Number.isFinite(amount) || amount === 0) {
+		return '0.00';
+	}
+
+	const formatted = amount.toFixed(8).replace(/\.?0+$/, '');
+
+	return formatted.includes('.') ? formatted.replace(/(\.\d)$/, '$10') : `${formatted}.00`;
+};
+
 /**
  * Gets the total payable text including coupon discounts
  * @param fixedCharges - Array of fixed (FIXED type) prices
@@ -229,11 +239,11 @@ export const getTotalPayableTextWithCoupons = (
 		const totalDiscount = calculateTotalCouponDiscount(coupons, recurringTotal);
 		const finalAmount = Math.max(0, recurringTotal - totalDiscount);
 
-		text += `${getCurrencySymbol(currency)}${finalAmount.toFixed(2)}`;
+		text += `${getCurrencySymbol(currency)}${formatPayableAmount(finalAmount)}`;
 
 		// Show discount information if there are coupons
 		if (coupons.length > 0 && totalDiscount > 0) {
-			text += ` (${getCurrencySymbol(currency)}${recurringTotal.toFixed(2)} - ${getCurrencySymbol(currency)}${totalDiscount.toFixed(2)} discount)`;
+			text += ` (${getCurrencySymbol(currency)}${formatPayableAmount(recurringTotal)} - ${getCurrencySymbol(currency)}${formatPayableAmount(totalDiscount)} discount)`;
 		}
 	}
 


### PR DESCRIPTION
… for precise monetary formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected addon charge displays to reflect the selected billing period and currency.
  * Improved payable amount formatting so sub-cent charges and discounts retain their precision instead of rounding up.
  * Ensured zero-value amounts display consistently as `0.00`.

* **Tests**
  * Added coverage for standard amounts, sub-cent values, zero totals, addon charges, and coupon calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->