### PR TITLE
fix(Sheet): stop non-modal sheets closing when focus returns to their trigger

### DIFF
--- a/src/components/atoms/Sheet/Sheet.tsx
+++ b/src/components/atoms/Sheet/Sheet.tsx
@@ -1,9 +1,20 @@
-import { FC, ReactNode, useRef, useEffect, useState, cloneElement, isValidElement } from 'react';
+import { FC, ReactNode, useRef, useEffect, useState, useCallback, cloneElement, isValidElement } from 'react';
 import { Sheet as ShadcnSheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 import { hasRegisteredOpenModals, registerModalOpen } from '@/lib/modal-scroll-lock';
 import { useLocaleStore } from '@/store/useLocaleStore';
 import { Direction } from '@/config/branding';
+
+/**
+ * Modal sheets set body `pointer-events: none`, and Radix Popover-based comboboxes
+ * (SearchableSelect, AsyncSearchableSelect, and anything built on them, e.g. SelectGroup,
+ * SelectFeature) portal their option list outside the sheet's DOM subtree, so their options
+ * become unclickable — clicks fall through to the overlay instead of the option. Rendering
+ * the sheet as non-modal and ignoring "outside" interactions that originate inside a
+ * portaled popper avoids this for every consumer of this atom.
+ */
+export const isPortaledSelectTarget = (target: EventTarget | null) =>
+	target instanceof Element && !!target.closest('[data-radix-popper-content-wrapper]');
 
 interface Props {
 	trigger?: ReactNode;
@@ -21,6 +32,12 @@ const Sheet: FC<Props> = ({ children, trigger, description, title, isOpen, onOpe
 	const direction = useLocaleStore((s) => s.direction);
 	const side = direction === Direction.RTL ? 'left' : 'right';
 	const [isScrollable, setIsScrollable] = useState(false);
+
+	const preventPortaledSelectDismiss = useCallback((event: Event) => {
+		if (isPortaledSelectTarget(event.target)) {
+			event.preventDefault();
+		}
+	}, []);
 
 	useEffect(() => {
 		if (isOpen && contentRef.current) {
@@ -141,11 +158,14 @@ const Sheet: FC<Props> = ({ children, trigger, description, title, isOpen, onOpe
 	}
 
 	return (
-		<ShadcnSheet open={isOpen} onOpenChange={onOpenChange}>
+		<ShadcnSheet open={isOpen} onOpenChange={onOpenChange} modal={false}>
 			{trigger && <SheetTrigger asChild>{trigger}</SheetTrigger>}
 			<SheetContent
 				ref={contentRef}
 				side={side}
+				onPointerDownOutside={preventPortaledSelectDismiss}
+				onInteractOutside={preventPortaledSelectDismiss}
+				onFocusOutside={preventPortaledSelectDismiss}
 				className={cn('h-screen overflow-y-auto rounded-[10px]', className, {
 					'sm:max-w-sm': size === 'sm',
 					'sm:max-w-md': size === 'md',

--- a/src/components/atoms/Sheet/Sheet.tsx
+++ b/src/components/atoms/Sheet/Sheet.tsx
@@ -39,6 +39,15 @@ const Sheet: FC<Props> = ({ children, trigger, description, title, isOpen, onOpe
 		}
 	}, []);
 
+	// Non-modal dialogs get no default protection against focus-outside dismissal (Radix only
+	// applies that to modal dialogs). Without it, a sheet opened from a menu item/action button
+	// closes itself the instant that trigger reclaims focus after its own menu finishes closing.
+	// Focus moving elsewhere should never by itself close the sheet — only an explicit outside
+	// click or the close button should.
+	const preventFocusOutsideDismiss = useCallback((event: Event) => {
+		event.preventDefault();
+	}, []);
+
 	useEffect(() => {
 		if (isOpen && contentRef.current) {
 			// Check if content is scrollable after a short delay to ensure DOM is fully rendered
@@ -165,7 +174,7 @@ const Sheet: FC<Props> = ({ children, trigger, description, title, isOpen, onOpe
 				side={side}
 				onPointerDownOutside={preventPortaledSelectDismiss}
 				onInteractOutside={preventPortaledSelectDismiss}
-				onFocusOutside={preventPortaledSelectDismiss}
+				onFocusOutside={preventFocusOutsideDismiss}
 				className={cn('h-screen overflow-y-auto rounded-[10px]', className, {
 					'sm:max-w-sm': size === 'sm',
 					'sm:max-w-md': size === 'md',

--- a/src/components/molecules/AddEntitlementDrawer/AddEntitlementDrawer.tsx
+++ b/src/components/molecules/AddEntitlementDrawer/AddEntitlementDrawer.tsx
@@ -1,5 +1,6 @@
 import { Button, Checkbox, Dialog, FormHeader, Input, Select, SelectFeature, Spacer, Toggle } from '@/components/atoms';
 import { Sheet as ShadcnSheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { isPortaledSelectTarget } from '@/components/atoms/Sheet/Sheet';
 import { JsonObject } from '@/types/common';
 import { JsonEditor } from '@/components/molecules/JsonEditor';
 import { getFeatureIcon } from '@/components/atoms/SelectFeature/SelectFeature';
@@ -21,13 +22,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { useLocaleStore } from '@/store/useLocaleStore';
 import { Direction } from '@/config/branding';
-
-/**
- * Modal Sheets set body `pointer-events: none`. SelectFeature portals its Popover outside
- * Sheet content, so options become unclickable and clicks fall through to the overlay.
- */
-const isPortaledSelectTarget = (target: EventTarget | null) =>
-	target instanceof Element && !!target.closest('[data-radix-popper-content-wrapper]');
 
 interface Props {
 	isOpen: boolean;

--- a/src/components/molecules/AddEntitlementDrawer/AddEntitlementDrawer.tsx
+++ b/src/components/molecules/AddEntitlementDrawer/AddEntitlementDrawer.tsx
@@ -332,6 +332,14 @@ const AddEntitlementDrawer: FC<Props> = ({
 		}
 	}, []);
 
+	// Non-modal dialogs get no default protection against focus-outside dismissal (Radix only
+	// applies that to modal dialogs). Without it, opening this drawer from a menu item/action
+	// button would close it the instant that trigger reclaims focus after its own menu finishes
+	// closing. Focus moving elsewhere should never by itself close the drawer.
+	const preventFocusOutsideDismiss = useCallback((event: Event) => {
+		event.preventDefault();
+	}, []);
+
 	// Reset states when drawer opens/closes
 	useEffect(() => {
 		if (isOpen) {
@@ -479,7 +487,7 @@ const AddEntitlementDrawer: FC<Props> = ({
 					className={cn('h-screen overflow-y-auto rounded-[10px] sm:max-w-sm bg-card')}
 					onPointerDownOutside={preventPortaledSelectDismiss}
 					onInteractOutside={preventPortaledSelectDismiss}
-					onFocusOutside={preventPortaledSelectDismiss}>
+					onFocusOutside={preventFocusOutsideDismiss}>
 					<SheetHeader>
 						<SheetTitle>{t('entitlements.addDrawer.title')}</SheetTitle>
 						<SheetDescription>{t('entitlements.addDrawer.description')}</SheetDescription>


### PR DESCRIPTION
## Summary
Follow-up to flexprice/flexprice-front#1184 (already merged into `develop`), which switched the shared `Sheet` atom to `modal={false}` to fix portaled comboboxes (e.g. the Group select) being unclickable inside sheets. That change introduced a regression: opening a Sheet from a row's "Edit" action (a Radix `DropdownMenu` item) caused the sheet to flash open and immediately close.

**Root cause:** Radix's modal `Dialog` always prevents dismissal on focus-outside by default; non-modal dialogs get no such protection. The closing `DropdownMenu` returns focus to its own trigger button shortly after close, and since that button sits outside the freshly-opened Sheet's content, Radix's default `onFocusOutside` handling treated it as an outside interaction and closed the sheet.

**Fix:** always `preventDefault()` on `onFocusOutside` (matching what Radix's modal Dialog already does by default), instead of gating it on the portaled-popper check. Only an explicit outside click or the close button dismisses the sheet now. Applied the same fix to `AddEntitlementDrawer`'s inline Sheet composition for consistency.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on both touched files — 0 errors (pre-existing warnings only)
- [x] `npx vitest run` — 47 files / 301 tests pass
- [ ] Manual click-through of Edit Feature (row action → drawer) and Add Entitlement drawers

🤖 Generated with [Claude Code](https://claude.com/claude-code)