### PR TITLE
fix(CreateCustomerDrawer): stop toggleOpen from ignoring the value Radix passes it

### DIFF
--- a/src/components/molecules/Customer/CreateCustomerDrawer.tsx
+++ b/src/components/molecules/Customer/CreateCustomerDrawer.tsx
@@ -73,11 +73,15 @@ const CreateCustomerDrawer: FC<Props> = ({ data, onOpenChange, open, trigger }) 
 	}, [data]);
 
 	const currentOpen = isControlled ? open : uiState.internalOpen;
-	const toggleOpen = (open?: boolean) => {
+	// Radix passes the intended next-open value here (e.g. from onOpenChange/dismiss handlers).
+	// It must be used as-is rather than blindly toggled — a blind toggle drops out of sync with
+	// Radix's own state the moment it's called for any reason other than a simple trigger click.
+	const toggleOpen = (nextOpen?: boolean) => {
+		const value = nextOpen ?? !currentOpen;
 		if (isControlled) {
-			onOpenChange?.(open ?? false);
+			onOpenChange?.(value);
 		} else {
-			updateUIState({ internalOpen: !uiState.internalOpen });
+			updateUIState({ internalOpen: value });
 		}
 	};
 


### PR DESCRIPTION
Same fix as flexprice/flexprice-front#1188, cherry-picked onto \`main\`.

## Summary

Investigated as a follow-up to flexprice/flexprice-front#1184 / flexprice/flexprice-front#1185 — report that the "Add Customer" drawer opens and then closes on any click, even clicks inside it.

Found a real bug in \`CreateCustomerDrawer\`'s \`toggleOpen\` (\`src/components/molecules/Customer/CreateCustomerDrawer.tsx\`): its uncontrolled branch blindly flipped \`uiState.internalOpen\` instead of using the boolean Radix's Dialog actually passes to \`onOpenChange\`. Radix only calls \`onOpenChange\` when it wants the open state to become a specific value — ignoring that value and toggling instead can desync the drawer's shadow state from Radix's own dialog state, which can present as the drawer closing on its own.

Fix: use the value Radix passes directly, falling back to toggling only when called with no argument (the internal post-submit close call).

**Caveat:** I could not reproduce the exact "closes on any click inside" symptom via automated RTL/jsdom testing against either real entry point (\`CustomerListPage\`'s trigger+controlled combo, \`CustomerOverviewCard\`'s uncontrolled Edit trigger). jsdom diverges from real browsers around pointer capture/focus timing. This fixes a genuine, independent bug in the same open-state plumbing — please retest and confirm.

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx eslint\` on the changed file — 0 errors (pre-existing warnings only)
- [x] \`npx vitest run\` — 47 files / 301 tests pass
- [ ] Manual verification (no login access in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)