### PR TITLE
fix(AwsMarketplace): use deterministic External ID

### DIFF
--- a/src/components/molecules/AwsMarketplaceConnectionDrawer/AwsMarketplaceConnectionDrawer.test.ts
+++ b/src/components/molecules/AwsMarketplaceConnectionDrawer/AwsMarketplaceConnectionDrawer.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { generateExternalId } from './AwsMarketplaceConnectionDrawer';
+
+describe('generateExternalId', () => {
+	it('joins tenant and environment ids', () => {
+		expect(generateExternalId('tenant_abc', 'env_xyz')).toBe('tenant_abc-env_xyz');
+	});
+});

--- a/src/components/molecules/AwsMarketplaceConnectionDrawer/AwsMarketplaceConnectionDrawer.test.tsx
+++ b/src/components/molecules/AwsMarketplaceConnectionDrawer/AwsMarketplaceConnectionDrawer.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { generateExternalId } from './AwsMarketplaceConnectionDrawer';
 
 describe('generateExternalId', () => {
-	it('joins tenant and environment ids', () => {
-		expect(generateExternalId('tenant_abc', 'env_xyz')).toBe('tenant_abc-env_xyz');
+	it('joins tenant and environment ids with an underscore', () => {
+		expect(generateExternalId('tenant_abc', 'env_xyz')).toBe('tenant_abc_env_xyz');
 	});
 });

--- a/src/components/molecules/AwsMarketplaceConnectionDrawer/AwsMarketplaceConnectionDrawer.tsx
+++ b/src/components/molecules/AwsMarketplaceConnectionDrawer/AwsMarketplaceConnectionDrawer.tsx
@@ -12,6 +12,8 @@ import { CreateConnectionPayload } from '@/types/dto';
 import { config } from '@/config/config';
 import { copyToClipboard } from '@/utils/common/helper_functions';
 import { cn } from '@/lib/utils';
+import useUser from '@/hooks/useUser';
+import useEnvironment from '@/hooks/useEnvironment';
 
 interface AwsMarketplaceConnectionDrawerProps {
 	isOpen: boolean;
@@ -42,13 +44,12 @@ const DEFAULT_AWS_MARKETPLACE_REGION = 'us-east-1';
 /** On-screen mask for variable values (real value is only ever copied, never shown). */
 const MASKED_VALUE = '••••••••••••';
 
-/** A fresh, unique external ID per connection attempt — guards the confused-deputy risk on AssumeRole. */
-const generateExternalId = (): string => {
-	const rand =
-		typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-			? crypto.randomUUID()
-			: `${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
-	return `flexprice-mp-${rand}`;
+/**
+ * Deterministic STS ExternalId scoped to the current tenant + environment.
+ * Replaces a random UUID so the same org/env always gets a stable AssumeRole condition.
+ */
+export const generateExternalId = (tenantId: string, environmentId: string): string => {
+	return `${tenantId}-${environmentId}`;
 };
 
 /** IAM permission policy — identical for every tenant. `BatchMeterUsage` is not resource-scopable. */
@@ -165,13 +166,15 @@ const VariableCopyRow: FC<{ name: string; value: string; copyToast: string; info
 const AwsMarketplaceConnectionDrawer: FC<AwsMarketplaceConnectionDrawerProps> = ({ isOpen, onOpenChange, connection, onSave }) => {
 	const { t } = useTranslation('settings');
 	const { t: tc } = useTranslation('common');
+	const { user } = useUser();
+	const { activeEnvironment } = useEnvironment();
 	const isEditMode = !!connection;
 
 	const [formData, setFormData] = useState<FormData>({ name: '', role_arn: '', region: DEFAULT_AWS_MARKETPLACE_REGION });
 	const [errors, setErrors] = useState<ValidationErrors>({});
 	const [externalId, setExternalId] = useState<string>('');
 
-	// Reset form and mint a fresh external ID each time the drawer opens for a new connection.
+	// Reset form and set ExternalId from tenant + environment when opening a new connection.
 	useEffect(() => {
 		if (!isOpen) return;
 		if (connection) {
@@ -179,10 +182,12 @@ const AwsMarketplaceConnectionDrawer: FC<AwsMarketplaceConnectionDrawerProps> = 
 			setExternalId('');
 		} else {
 			setFormData({ name: '', role_arn: '', region: DEFAULT_AWS_MARKETPLACE_REGION });
-			setExternalId(generateExternalId());
+			const tenantId = user?.tenant?.id;
+			const environmentId = activeEnvironment?.id;
+			setExternalId(tenantId && environmentId ? generateExternalId(tenantId, environmentId) : '');
 		}
 		setErrors({});
-	}, [connection, isOpen]);
+	}, [connection, isOpen, user?.tenant?.id, activeEnvironment?.id]);
 
 	const flexpriceAwsAccountId = config.integrations.flexpriceAwsAccountId;
 
@@ -263,6 +268,10 @@ const AwsMarketplaceConnectionDrawer: FC<AwsMarketplaceConnectionDrawerProps> = 
 		if (isEditMode) {
 			updateConnection();
 		} else {
+			if (!externalId.trim()) {
+				toast.error(t('connection.toast.failedToCreate'));
+				return;
+			}
 			createConnection();
 		}
 	};

--- a/src/components/molecules/AwsMarketplaceConnectionDrawer/AwsMarketplaceConnectionDrawer.tsx
+++ b/src/components/molecules/AwsMarketplaceConnectionDrawer/AwsMarketplaceConnectionDrawer.tsx
@@ -49,7 +49,7 @@ const MASKED_VALUE = '••••••••••••';
  * Replaces a random UUID so the same org/env always gets a stable AssumeRole condition.
  */
 export const generateExternalId = (tenantId: string, environmentId: string): string => {
-	return `${tenantId}-${environmentId}`;
+	return `${tenantId}_${environmentId}`;
 };
 
 /** IAM permission policy — identical for every tenant. `BatchMeterUsage` is not resource-scopable. */
@@ -269,7 +269,7 @@ const AwsMarketplaceConnectionDrawer: FC<AwsMarketplaceConnectionDrawerProps> = 
 			updateConnection();
 		} else {
 			if (!externalId.trim()) {
-				toast.error(t('connection.toast.failedToCreate'));
+				toast.error(t('connection.toast.externalIdUnavailable'));
 				return;
 			}
 			createConnection();

--- a/src/i18n/locales/ar/settings.json
+++ b/src/i18n/locales/ar/settings.json
@@ -668,6 +668,7 @@
 			"updated": "تم تحديث اتصال {{provider}} بنجاح",
 			"failedToCreate": "فشل إنشاء الاتصال",
 			"failedToUpdate": "فشل تحديث الاتصال",
+			"externalIdUnavailable": "تعذّر إنشاء الاتصال — معرّف المستأجر أو البيئة غير متوفر",
 			"webhookUrlCopied": "تم نسخ عنوان الويب هوك!",
 			"redirectUriCopied": "تم نسخ عنوان إعادة التوجيه!",
 			"failedOAuth": "فشل بدء OAuth",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -665,6 +665,7 @@
 			"updated": "{{provider}} connection updated successfully",
 			"failedToCreate": "Failed to create connection",
 			"failedToUpdate": "Failed to update connection",
+			"externalIdUnavailable": "Unable to create connection — tenant or environment is missing",
 			"webhookUrlCopied": "Webhook URL copied to clipboard!",
 			"redirectUriCopied": "Redirect URI copied to clipboard!",
 			"failedOAuth": "Failed to initiate OAuth",


### PR DESCRIPTION
## Summary
- Generate AWS Marketplace External ID as `${tenantId}_${environmentId}` instead of a random UUID
- Show a toast when External ID is unavailable and block create
- Add unit coverage for External ID generation

## Test plan
- [ ] Open AWS Marketplace connection drawer and confirm External ID matches `tenantId_environmentId`
- [ ] Verify External ID field remains read-only / non-editable
- [ ] With missing tenant or environment context, confirm create is blocked and toast is shown
- [ ] Run `npx vitest run src/components/molecules/AwsMarketplaceConnectionDrawer/AwsMarketplaceConnectionDrawer.test.tsx`


Made with [Cursor](https://cursor.com)