### PR TITLE
fix(CreateCustomerDrawer): stop toggleOpen from ignoring the value Radix passes it

### DIFF
--- a/src/components/molecules/Customer/CreateCustomerDrawer.tsx
+++ b/src/components/molecules/Customer/CreateCustomerDrawer.tsx
@@ -73,11 +73,15 @@ const CreateCustomerDrawer: FC<Props> = ({ data, onOpenChange, open, trigger }) 
 	}, [data]);
 
 	const currentOpen = isControlled ? open : uiState.internalOpen;
-	const toggleOpen = (open?: boolean) => {
+	// Radix passes the intended next-open value here (e.g. from onOpenChange/dismiss handlers).
+	// It must be used as-is rather than blindly toggled — a blind toggle drops out of sync with
+	// Radix's own state the moment it's called for any reason other than a simple trigger click.
+	const toggleOpen = (nextOpen?: boolean) => {
+		const value = nextOpen ?? !currentOpen;
 		if (isControlled) {
-			onOpenChange?.(open ?? false);
+			onOpenChange?.(value);
 		} else {
-			updateUIState({ internalOpen: !uiState.internalOpen });
+			updateUIState({ internalOpen: value });
 		}
 	};
 


### PR DESCRIPTION
## Summary

Investigated as a follow-up to flexprice/flexprice-front#1184 / flexprice/flexprice-front#1185 — report that the "Add Customer" drawer opens and then closes on any click, even clicks inside it.

Found a real bug in `CreateCustomerDrawer`'s `toggleOpen` (`src/components/molecules/Customer/CreateCustomerDrawer.tsx`):

```ts
const toggleOpen = (open?: boolean) => {
  if (isControlled) {
    onOpenChange?.(open ?? false);
  } else {
    updateUIState({ internalOpen: !uiState.internalOpen }); // <-- ignores `open`
  }
};
```

Radix only calls `onOpenChange` when it wants the open state to become a specific value (from a trigger click, dismiss, escape, etc.) — never as a bare "toggle me" signal. The uncontrolled branch here ignored the value Radix passed and blindly flipped `internalOpen` instead. Whenever Radix's own dialog state and our shadow `internalOpen` state fall out of alignment (e.g. because of the exact sequence of calls around focus/dismiss handling in the two prior Sheet fixes), this makes the drawer's displayed state diverge from what Radix's own DOM structure expects, which can present as the drawer closing on its own.

Fix: use the value Radix passes directly in both branches, falling back to toggling only when called with no argument (the internal post-submit `toggleOpen()` close call).

## Caveat

I could **not** reproduce the exact "closes on any click inside" symptom via automated testing — I wrote RTL/jsdom repros matching both real entry points (`CustomerListPage`'s `trigger` + controlled `open`/`onOpenChange` combo, and `CustomerOverviewCard`'s uncontrolled `trigger`-only "Edit" button) and clicked/typed into plain inputs, a plain button, and the Country `<Select>`, and the drawer stayed open in every case. jsdom is known to diverge from real browsers around pointer capture and focus timing (`hasPointerCapture` isn't even implemented in jsdom), so this may not be reproducible outside a real browser. This fix addresses a genuine, independent correctness bug in the same open-state plumbing that's the most likely accompanying cause — please retest against this branch and let me know if the symptom persists.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/components/molecules/Customer/CreateCustomerDrawer.tsx` — 0 errors (pre-existing warnings only)
- [x] `npx vitest run` — 47 files / 301 tests pass
- [ ] Manual verification that the Add/Edit Customer drawer no longer closes unexpectedly (please confirm — I don't have login access to a running instance in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)