### PR TITLE
fix(features): add explicit remove option for custom expression field

### DIFF
--- a/src/pages/product-catalog/features/AddFeature.tsx
+++ b/src/pages/product-catalog/features/AddFeature.tsx
@@ -912,7 +912,9 @@ const AggregationSection = ({
 				{showExpressionInput && (
 					<div className='space-y-1'>
 						<div className='flex items-center justify-between gap-2'>
-							<label className='text-sm font-medium text-gray-700'>{t('catalog:features.form.customExpression')}</label>
+							<label htmlFor='feature-custom-expression' className='text-sm font-medium text-gray-700'>
+								{t('catalog:features.form.customExpression')}
+							</label>
 							<button
 								type='button'
 								onClick={toggleCustomExpression}
@@ -921,6 +923,7 @@ const AggregationSection = ({
 							</button>
 						</div>
 						<Input
+							id='feature-custom-expression'
 							value={meter?.aggregation?.expression || ''}
 							onChange={handleAggregationExpressionChange}
 							placeholder={t('catalog:features.form.customExpressionPh')}

--- a/src/pages/product-catalog/features/AddFeature.tsx
+++ b/src/pages/product-catalog/features/AddFeature.tsx
@@ -910,14 +910,24 @@ const AggregationSection = ({
 				)}
 
 				{showExpressionInput && (
-					<Input
-						value={meter?.aggregation?.expression || ''}
-						onChange={handleAggregationExpressionChange}
-						label={t('catalog:features.form.customExpression')}
-						placeholder={t('catalog:features.form.customExpressionPh')}
-						description={<span className='whitespace-pre-line'>{t('catalog:features.form.customExpressionHelp')}</span>}
-						error={meterErrors.aggregation_expression}
-					/>
+					<div className='space-y-1'>
+						<div className='flex items-center justify-between gap-2'>
+							<label className='text-sm font-medium text-gray-700'>{t('catalog:features.form.customExpression')}</label>
+							<button
+								type='button'
+								onClick={toggleCustomExpression}
+								className='text-sm text-gray-500 hover:text-gray-800 underline-offset-2 hover:underline'>
+								{t('common:form.remove')}
+							</button>
+						</div>
+						<Input
+							value={meter?.aggregation?.expression || ''}
+							onChange={handleAggregationExpressionChange}
+							placeholder={t('catalog:features.form.customExpressionPh')}
+							description={<span className='whitespace-pre-line'>{t('catalog:features.form.customExpressionHelp')}</span>}
+							error={meterErrors.aggregation_expression}
+						/>
+					</div>
 				)}
 
 				{showMultiplierInput && (


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a labeled custom aggregation expression input with a remove option.
  * Users can switch back to selecting an aggregation field after removing the custom expression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add a clear way to remove custom aggregation expressions

### What Changed
- Custom aggregation expressions now show a labeled Remove action
- Removing the expression lets users return to selecting an aggregation field
- The custom expression label is correctly connected to its input for easier access

### Impact
`✅ Easier aggregation changes`
`✅ Clearer custom expression controls`
`✅ Improved form accessibility`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
