### PR TITLE
fix(CustomerListPage): remove duplicate CreateCustomerDrawer instance

### DIFF
--- a/src/components/molecules/Customer/CreateCustomerDrawer.tsx
+++ b/src/components/molecules/Customer/CreateCustomerDrawer.tsx
@@ -1,5 +1,5 @@
 import { Button, Input, Select, SelectOption, Sheet, Spacer } from '@/components/atoms';
-import { FC, useEffect, useMemo, useState } from 'react';
+import { cloneElement, FC, isValidElement, MouseEvent, ReactElement, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMutation } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
@@ -84,6 +84,20 @@ const CreateCustomerDrawer: FC<Props> = ({ data, onOpenChange, open, trigger }) 
 			updateUIState({ internalOpen: value });
 		}
 	};
+
+	// Render the trigger ourselves and open the drawer with a plain onClick, instead of handing it
+	// to Sheet's `trigger` prop (Radix SheetTrigger/asChild). Radix's trigger adds its own toggle
+	// and focus bookkeeping on top of our own controlled/uncontrolled state, which is unnecessary
+	// here and matches every other Sheet consumer in the app that's driven purely by isOpen/onOpenChange.
+	const triggerElement =
+		trigger && isValidElement(trigger)
+			? cloneElement(trigger as ReactElement<{ onClick?: (event: MouseEvent) => void }>, {
+					onClick: (event: MouseEvent) => {
+						(trigger as ReactElement<{ onClick?: (event: MouseEvent) => void }>).props.onClick?.(event);
+						toggleOpen(true);
+					},
+				})
+			: trigger;
 
 	const countriesOptions: SelectOption[] = Country.getAllCountries().map(({ name, isoCode }) => ({ label: name, value: isoCode }));
 	const statesOptions: SelectOption[] = formData.address_country
@@ -217,13 +231,13 @@ const CreateCustomerDrawer: FC<Props> = ({ data, onOpenChange, open, trigger }) 
 
 	return (
 		<div>
+			{triggerElement}
 			<Sheet
 				isOpen={currentOpen}
 				size='lg'
 				onOpenChange={toggleOpen}
 				title={data ? t('form.drawer.editCustomer') : t('form.drawer.addCustomer')}
-				description={data ? t('form.drawer.editDescription') : t('form.drawer.createDescription')}
-				trigger={trigger}>
+				description={data ? t('form.drawer.editDescription') : t('form.drawer.createDescription')}>
 				<div className='space-y-8 mt-4'>
 					<div className='relative card !p-4 !mb-6'>
 						<span className='absolute -top-4 left-2 text-[#18181B] text-sm bg-white font-medium px-2 py-1'>

--- a/src/pages/customer/customers/CustomerListPage.tsx
+++ b/src/pages/customer/customers/CustomerListPage.tsx
@@ -301,7 +301,6 @@ const CustomerListPage = () => {
 					tutorials: guides.customers.tutorials,
 				}}
 			/>
-			<CreateCustomerDrawer open={customerDrawerOpen} onOpenChange={setcustomerDrawerOpen} data={activeCustomer} />
 		</Page>
 	);
 };


### PR DESCRIPTION
Same fix as flexprice/flexprice-front#1191, cherry-picked onto \`main\`.

## Summary

Follow-up to flexprice/flexprice-front#1189 (merged) — the "Add Customer" drawer would open and then close on any click inside it, even typing.

**Root cause:** \`CustomerListPage.tsx\` rendered **two separate \`<CreateCustomerDrawer>\` instances**, both bound to the exact same \`open\`/\`onOpenChange\`/\`data\` state — one wired to the header's "+ Add Customer" trigger button, and a second, trigger-less instance further down the tree. Since both render as \`open\` simultaneously, two independent Radix \`Dialog\`/\`Sheet\` instances mount at once, each with its own \`DismissableLayer\`. Verified live: \`document.querySelectorAll('[role="dialog"]')\` returned **2 elements** while the drawer was open. Clicking inside was, from the *other* instance's perspective, a click outside its own tracked DOM subtree, dismissing that instance — and since both share the same \`onOpenChange\` setter, that closes both.

**Fix:** delete the redundant second instance. Also includes \`CreateCustomerDrawer\` now rendering its \`trigger\` prop directly with a plain \`onClick\` instead of Radix's \`SheetTrigger\`/\`asChild\`.

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx eslint\` on both changed files — 0 errors (pre-existing warnings only)
- [x] \`npx vitest run\` — 47 files / 301 tests pass
- [x] Manual end-to-end verification against a live dev server (typing, billing details, portaled Country select) — drawer stayed open throughout, only 1 \`[role="dialog"]\` element exists while open

🤖 Generated with [Claude Code](https://claude.com/claude-code)