### PR TITLE
feat(wallet): Added autotopup cooloff provider in modal

### DIFF
--- a/src/components/atoms/Toggle/Toggle.tsx
+++ b/src/components/atoms/Toggle/Toggle.tsx
@@ -1,7 +1,7 @@
 import { Label } from '@/components/ui/label';
 import { FormHeader, Spacer } from '..';
 import { Switch } from '@/components/ui/switch';
-import { FC } from 'react';
+import { FC, useId } from 'react';
 interface Props {
 	onChange: (value: boolean) => void;
 	checked: boolean;
@@ -14,12 +14,14 @@ interface Props {
 }
 
 const Toggle: FC<Props> = ({ onChange, checked, description, error, label, title, disabled, className }) => {
+	const switchId = useId();
+
 	return (
 		<div>
 			<FormHeader title={title} variant='form-component-title' />
 			<div className='flex items-start space-x-4 s'>
-				<Switch id='airplane-mode' checked={checked} onCheckedChange={onChange} disabled={disabled} className={className} />
-				<Label htmlFor='airplane-mode'>
+				<Switch id={switchId} checked={checked} onCheckedChange={onChange} disabled={disabled} className={className} />
+				<Label htmlFor={switchId}>
 					<p className='font-medium text-sm text-[#18181B] peer-checked:text-black'>{label}</p>
 					<Spacer height={'4px'} />
 					<p className='text-sm font-normal text-[#71717A] peer-checked:text-gray-700'>{description}</p>

--- a/src/components/molecules/WalletAutoTopup/WalletAutoTopup.tsx
+++ b/src/components/molecules/WalletAutoTopup/WalletAutoTopup.tsx
@@ -1,15 +1,12 @@
-import React, { useState, useEffect } from 'react';
-import { Dialog, Button, Input, Toggle } from '@/components/atoms';
+import React, { useState, useEffect, useMemo } from 'react';
+import { Dialog, Button, Input, Toggle, Select } from '@/components/atoms';
+import type { SelectOption } from '@/components/atoms';
 import { toast } from 'react-hot-toast';
 import { PremiumFeatureIcon } from '../PremiumFeature/PremiumFeature';
 import { useTranslation } from 'react-i18next';
+import type { AutoTopup, DurationUnit } from '@/models';
 
-export interface AutoTopupConfig {
-	enabled: boolean;
-	threshold: string;
-	amount: string;
-	invoicing: boolean;
-}
+export type AutoTopupConfig = AutoTopup;
 
 interface WalletAutoTopupProps {
 	open: boolean;
@@ -18,56 +15,153 @@ interface WalletAutoTopupProps {
 	onClose: () => void;
 }
 
+/** Backend treats value 0 as unset cooloff (preferred over null for PUT merge). */
+const UNSET_COOLDOWN = { value: 0, unit: 'SECOND' as const };
+
+const DEFAULT_CONFIG: AutoTopupConfig = {
+	enabled: false,
+	threshold: '0.00',
+	amount: '0.00',
+	invoicing: false,
+	cooldown: UNSET_COOLDOWN,
+};
+
+const DURATION_UNITS: DurationUnit[] = ['SECOND', 'MINUTE', 'HOUR', 'DAY'];
+
+const UNIT_DEFAULT_LABELS: Record<DurationUnit, string> = {
+	SECOND: 'Second',
+	MINUTE: 'Minute',
+	HOUR: 'Hour',
+	DAY: 'Day',
+};
+
 const WalletAutoTopup: React.FC<WalletAutoTopupProps> = ({ open, autoTopupConfig, onSave, onClose }) => {
 	const { t } = useTranslation('billing');
-	const [localConfig, setLocalConfig] = useState<AutoTopupConfig>(
-		autoTopupConfig || {
-			enabled: false,
-			threshold: '0.00',
-			amount: '0.00',
-			invoicing: false,
-		},
+	const [localConfig, setLocalConfig] = useState<AutoTopupConfig>(autoTopupConfig || DEFAULT_CONFIG);
+	const [cooldownEnabled, setCooldownEnabled] = useState(false);
+	const [cooldownValue, setCooldownValue] = useState('');
+	const [cooldownUnit, setCooldownUnit] = useState<DurationUnit | ''>('');
+
+	const cooldownUnitOptions: SelectOption[] = useMemo(
+		() =>
+			DURATION_UNITS.map((unit) => ({
+				value: unit,
+				label: t(`wallet.autoTopup.cooldownUnits.${unit}`, { defaultValue: UNIT_DEFAULT_LABELS[unit] }),
+			})),
+		[t],
 	);
+
+	const hydrateFromConfig = (config: AutoTopupConfig | undefined) => {
+		const next = config || DEFAULT_CONFIG;
+		setLocalConfig({
+			enabled: next.enabled ?? false,
+			threshold: next.threshold ?? DEFAULT_CONFIG.threshold,
+			amount: next.amount ?? DEFAULT_CONFIG.amount,
+			invoicing: next.invoicing ?? false,
+			cooldown: next.cooldown ?? UNSET_COOLDOWN,
+		});
+
+		const cooldown = next.cooldown;
+		const cooldownValueNumber = cooldown?.value != null ? Number(cooldown.value) : NaN;
+		// value <= 0 (or missing) means cooloff is unset
+		const hasCooldown = cooldown != null && Number.isFinite(cooldownValueNumber) && cooldownValueNumber > 0 && Boolean(cooldown.unit);
+
+		if (hasCooldown && cooldown?.unit) {
+			setCooldownEnabled(true);
+			setCooldownValue(String(cooldownValueNumber));
+			setCooldownUnit(cooldown.unit);
+		} else {
+			setCooldownEnabled(false);
+			setCooldownValue('');
+			setCooldownUnit('');
+		}
+	};
 
 	// Sync local state with props
 	useEffect(() => {
-		setLocalConfig(
-			autoTopupConfig || {
-				enabled: false,
-				threshold: '0.00',
-				amount: '0.00',
-				invoicing: false,
-			},
-		);
+		hydrateFromConfig(autoTopupConfig);
 	}, [autoTopupConfig, open]);
+
+	const handleCooldownEnabledChange = (enabled: boolean) => {
+		setCooldownEnabled(enabled);
+		if (!enabled) {
+			setCooldownValue('');
+			setCooldownUnit('');
+		}
+	};
 
 	const handleSave = () => {
 		if (localConfig.enabled) {
 			if (!localConfig.threshold || isNaN(parseFloat(localConfig.threshold))) {
-				toast.error('Please enter a valid threshold value');
+				toast.error(
+					t('wallet.autoTopup.errors.invalidThreshold', {
+						defaultValue: 'Please enter a valid threshold value',
+					}),
+				);
 				return;
 			}
 			if (!localConfig.amount || isNaN(parseFloat(localConfig.amount)) || parseFloat(localConfig.amount) <= 0) {
-				toast.error('Please enter a valid amount value greater than 0');
+				toast.error(
+					t('wallet.autoTopup.errors.invalidAmount', {
+						defaultValue: 'Please enter a valid amount value greater than 0',
+					}),
+				);
+				return;
+			}
+
+			if (cooldownEnabled) {
+				const trimmedValue = cooldownValue.trim();
+				if (!trimmedValue || !cooldownUnit) {
+					toast.error(
+						t('wallet.autoTopup.errors.cooldownIncomplete', {
+							defaultValue: 'Enter both a cooloff value and unit, or turn cooloff off',
+						}),
+					);
+					return;
+				}
+
+				const parsed = Number(trimmedValue);
+				if (!Number.isInteger(parsed) || parsed <= 0) {
+					toast.error(
+						t('wallet.autoTopup.errors.cooldownInvalidValue', {
+							defaultValue: 'Cooloff value must be a positive integer',
+						}),
+					);
+					return;
+				}
+
+				onSave({
+					...localConfig,
+					cooldown: { value: parsed, unit: cooldownUnit },
+				});
 				return;
 			}
 		}
 
-		onSave(localConfig);
+		onSave({
+			...localConfig,
+			cooldown: UNSET_COOLDOWN,
+		});
 	};
 
 	const handleClose = () => {
-		// Reset to original values
-		setLocalConfig(
-			autoTopupConfig || {
-				enabled: false,
-				threshold: '0.00',
-				amount: '0.00',
-				invoicing: false,
-			},
-		);
+		hydrateFromConfig(autoTopupConfig);
 		onClose();
 	};
+
+	const cooldownToggleDescription = cooldownEnabled
+		? t('wallet.autoTopup.cooldownDescription', {
+				defaultValue:
+					'After a successful auto top-up, the system will not auto top-up again until this window ends, even if the balance is still below the threshold.',
+			})
+		: !localConfig.invoicing
+			? t('wallet.autoTopup.cooldownBurstDescription', {
+					defaultValue:
+						'When cooloff is off and invoice payment is not required, the system may top up repeatedly until the balance exceeds the threshold.',
+				})
+			: t('wallet.autoTopup.cooldownOptionalDescription', {
+					defaultValue: 'When cooloff is off, there is no wait between auto top-ups.',
+				});
 
 	return (
 		<Dialog
@@ -122,6 +216,42 @@ const WalletAutoTopup: React.FC<WalletAutoTopupProps> = ({ open, autoTopupConfig
 								description={t('wallet.autoTopup.amountDescription')}
 							/>
 						</div>
+
+						{/* Cooloff (optional) */}
+						<Toggle
+							title={t('wallet.autoTopup.cooldownTitle', { defaultValue: 'Cooloff' })}
+							label={t('wallet.autoTopup.cooldownLabel', {
+								defaultValue: 'Wait before next auto top-up',
+							})}
+							description={cooldownToggleDescription}
+							checked={cooldownEnabled}
+							onChange={handleCooldownEnabledChange}
+						/>
+
+						{cooldownEnabled && (
+							<div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
+								<Input
+									label={t('wallet.autoTopup.cooldownValueLabel', { defaultValue: 'Duration' })}
+									placeholder={t('wallet.autoTopup.cooldownValuePlaceholder', { defaultValue: 'e.g. 1' })}
+									value={cooldownValue}
+									onChange={setCooldownValue}
+									variant='integer'
+									formatOptions={{
+										allowDecimals: false,
+										allowNegative: false,
+										decimalSeparator: '.',
+										thousandSeparator: ',',
+									}}
+								/>
+								<Select
+									label={t('wallet.autoTopup.cooldownUnitLabel', { defaultValue: 'Unit' })}
+									options={cooldownUnitOptions}
+									value={cooldownUnit || undefined}
+									placeholder={t('wallet.autoTopup.cooldownUnitPlaceholder', { defaultValue: 'Select unit' })}
+									onChange={(value) => setCooldownUnit((value as DurationUnit) || '')}
+								/>
+							</div>
+						)}
 
 						{/* Invoicing Toggle */}
 						<Toggle

--- a/src/components/molecules/WalletAutoTopup/WalletAutoTopup.tsx
+++ b/src/components/molecules/WalletAutoTopup/WalletAutoTopup.tsx
@@ -16,7 +16,7 @@ interface WalletAutoTopupProps {
 }
 
 /** Backend treats value 0 as unset cooloff (preferred over null for PUT merge). */
-const UNSET_COOLDOWN = { value: 0, unit: 'SECOND' as const };
+const UNSET_COOLDOWN = { value: 0, unit: 'second' as const };
 
 const DEFAULT_CONFIG: AutoTopupConfig = {
 	enabled: false,
@@ -26,13 +26,13 @@ const DEFAULT_CONFIG: AutoTopupConfig = {
 	cooldown: UNSET_COOLDOWN,
 };
 
-const DURATION_UNITS: DurationUnit[] = ['SECOND', 'MINUTE', 'HOUR', 'DAY'];
+const DURATION_UNITS: DurationUnit[] = ['second', 'minute', 'hour', 'day'];
 
 const UNIT_DEFAULT_LABELS: Record<DurationUnit, string> = {
-	SECOND: 'Second',
-	MINUTE: 'Minute',
-	HOUR: 'Hour',
-	DAY: 'Day',
+	second: 'Second',
+	minute: 'Minute',
+	hour: 'Hour',
+	day: 'Day',
 };
 
 const WalletAutoTopup: React.FC<WalletAutoTopupProps> = ({ open, autoTopupConfig, onSave, onClose }) => {

--- a/src/components/molecules/WalletAutoTopup/index.ts
+++ b/src/components/molecules/WalletAutoTopup/index.ts
@@ -1,1 +1,2 @@
 export { default } from './WalletAutoTopup';
+export type { AutoTopupConfig } from './WalletAutoTopup';

--- a/src/i18n/locales/ar/billing.json
+++ b/src/i18n/locales/ar/billing.json
@@ -804,12 +804,33 @@
 			"amountLabel": "مبلغ التعبئة (أرصدة)",
 			"amountPlaceholder": "0.00",
 			"amountDescription": "عدد الأرصدة المضافة عند تشغيل التعبئة التلقائية",
+			"cooldownTitle": "فترة الانتظار",
+			"cooldownLabel": "الانتظار قبل التعبئة التلقائية التالية",
+			"cooldownValueLabel": "المدة",
+			"cooldownValuePlaceholder": "مثال: 1",
+			"cooldownUnitLabel": "الوحدة",
+			"cooldownUnitPlaceholder": "اختر الوحدة",
+			"cooldownDescription": "بعد تعبئة تلقائية ناجحة، لن يعيد النظام التعبئة تلقائياً حتى تنتهي هذه المدة، حتى لو بقي الرصيد دون العتبة.",
+			"cooldownBurstDescription": "عند إيقاف فترة الانتظار وعدم طلب دفع الفاتورة، قد يعيد النظام التعبئة مراراً حتى يتجاوز الرصيد العتبة.",
+			"cooldownOptionalDescription": "عند إيقاف فترة الانتظار، لا يوجد انتظار بين التعبئات التلقائية.",
+			"cooldownUnits": {
+				"SECOND": "ثانية",
+				"MINUTE": "دقيقة",
+				"HOUR": "ساعة",
+				"DAY": "يوم"
+			},
 			"invoiceTitle": "يتطلب دفع الفاتورة",
 			"invoiceLabel": "إنشاء فاتورة للتعبئة التلقائية (يتطلب الدفع قبل إضافة الأرصدة)",
 			"invoiceDescriptionWhenInvoiced": "تُضاف الأرصدة فقط بعد دفع الفاتورة. تُنشأ فاتورة بحالة PENDING عند تشغيل التعبئة التلقائية.",
 			"invoiceDescriptionImmediate": "تُضاف الأرصدة فوراً عند تشغيل التعبئة التلقائية.",
 			"cancel": "إلغاء",
-			"saveChanges": "حفظ التغييرات"
+			"saveChanges": "حفظ التغييرات",
+			"errors": {
+				"invalidThreshold": "يرجى إدخال قيمة عتبة صالحة",
+				"invalidAmount": "يرجى إدخال مبلغ صالح أكبر من 0",
+				"cooldownIncomplete": "أدخل قيمة وحدة الانتظار معاً، أو أوقف فترة الانتظار",
+				"cooldownInvalidValue": "يجب أن تكون قيمة فترة الانتظار عدداً صحيحاً موجباً"
+			}
 		},
 		"terminate": {
 			"title": "إنهاء المحفظة",

--- a/src/i18n/locales/en/billing.json
+++ b/src/i18n/locales/en/billing.json
@@ -928,12 +928,33 @@
 			"amountLabel": "Top-Up Amount (Credits)",
 			"amountPlaceholder": "0.00",
 			"amountDescription": "Number of credits to add when auto top-up is triggered",
+			"cooldownTitle": "Cooloff",
+			"cooldownLabel": "Wait before next auto top-up",
+			"cooldownValueLabel": "Duration",
+			"cooldownValuePlaceholder": "e.g. 1",
+			"cooldownUnitLabel": "Unit",
+			"cooldownUnitPlaceholder": "Select unit",
+			"cooldownDescription": "After a successful auto top-up, the system will not auto top-up again until this window ends, even if the balance is still below the threshold.",
+			"cooldownBurstDescription": "When cooloff is off and invoice payment is not required, the system may top up repeatedly until the balance exceeds the threshold.",
+			"cooldownOptionalDescription": "When cooloff is off, there is no wait between auto top-ups.",
+			"cooldownUnits": {
+				"SECOND": "Second",
+				"MINUTE": "Minute",
+				"HOUR": "Hour",
+				"DAY": "Day"
+			},
 			"invoiceTitle": "Require Invoice Payment",
 			"invoiceLabel": "Create invoice for auto top-up (requires payment before credits are added)",
 			"invoiceDescriptionWhenInvoiced": "Credits will be added only after the invoice is paid. An invoice will be created in PENDING state when auto top-up is triggered.",
 			"invoiceDescriptionImmediate": "Credits will be added immediately when auto top-up is triggered.",
 			"cancel": "Cancel",
-			"saveChanges": "Save Changes"
+			"saveChanges": "Save Changes",
+			"errors": {
+				"invalidThreshold": "Please enter a valid threshold value",
+				"invalidAmount": "Please enter a valid amount value greater than 0",
+				"cooldownIncomplete": "Enter both a cooloff value and unit, or turn cooloff off",
+				"cooldownInvalidValue": "Cooloff value must be a positive integer"
+			}
 		},
 		"terminate": {
 			"title": "Terminate Wallet",

--- a/src/models/Wallet.ts
+++ b/src/models/Wallet.ts
@@ -1,7 +1,7 @@
 import { BaseModel, Metadata } from './base';
 import { Meter } from './Meter';
 
-export type DurationUnit = 'SECOND' | 'MINUTE' | 'HOUR' | 'DAY';
+export type DurationUnit = 'second' | 'minute' | 'hour' | 'day';
 
 export type Duration = {
 	value: number;
@@ -13,7 +13,7 @@ export type AutoTopup = {
 	threshold: string;
 	amount: string;
 	invoicing: boolean;
-	/** Omit/null/undefined = no cooloff. Send `{ value: 0, unit: 'SECOND' }` on PUT to clear. */
+	/** Omit/null/undefined = no cooloff. Send `{ value: 0, unit: 'second' }` on PUT to clear. */
 	cooldown?: Duration | null;
 };
 

--- a/src/models/Wallet.ts
+++ b/src/models/Wallet.ts
@@ -1,6 +1,22 @@
 import { BaseModel, Metadata } from './base';
 import { Meter } from './Meter';
 
+export type DurationUnit = 'SECOND' | 'MINUTE' | 'HOUR' | 'DAY';
+
+export type Duration = {
+	value: number;
+	unit: DurationUnit;
+};
+
+export type AutoTopup = {
+	enabled: boolean;
+	threshold: string;
+	amount: string;
+	invoicing: boolean;
+	/** Omit/null/undefined = no cooloff. Send `{ value: 0, unit: 'SECOND' }` on PUT to clear. */
+	cooldown?: Duration | null;
+};
+
 export interface WalletAlertThreshold {
 	threshold: string;
 	condition: 'above' | 'below';
@@ -34,12 +50,7 @@ export interface Wallet extends BaseModel {
 	readonly meter: Meter;
 	readonly alert_settings?: WalletAlertSettings;
 	readonly alert_state?: WalletAlertState;
-	readonly auto_topup?: {
-		enabled: boolean;
-		threshold: string;
-		amount: string;
-		invoicing: boolean;
-	};
+	readonly auto_topup?: AutoTopup;
 }
 
 export enum WALLET_STATUS {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -181,7 +181,7 @@ export { TenantMetadataKey } from './Tenant';
 export type { User } from './User';
 
 // Wallet
-export type { Wallet, WalletAlertSettings, WalletAlertThreshold, WalletAlertState } from './Wallet';
+export type { Wallet, WalletAlertSettings, WalletAlertThreshold, WalletAlertState, DurationUnit, Duration, AutoTopup } from './Wallet';
 export {
 	WALLET_STATUS,
 	WALLET_TX_REFERENCE_TYPE,

--- a/src/types/dto/Wallet.ts
+++ b/src/types/dto/Wallet.ts
@@ -9,6 +9,7 @@ import {
 	WalletTransaction,
 	WalletAlertSettings,
 	WalletAlertState,
+	AutoTopup,
 } from '@/models';
 import { TypedBackendFilter, TypedBackendSort } from '../formatters/QueryBuilder';
 
@@ -35,12 +36,7 @@ export interface CreateWalletPayload {
 	initial_credits_to_load_expiry_date?: number; // YYYYMMDD format
 	initial_credits_expiry_date_utc?: string; // ISO string
 	alert_settings?: WalletAlertSettings;
-	auto_topup?: {
-		enabled: boolean;
-		threshold: string;
-		amount: string;
-		invoicing: boolean;
-	};
+	auto_topup?: AutoTopup;
 	price_unit?: string;
 }
 
@@ -79,12 +75,7 @@ export interface UpdateWalletRequest {
 	description?: string;
 	metadata?: Metadata;
 	config?: WalletConfig;
-	auto_topup?: {
-		enabled: boolean;
-		threshold: string;
-		amount: string;
-		invoicing: boolean;
-	};
+	auto_topup?: AutoTopup;
 	alert_settings?: WalletAlertSettings;
 }
 
@@ -98,12 +89,7 @@ export interface WalletResponse {
 	credit_balance: string;
 	wallet_status: WALLET_STATUS;
 	metadata: Metadata;
-	auto_topup?: {
-		enabled: boolean;
-		threshold: string;
-		amount: string;
-		invoicing: boolean;
-	};
+	auto_topup?: AutoTopup;
 	wallet_type: WALLET_TYPE;
 	config: {
 		allowed_price_types: WALLET_CONFIG_PRICE_TYPE[];
@@ -117,12 +103,7 @@ export interface WalletResponse {
 }
 
 export interface GetCustomerWalletsResponse extends BaseModel {
-	auto_topup?: {
-		enabled: boolean;
-		threshold: string;
-		amount: string;
-		invoicing: boolean;
-	};
+	auto_topup?: AutoTopup;
 	balance: number;
 	config: {
 		allowed_price_types: WALLET_CONFIG_PRICE_TYPE[];


### PR DESCRIPTION
<img width="929" height="660" alt="Screenshot 2026-07-23 at 12 03 29 AM" src="https://github.com/user-attachments/assets/b46cea49-a2cb-4b24-a480-a76ba2f0c505" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable cooldown period for wallet automatic top-ups, with second, minute, hour, and day units.
  * Added validation for cooldown duration, threshold, and top-up amount.
  * Cooldown settings are preserved when editing or reopening the configuration.
* **Localization**
  * Added English and Arabic labels, guidance, placeholders, and validation messages for cooldown settings.
* **Accessibility**
  * Improved toggle and label associations when multiple toggles appear on the same page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->