### PR TITLE
Fix/charge currency

### DIFF
--- a/src/utils/common/format_date.test.ts
+++ b/src/utils/common/format_date.test.ts
@@ -1,46 +1,41 @@
-import { describe, expect, test } from 'vitest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { formatBillingPeriod, formatBillingPeriodDate } from './format_date';
 
-describe('formatBillingPeriodDate', () => {
+const IST = 'Asia/Kolkata';
+const previousTz = process.env.TZ;
+
+describe('formatBillingPeriodDate / formatBillingPeriod (Asia/Kolkata)', () => {
+	beforeAll(() => {
+		process.env.TZ = IST;
+		// Fail fast if the runner ignores mid-process TZ changes.
+		expect(new Date().getTimezoneOffset()).toBe(-330);
+	});
+
+	afterAll(() => {
+		if (previousTz === undefined) {
+			delete process.env.TZ;
+		} else {
+			process.env.TZ = previousTz;
+		}
+	});
+
 	test('utc zone uses the UTC calendar day for IST midnight instants', () => {
 		// 31 Jul 00:00 IST == 30 Jul 18:30 UTC
 		expect(formatBillingPeriodDate('2025-07-30T18:30:00.000Z', 'utc')).toBe('30 Jul');
 	});
 
 	test('local zone uses the local calendar day for IST midnight instants', () => {
-		const local = formatBillingPeriodDate('2025-07-30T18:30:00.000Z', 'local');
-		const utc = formatBillingPeriodDate('2025-07-30T18:30:00.000Z', 'utc');
-		// East of UTC (e.g. IST): local is the next calendar day
-		if (new Date().getTimezoneOffset() < 0) {
-			expect(local).toBe('31 Jul');
-			expect(utc).toBe('30 Jul');
-		} else {
-			expect(local).toBe(utc);
-		}
+		expect(formatBillingPeriodDate('2025-07-30T18:30:00.000Z', 'local')).toBe('31 Jul');
+		expect(formatBillingPeriodDate('2025-07-30T18:30:00.000Z', 'utc')).toBe('30 Jul');
 	});
-});
 
-describe('formatBillingPeriod', () => {
 	test('formats exclusive end in local time (not UTC)', () => {
-		const periodEnd = '2025-07-31T00:00:00.000Z';
-		const endMinusOneSec = new Date(new Date(periodEnd).getTime() - 1000).toISOString();
-		const expectedEnd = formatBillingPeriodDate(endMinusOneSec, 'local');
-		const result = formatBillingPeriod('2025-07-01T00:00:00.000Z', periodEnd);
-
-		expect(result.endsWith(expectedEnd)).toBe(true);
-		// Must not keep the old UTC-only end (30 Jul for +offset zones).
-		if (new Date().getTimezoneOffset() < 0) {
-			expect(expectedEnd).toBe('31 Jul');
-			expect(result).not.toMatch(/30 Jul$/);
-		}
+		// Exclusive end at 31 Jul 00:00 UTC → last included instant is still 31 Jul in IST
+		expect(formatBillingPeriod('2025-07-01T00:00:00.000Z', '2025-07-31T00:00:00.000Z')).toBe('1 Jul - 31 Jul');
 	});
 
-	test('IST-aligned exclusive month end still shows last included day', () => {
-		const result = formatBillingPeriod('2025-06-30T18:30:00.000Z', '2025-07-31T18:30:00.000Z');
-		const expectedEnd = formatBillingPeriodDate(new Date(new Date('2025-07-31T18:30:00.000Z').getTime() - 1000).toISOString(), 'local');
-		expect(result.endsWith(expectedEnd)).toBe(true);
-		if (new Date().getTimezoneOffset() === -330) {
-			expect(result).toBe('1 Jul - 31 Jul');
-		}
+	test('IST-aligned exclusive month end shows last included day', () => {
+		// [1 Jul 00:00 IST, 1 Aug 00:00 IST)
+		expect(formatBillingPeriod('2025-06-30T18:30:00.000Z', '2025-07-31T18:30:00.000Z')).toBe('1 Jul - 31 Jul');
 	});
 });

--- a/src/utils/common/format_date.test.ts
+++ b/src/utils/common/format_date.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import { formatBillingPeriod, formatBillingPeriodDate } from './format_date';
+
+describe('formatBillingPeriodDate', () => {
+	test('utc zone uses the UTC calendar day for IST midnight instants', () => {
+		// 31 Jul 00:00 IST == 30 Jul 18:30 UTC
+		expect(formatBillingPeriodDate('2025-07-30T18:30:00.000Z', 'utc')).toBe('30 Jul');
+	});
+
+	test('local zone uses the local calendar day for IST midnight instants', () => {
+		const local = formatBillingPeriodDate('2025-07-30T18:30:00.000Z', 'local');
+		const utc = formatBillingPeriodDate('2025-07-30T18:30:00.000Z', 'utc');
+		// East of UTC (e.g. IST): local is the next calendar day
+		if (new Date().getTimezoneOffset() < 0) {
+			expect(local).toBe('31 Jul');
+			expect(utc).toBe('30 Jul');
+		} else {
+			expect(local).toBe(utc);
+		}
+	});
+});
+
+describe('formatBillingPeriod', () => {
+	test('formats exclusive end in local time (not UTC)', () => {
+		const periodEnd = '2025-07-31T00:00:00.000Z';
+		const endMinusOneSec = new Date(new Date(periodEnd).getTime() - 1000).toISOString();
+		const expectedEnd = formatBillingPeriodDate(endMinusOneSec, 'local');
+		const result = formatBillingPeriod('2025-07-01T00:00:00.000Z', periodEnd);
+
+		expect(result.endsWith(expectedEnd)).toBe(true);
+		// Must not keep the old UTC-only end (30 Jul for +offset zones).
+		if (new Date().getTimezoneOffset() < 0) {
+			expect(expectedEnd).toBe('31 Jul');
+			expect(result).not.toMatch(/30 Jul$/);
+		}
+	});
+
+	test('IST-aligned exclusive month end still shows last included day', () => {
+		const result = formatBillingPeriod('2025-06-30T18:30:00.000Z', '2025-07-31T18:30:00.000Z');
+		const expectedEnd = formatBillingPeriodDate(new Date(new Date('2025-07-31T18:30:00.000Z').getTime() - 1000).toISOString(), 'local');
+		expect(result.endsWith(expectedEnd)).toBe(true);
+		if (new Date().getTimezoneOffset() === -330) {
+			expect(result).toBe('1 Jul - 31 Jul');
+		}
+	});
+});

--- a/src/utils/common/format_date.ts
+++ b/src/utils/common/format_date.ts
@@ -203,8 +203,8 @@ export function formatBillingPeriodDate(date: string | Date, zone: DateTimezone 
 	return `${day} ${month}`;
 }
 
-/** Format a billing period as "7 Mar - 8 Dec". Start date is shown in the user's local timezone; end date stays in UTC. End date is shown as periodEnd - 1 second. */
+/** Format a billing period as "7 Mar - 8 Dec". Both ends use the user's local timezone so IST (etc.) midnight boundaries (e.g. `…T18:30:00Z`) map to the intended calendar day. End date is shown as periodEnd - 1 second (exclusive end → last included day). */
 export function formatBillingPeriod(periodStart: string, periodEnd: string): string {
 	const endMinusOneSec = new Date(new Date(periodEnd).getTime() - 1000).toISOString();
-	return `${formatBillingPeriodDate(periodStart, 'local')} - ${formatBillingPeriodDate(endMinusOneSec, 'utc')}`;
+	return `${formatBillingPeriodDate(periodStart, 'local')} - ${formatBillingPeriodDate(endMinusOneSec, 'local')}`;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Billing period end dates are now displayed using the user’s local timezone, ensuring the correct last included day appears across time zones.
  * Improved handling of exclusive billing period end dates, including month-end cases.

* **Tests**
  * Added coverage for local and UTC date formatting behavior across timezone-dependent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->