### PR TITLE
fix(Sheet): make portaled comboboxes clickable inside modal sheets

### DIFF
--- a/src/components/atoms/Sheet/Sheet.tsx
+++ b/src/components/atoms/Sheet/Sheet.tsx
@@ -1,9 +1,20 @@
-import { FC, ReactNode, useRef, useEffect, useState, cloneElement, isValidElement } from 'react';
+import { FC, ReactNode, useRef, useEffect, useState, useCallback, cloneElement, isValidElement } from 'react';
 import { Sheet as ShadcnSheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 import { hasRegisteredOpenModals, registerModalOpen } from '@/lib/modal-scroll-lock';
 import { useLocaleStore } from '@/store/useLocaleStore';
 import { Direction } from '@/config/branding';
+
+/**
+ * Modal sheets set body `pointer-events: none`, and Radix Popover-based comboboxes
+ * (SearchableSelect, AsyncSearchableSelect, and anything built on them, e.g. SelectGroup,
+ * SelectFeature) portal their option list outside the sheet's DOM subtree, so their options
+ * become unclickable — clicks fall through to the overlay instead of the option. Rendering
+ * the sheet as non-modal and ignoring "outside" interactions that originate inside a
+ * portaled popper avoids this for every consumer of this atom.
+ */
+export const isPortaledSelectTarget = (target: EventTarget | null) =>
+	target instanceof Element && !!target.closest('[data-radix-popper-content-wrapper]');
 
 interface Props {
 	trigger?: ReactNode;
@@ -21,6 +32,12 @@ const Sheet: FC<Props> = ({ children, trigger, description, title, isOpen, onOpe
 	const direction = useLocaleStore((s) => s.direction);
 	const side = direction === Direction.RTL ? 'left' : 'right';
 	const [isScrollable, setIsScrollable] = useState(false);
+
+	const preventPortaledSelectDismiss = useCallback((event: Event) => {
+		if (isPortaledSelectTarget(event.target)) {
+			event.preventDefault();
+		}
+	}, []);
 
 	useEffect(() => {
 		if (isOpen && contentRef.current) {
@@ -141,11 +158,14 @@ const Sheet: FC<Props> = ({ children, trigger, description, title, isOpen, onOpe
 	}
 
 	return (
-		<ShadcnSheet open={isOpen} onOpenChange={onOpenChange}>
+		<ShadcnSheet open={isOpen} onOpenChange={onOpenChange} modal={false}>
 			{trigger && <SheetTrigger asChild>{trigger}</SheetTrigger>}
 			<SheetContent
 				ref={contentRef}
 				side={side}
+				onPointerDownOutside={preventPortaledSelectDismiss}
+				onInteractOutside={preventPortaledSelectDismiss}
+				onFocusOutside={preventPortaledSelectDismiss}
 				className={cn('h-screen overflow-y-auto rounded-[10px]', className, {
 					'sm:max-w-sm': size === 'sm',
 					'sm:max-w-md': size === 'md',

--- a/src/components/molecules/AddEntitlementDrawer/AddEntitlementDrawer.tsx
+++ b/src/components/molecules/AddEntitlementDrawer/AddEntitlementDrawer.tsx
@@ -1,5 +1,6 @@
 import { Button, Checkbox, Dialog, FormHeader, Input, Select, SelectFeature, Spacer, Toggle } from '@/components/atoms';
 import { Sheet as ShadcnSheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { isPortaledSelectTarget } from '@/components/atoms/Sheet/Sheet';
 import { JsonObject } from '@/types/common';
 import { JsonEditor } from '@/components/molecules/JsonEditor';
 import { getFeatureIcon } from '@/components/atoms/SelectFeature/SelectFeature';
@@ -21,13 +22,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { useLocaleStore } from '@/store/useLocaleStore';
 import { Direction } from '@/config/branding';
-
-/**
- * Modal Sheets set body `pointer-events: none`. SelectFeature portals its Popover outside
- * Sheet content, so options become unclickable and clicks fall through to the overlay.
- */
-const isPortaledSelectTarget = (target: EventTarget | null) =>
-	target instanceof Element && !!target.closest('[data-radix-popper-content-wrapper]');
 
 interface Props {
 	isOpen: boolean;


### PR DESCRIPTION
## Summary
- The "Group" select in the Edit Feature drawer didn't respond to clicks: Radix's modal `Dialog` sets `pointer-events: none` on `<body>` and only re-enables it inside its own `Content` subtree, but Popover-based comboboxes (`SearchableSelect`, `AsyncSearchableSelect`, and everything built on them — `SelectGroup`, `SelectFeature`) portal their option list to `<body>` as a sibling, so clicks on the options fell through to the sheet overlay instead of registering.
- This is the same bug class already fixed for `AddEntitlementDrawer`'s `SelectFeature` combobox (`modal={false}` + outside-interaction guards, see `8fd0a5a8`), but that fix was applied locally to one drawer that bypasses the shared `Sheet` atom. Since `FeatureDrawer` (and ~30 other drawers) render through the shared `Sheet` atom, the same bug was latent everywhere that atom hosts a portaled combobox.
- Moved the fix into `src/components/atoms/Sheet/Sheet.tsx` itself so every consumer of the atom is fixed at once, and deduped `AddEntitlementDrawer`'s local copy of the guard to import from the atom instead.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/components/atoms/Sheet/Sheet.tsx src/components/molecules/AddEntitlementDrawer/AddEntitlementDrawer.tsx` — 0 errors (pre-existing warnings only)
- [x] `npx vitest run` — 47 files / 301 tests pass, including drawers that render through the `Sheet` atom (`CouponDrawer`, `MoyasarConnectionDrawer`, `AwsMarketplaceConnectionDrawer`)
- [x] Audited the ~38 components rendering `<Sheet>` from `@/components/atoms` for the two components that also nest a `<Dialog>` (`ServiceAccountDrawer`, `SubscriptionEntitlementsSection`) — Radix's `DismissableLayer` stacking (which governs nested-modal outside-click behavior) is independent of the outer layer's `modal` prop, so nested confirmation dialogs are unaffected
- [ ] Manual click-through of the Group select in Edit Feature drawer and the Add Entitlement drawer (blocked in this environment — dev server requires login credentials not available here)

Note: setting `modal={false}` also means sheets no longer lock body scroll or trap keyboard focus while open (background page can scroll / receive Tab focus) — the same trade-off already accepted for `AddEntitlementDrawer`, now applied to every `Sheet`-atom consumer. The overlay still intercepts outside clicks to dismiss the sheet as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)