### PR TITLE
fix(deps): bump dompurify to 3.4.12 (Dependabot #142)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3114,9 +3114,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3131,9 +3128,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3148,9 +3142,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3165,9 +3156,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3182,9 +3170,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3199,9 +3184,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3216,9 +3198,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3233,9 +3212,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3250,9 +3226,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3267,9 +3240,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3284,9 +3254,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3301,9 +3268,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3318,9 +3282,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6938,9 +6899,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
Resolves Dependabot alert [#142](https://github.com/flexprice/flexprice-front/security/dependabot/142).

## Vulnerability
- **Advisory:** GHSA-c2j3-45gr-mqc4 (low severity)
- **Package:** `dompurify` — `<= 3.4.11` vulnerable, patched in `3.4.12`
- **Issue:** `CUSTOM_ELEMENT_HANDLING` bypasses `afterSanitizeElements` for allowed custom elements

## Fix
`dompurify` is a transitive dependency via `posthog-js@1.396.4`. That package's range is `^3.3.2`, which already accepts the patched `3.4.12`, so no `posthog-js` upgrade was needed — only a lockfile refresh via `npm update dompurify --package-lock-only`.

**`package-lock.json` only** (+3/-42). No `package.json` change.

## Verification
- `node_modules/dompurify` resolves to `3.4.12` (confirmed after `npm ci`)
- `npm run build` — passes
- `npx eslint src/` — exit 0, zero errors (249 pre-existing warnings, untouched)
- `npm audit` could not be run: the registry returned a malformed gzip response from the bulk advisories endpoint. Environmental and unrelated to this change, so "no remaining advisories" is unverified; Dependabot will confirm on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)