### PR TITLE
feat(config): add revenue feature toggle to platform configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,7 @@ VITE_RESTRICTED_ENVS=
 # Tenant feature allowlist (comma-separated tenant IDs or JSON array)
 # Enables gated UI such as the customer org_type metadata filter (parent / child).
 VITE_TENANT_FEATURE_ALLOWLIST=
+# VITE_PLATFORM_CONFIG={"revenue":{"enabled":false},"production":{"enabled":true},"signup":{"enabled":true},"contact_us":{"enabled":true},"onboarding":{"enabled":true},"guides":{"enabled":true},"sidebar_documentation":{"enabled":true},"api_reference":{"enabled":true}}
 
 # Typography — optional JSON: {"primary":"…","fallback":"…"} (see src/config/config.ts). Omitted = Qanelas (src/assets/fonts/qanelas) + system UI.
 # VITE_FONT_CONFIG={"primary":"Qanelas","fallback":"ui-sans-serif, system-ui, sans-serif"}

--- a/src/components/molecules/Sidebar/Sidebar.tsx
+++ b/src/components/molecules/Sidebar/Sidebar.tsx
@@ -9,6 +9,7 @@ import { Settings, Landmark, Layers2, CodeXml, Puzzle, GalleryHorizontalEnd, Hom
 import { cn } from '@/lib/utils';
 import { useLocaleStore } from '@/store/useLocaleStore';
 import { Direction } from '@/config/branding';
+import { config } from '@/config/config';
 
 const AppSidebar: React.FC<React.ComponentProps<typeof Sidebar>> = ({ ...props }) => {
 	const { t } = useTranslation('common');
@@ -89,11 +90,15 @@ const AppSidebar: React.FC<React.ComponentProps<typeof Sidebar>> = ({ ...props }
 					},
 				],
 			},
