### PR TITLE
fix(event-debugger): Pass event id in query param to be url safe

### DIFF
--- a/src/api/EventsApi.ts
+++ b/src/api/EventsApi.ts
@@ -28,10 +28,11 @@ class EventsApi {
 
 	/**
 	 * Event debugger response for a single event
-	 * GET /events/:id
+	 * GET /events/lookup?id=... (query param avoids issues with `/` in event IDs)
 	 */
 	public static async getEventDebug(eventId: string): Promise<GetEventDebugResponse> {
-		return await AxiosClient.get<GetEventDebugResponse>(`${EventsApi.baseUrl}/${eventId}`);
+		const url = generateQueryParams(`${EventsApi.baseUrl}/lookup`, { id: eventId });
+		return await AxiosClient.get<GetEventDebugResponse>(url);
 	}
 
 	/**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event debug lookups to use the correct query-based endpoint.
  * Existing event debug response behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->