-			{
-				title: t('sidebar.nav.revenue'),
-				url: RouteNames.revenue,
-				icon: BarChart3,
-			},
+			...(config.platform.revenue.enabled
+				? [
+						{
+							title: t('sidebar.nav.revenue'),
+							url: RouteNames.revenue,
+							icon: BarChart3,
+						},
+					]
+				: []),
 
 			{
 				title: t('sidebar.nav.tools'),

--- a/src/components/organisms/CommandPalette/CommandPalette.tsx
+++ b/src/components/organisms/CommandPalette/CommandPalette.tsx
@@ -5,8 +5,14 @@ import { useNavigate } from 'react-router';
 import { defaultFilter } from 'cmdk';
 import { CommandPaletteDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command-palette';
 
-import { commandPaletteCommands, COMMAND_PALETTE_INITIAL_SUGGESTED_IDS, CommandPaletteGroup } from '@/config/command-palette';
+import {
+	commandPaletteCommands,
+	COMMAND_PALETTE_INITIAL_SUGGESTED_IDS,
+	CommandPaletteCommandId,
+	CommandPaletteGroup,
+} from '@/config/command-palette';
 import { isIntercomMessengerAvailable } from '@/config/intercom';
+import { config } from '@/config/config';
 import {
 	dispatchCommandPaletteAction,
 	getCommandPaletteActionEventName,
@@ -68,6 +74,9 @@ const CommandPalette = () => {
 		return commandPaletteCommands.filter((cmd) => {
 			if (cmd.actionId && isCommandPaletteActionDevOnly(cmd.actionId)) return isDevelopment;
 			if (cmd.actionId === CommandPaletteActionId.OpenIntercom && !isIntercomMessengerAvailable()) {
+				return false;
+			}
+			if (cmd.id === CommandPaletteCommandId.navToolsRevenue && !config.platform.revenue.enabled) {
 				return false;
 			}
 			return true;

--- a/src/config/config.brand.test.ts
+++ b/src/config/config.brand.test.ts
@@ -193,6 +193,7 @@ describe('config object', () => {
 		expect(typeof config.platform.contact_us.enabled).toBe('boolean');
 		expect(typeof config.platform.production.enabled).toBe('boolean');
 		expect(typeof config.platform.signup.enabled).toBe('boolean');
+		expect(typeof config.platform.revenue.enabled).toBe('boolean');
 	});
 });
 
@@ -207,17 +208,19 @@ describe('parsePlatformConfig', () => {
 		expect(result.contact_us.enabled).toBe(false);
 		expect(result.production.enabled).toBe(false);
 		expect(result.signup.enabled).toBe(true);
+		expect(result.revenue.enabled).toBe(true);
 	});
 
 	it('applies per-feature overrides from VITE_PLATFORM_CONFIG JSON', async () => {
 		const { parsePlatformConfig } = await import('./config');
 		const result = parsePlatformConfig(
-			'{"api_reference":{"enabled":false},"sidebar_documentation":{"enabled":false},"guides":{"enabled":false},"onboarding":{"enabled":false}}',
+			'{"api_reference":{"enabled":false},"sidebar_documentation":{"enabled":false},"guides":{"enabled":false},"onboarding":{"enabled":false},"revenue":{"enabled":false}}',
 		);
 		expect(result.api_reference.enabled).toBe(false);
 		expect(result.sidebar_documentation.enabled).toBe(false);
 		expect(result.guides.enabled).toBe(false);
 		expect(result.onboarding.enabled).toBe(false);
+		expect(result.revenue.enabled).toBe(false);
 	});
 
 	it('leaves unspecified keys enabled when only some features are set in env', async () => {
@@ -227,6 +230,7 @@ describe('parsePlatformConfig', () => {
 		expect(result.sidebar_documentation.enabled).toBe(true);
 		expect(result.guides.enabled).toBe(false);
 		expect(result.onboarding.enabled).toBe(true);
+		expect(result.revenue.enabled).toBe(true);
 	});
 
 	it('falls back to defaults when JSON is invalid', async () => {
@@ -236,6 +240,7 @@ describe('parsePlatformConfig', () => {
 		expect(result.onboarding.enabled).toBe(true);
 		expect(result.contact_us.enabled).toBe(false);
 		expect(result.signup.enabled).toBe(true);
+		expect(result.revenue.enabled).toBe(true);
 	});
 
 	it('enables contact_us from boolean or enabled object', async () => {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -100,6 +100,9 @@ export interface PlatformConfig {
 	signup: {
 		enabled: boolean;
 	};
+	revenue: {
+		enabled: boolean;
+	};
 }
 
 const PLATFORM_FEATURE_DEFAULTS = {
@@ -109,6 +112,7 @@ const PLATFORM_FEATURE_DEFAULTS = {
 	onboarding: true,
 	production: false,
 	signup: true,
+	revenue: true,
 } as const;
 
 type PlatformFeatureKey = keyof typeof PLATFORM_FEATURE_DEFAULTS;
@@ -121,6 +125,7 @@ interface PlatformConfigJson {
 	contact_us?: boolean | { enabled?: boolean };
 	production?: { enabled?: boolean };
 	signup?: { enabled?: boolean };
+	revenue?: { enabled?: boolean };
 }
 
 function parsePlatformFeatureEnabled(parsed: PlatformConfigJson | undefined, key: PlatformFeatureKey): boolean {
@@ -136,7 +141,7 @@ function parseContactUsEnabled(parsed: PlatformConfigJson | undefined): boolean 
 	return false;
 }
 
-/** Parse `VITE_PLATFORM_CONFIG` JSON. Keys: api_reference, sidebar_documentation, guides, onboarding, contact_us, production, signup. Omitted keys default to `enabled: true` (contact_us and production default to false). */
+/** Parse `VITE_PLATFORM_CONFIG` JSON. Keys: api_reference, sidebar_documentation, guides, onboarding, contact_us, production, signup, revenue. Omitted keys default to `enabled: true` (contact_us and production default to false). */
 export function parsePlatformConfig(rawPlatformConfig?: string): PlatformConfig {
 	let parsed: PlatformConfigJson | undefined;
 	const raw = rawPlatformConfig?.trim();
@@ -157,6 +162,7 @@ export function parsePlatformConfig(rawPlatformConfig?: string): PlatformConfig 
 		contact_us: { enabled: parseContactUsEnabled(parsed) },
 		production: { enabled: parsePlatformFeatureEnabled(parsed, 'production') },
 		signup: { enabled: parsePlatformFeatureEnabled(parsed, 'signup') },
+		revenue: { enabled: parsePlatformFeatureEnabled(parsed, 'revenue') },
 	};
 }
 

--- a/src/core/routes/Routes.tsx
+++ b/src/core/routes/Routes.tsx
@@ -5,6 +5,7 @@ import { useUser } from '@/hooks/UserContext';
 import { TenantMetadataKey } from '@/models/Tenant';
 import { Suspense } from 'react';
 import { Loader } from '@/components/atoms';
+import { config } from '@/config/config';
 import {
 	// Auth pages
 	Auth,
@@ -510,10 +511,14 @@ export const MainRouter: any = createBrowserRouter([
 				path: RouteNames.pricing,
 				element: <PricingPage />,
 			},
-			{
-				path: RouteNames.revenue,
-				element: <Revenue />,
-			},
+			...(config.platform.revenue.enabled
+				? [
+						{
+							path: RouteNames.revenue,
+							element: <Revenue />,
+						},
+					]
+				: []),
 			{
 				path: RouteNames.developers,
 				children: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable Revenue platform feature.
  * Revenue navigation, command palette entries, and routes now appear only when enabled.
  * Added configuration documentation and support for overriding the Revenue setting.

* **Bug Fixes**
  * Prevented access to Revenue pages when the feature is disabled.

* **Tests**
  * Added coverage for default, customized, partial, and invalid configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->