### PR TITLE
fix(tax): stop margin from popping in/out while filling the create ta…

### DIFF
--- a/src/components/atoms/Sheet/Sheet.tsx
+++ b/src/components/atoms/Sheet/Sheet.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useRef, useEffect, useState, useCallback, cloneElement, isValidElement } from 'react';
+import { FC, ReactNode, useRef, useEffect, useCallback } from 'react';
 import { Sheet as ShadcnSheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 import { hasRegisteredOpenModals, hasOpenOverlayInDom, registerModalOpen } from '@/lib/modal-scroll-lock';
@@ -31,7 +31,6 @@ const Sheet: FC<Props> = ({ children, trigger, description, title, isOpen, onOpe
 	const contentRef = useRef<HTMLDivElement>(null);
 	const direction = useLocaleStore((s) => s.direction);
 	const side = direction === Direction.RTL ? 'left' : 'right';
-	const [isScrollable, setIsScrollable] = useState(false);
 
 	const preventPortaledSelectDismiss = useCallback((event: Event) => {
 		if (isPortaledSelectTarget(event.target)) {
@@ -47,31 +46,6 @@ const Sheet: FC<Props> = ({ children, trigger, description, title, isOpen, onOpe
 	const preventFocusOutsideDismiss = useCallback((event: Event) => {
 		event.preventDefault();
 	}, []);
-
-	useEffect(() => {
-		if (isOpen && contentRef.current) {
-			// Check if content is scrollable after a short delay to ensure DOM is fully rendered
-			const checkScrollability = () => {
-				if (contentRef.current) {
-					const isScrollableContent = contentRef.current.scrollHeight > contentRef.current.clientHeight;
-					setIsScrollable(isScrollableContent);
-				}
-			};
-
-			// Check immediately and after a short delay
-			checkScrollability();
-			const timeoutId = setTimeout(checkScrollability, 100);
-			const resizeObserver = new ResizeObserver(checkScrollability);
-			resizeObserver.observe(contentRef.current);
-
-			return () => {
-				clearTimeout(timeoutId);
-				resizeObserver.disconnect();
-			};
-		} else {
-			setIsScrollable(false);
-		}
-	}, [isOpen, children]);
 
 	// Register while open so the safety net below (and every other Dialog/Sheet instance) knows
 	// not to clear the shared body lock while this one is still legitimately open.
@@ -97,74 +71,6 @@ const Sheet: FC<Props> = ({ children, trigger, description, title, isOpen, onOpe
 		return () => window.clearTimeout(timer);
 	}, [isOpen]);
 
-	// Process children to replace mt-4 with mt-9 if scrollable, or wrap in div with mt-9
-	const processChildren = (node: ReactNode): ReactNode => {
-		if (!isScrollable) {
-			return node;
-		}
-
-		if (!isValidElement(node)) {
-			return node;
-		}
-
-		const props = node.props as any;
-		if (props?.className) {
-			// Convert className to string to check for mt-4
-			const classNameStr = typeof props.className === 'string' ? props.className : cn(props.className);
-
-			if (classNameStr && classNameStr.includes('mt-4')) {
-				// Replace mt-4 with mt-9, handling both standalone and in class strings
-				const newClassName = cn(props.className).replace(/\bmt-4\b/g, 'mt-9');
-				return cloneElement(node, {
-					...props,
-					className: newClassName,
-				});
-			}
-		}
-
-		// Recursively process children if it's a fragment or has children
-		if (props?.children) {
-			return cloneElement(node, {
-				...props,
-				children: Array.isArray(props.children) ? props.children.map(processChildren) : processChildren(props.children),
-			});
-		}
-
-		return node;
-	};
-
-	// Check if first child has mt-4, if not and scrollable, wrap children in div with mt-9
-	let processedChildren = processChildren(children);
-
-	if (isScrollable) {
-		// Check if we already processed a child with mt-4/mt-9
-		let hasMarginTop = false;
-
-		if (isValidElement(processedChildren)) {
-			const className = (processedChildren.props as any)?.className;
-			if (className) {
-				const classNameStr = typeof className === 'string' ? className : cn(className);
-				hasMarginTop = classNameStr.includes('mt-');
-			}
-		} else if (Array.isArray(processedChildren)) {
-			// Check first child in array
-			const firstChild = processedChildren[0];
-			if (isValidElement(firstChild)) {
-				const props = firstChild.props as any;
-				const className = props?.className;
-				if (className) {
-					const classNameStr = typeof className === 'string' ? className : cn(className);
-					hasMarginTop = classNameStr.includes('mt-');
-				}
-			}
-		}
-
-		// If no margin-top found and scrollable, wrap in div with mt-9
-		if (!hasMarginTop) {
-			processedChildren = <div className='mt-9'>{processedChildren}</div>;
-		}
-	}
-
 	return (
 		<ShadcnSheet open={isOpen} onOpenChange={onOpenChange} modal={false}>
 			{trigger && <SheetTrigger asChild>{trigger}</SheetTrigger>}
@@ -189,7 +95,7 @@ const Sheet: FC<Props> = ({ children, trigger, description, title, isOpen, onOpe
 						{description && <SheetDescription>{description}</SheetDescription>}
 					</SheetHeader>
 				)}
-				{processedChildren}
+				{children}
 			</SheetContent>
 		</ShadcnSheet>
 	);

--- a/src/components/molecules/CouponDrawer/CouponDrawer.tsx
+++ b/src/components/molecules/CouponDrawer/CouponDrawer.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Sheet, Spacer, Textarea, Select, SelectOption, DatePicker } from '@/components/atoms';
+import { Button, Input, Sheet, Textarea, Select, SelectOption, DatePicker } from '@/components/atoms';
 import { Coupon } from '@/models/Coupon';
 import { FC, useEffect, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
@@ -161,24 +161,22 @@ const CouponDrawer: FC<Props> = ({ data, open, onOpenChange, trigger, refetchQue
 			title={isEdit ? t('coupons.drawer.editTitle') : t('coupons.drawer.createTitle')}
 			description={isEdit ? t('coupons.drawer.descriptionEdit') : t('coupons.drawer.descriptionCreate')}
 			trigger={trigger}>
-			<Spacer height={'20px'} />
-			<Input
-				placeholder={t('coupons.drawer.namePlaceholder')}
-				description={t('coupons.drawer.nameHelp')}
-				label={t('coupons.drawer.couponName')}
-				value={formData.name}
-				error={errors.name}
-				onChange={(e) => {
-					setFormData({
-						...formData,
-						name: e,
-					});
-				}}
-			/>
+			<div className='space-y-5 mt-4'>
+				<Input
+					placeholder={t('coupons.drawer.namePlaceholder')}
+					description={t('coupons.drawer.nameHelp')}
+					label={t('coupons.drawer.couponName')}
+					value={formData.name}
+					error={errors.name}
+					onChange={(e) => {
+						setFormData({
+							...formData,
+							name: e,
+						});
+					}}
+				/>
 
-			{!isEdit && (
-				<>
-					<Spacer height={'20px'} />
+				{!isEdit && (
 					<Input
 						id='coupon_code'
 						label={t('coupons.drawer.couponCode')}
@@ -188,104 +186,95 @@ const CouponDrawer: FC<Props> = ({ data, open, onOpenChange, trigger, refetchQue
 						onChange={(e) => setFormData({ ...formData, coupon_code: e })}
 						description={t('coupons.drawer.couponCodeHelp')}
 					/>
-				</>
-			)}
+				)}
 
-			<Spacer height={'20px'} />
-			<Select
-				label={t('coupons.drawer.couponType')}
-				placeholder={t('coupons.drawer.selectCouponType')}
-				options={typeOptions}
-				value={formData.type}
-				onChange={(e) => setFormData({ ...formData, type: e as COUPON_TYPE })}
-				error={errors.type}
-				description={t('coupons.drawer.couponTypeHelp')}
-			/>
+				<Select
+					label={t('coupons.drawer.couponType')}
+					placeholder={t('coupons.drawer.selectCouponType')}
+					options={typeOptions}
+					value={formData.type}
+					onChange={(e) => setFormData({ ...formData, type: e as COUPON_TYPE })}
+					error={errors.type}
+					description={t('coupons.drawer.couponTypeHelp')}
+				/>
 
-			<Spacer height={'20px'} />
-			{formData.type === COUPON_TYPE.FIXED ? (
-				<div className='grid grid-cols-2 gap-4'>
+				{formData.type === COUPON_TYPE.FIXED ? (
+					<div className='grid grid-cols-2 gap-4'>
+						<Input
+							label={t('coupons.drawer.amountOff')}
+							placeholder={t('coupons.drawer.amountPlaceholder')}
+							type='number'
+							step='0.01'
+							value={formData.amount_off}
+							error={errors.amount_off}
+							onChange={(e) => setFormData({ ...formData, amount_off: e })}
+							description={t('coupons.drawer.amountHelp')}
+						/>
+						<Select
+							label={t('coupons.drawer.currency')}
+							placeholder={t('coupons.drawer.selectCurrency')}
+							options={currencyOptions}
+							value={formData.currency}
+							onChange={(e) => setFormData({ ...formData, currency: e })}
+							error={errors.currency}
+						/>
+					</div>
+				) : (
 					<Input
-						label={t('coupons.drawer.amountOff')}
-						placeholder={t('coupons.drawer.amountPlaceholder')}
+						label={t('coupons.drawer.percentageOff')}
+						placeholder={t('coupons.drawer.percentagePlaceholder')}
 						type='number'
 						step='0.01'
-						value={formData.amount_off}
-						error={errors.amount_off}
-						onChange={(e) => setFormData({ ...formData, amount_off: e })}
-						description={t('coupons.drawer.amountHelp')}
+						max='100'
+						value={formData.percentage_off}
+						error={errors.percentage_off}
+						onChange={(e) => setFormData({ ...formData, percentage_off: e })}
+						description={t('coupons.drawer.percentageHelp')}
 					/>
-					<Select
-						label={t('coupons.drawer.currency')}
-						placeholder={t('coupons.drawer.selectCurrency')}
-						options={currencyOptions}
-						value={formData.currency}
-						onChange={(e) => setFormData({ ...formData, currency: e })}
-						error={errors.currency}
+				)}
+
+				<Select
+					label={t('coupons.drawer.cadence')}
+					placeholder={t('coupons.drawer.selectCadence')}
+					options={cadenceOptions}
+					value={formData.cadence}
+					onChange={(e) => setFormData({ ...formData, cadence: e as COUPON_CADENCE })}
+					error={errors.cadence}
+					description={t('coupons.drawer.cadenceHelp')}
+				/>
+
+				<div>
+					<DatePicker
+						label={t('coupons.drawer.redeemAfter')}
+						date={formData.redeem_after ? new Date(formData.redeem_after) : undefined}
+						setDate={(date) => setFormData({ ...formData, redeem_after: date?.toISOString() })}
+						placeholder={t('coupons.drawer.selectStartDate')}
 					/>
+					<p className='text-xs text-muted-foreground mt-1'>{t('coupons.drawer.redeemAfterHelp')}</p>
+					{errors.redeem_after && <p className='text-xs text-danger-bright mt-1'>{errors.redeem_after}</p>}
 				</div>
-			) : (
+
+				<div>
+					<DatePicker
+						label={t('coupons.drawer.redeemBefore')}
+						date={formData.redeem_before ? new Date(formData.redeem_before) : undefined}
+						setDate={(date) => setFormData({ ...formData, redeem_before: date?.toISOString() })}
+						placeholder={t('coupons.drawer.selectExpiryDate')}
+					/>
+					<p className='text-xs text-muted-foreground mt-1'>{t('coupons.drawer.redeemBeforeHelp')}</p>
+					{errors.redeem_before && <p className='text-xs text-danger-bright mt-1'>{errors.redeem_before}</p>}
+				</div>
+
 				<Input
-					label={t('coupons.drawer.percentageOff')}
-					placeholder={t('coupons.drawer.percentagePlaceholder')}
+					label={t('coupons.drawer.maxRedemptions')}
+					placeholder={t('coupons.drawer.maxRedemptionsPlaceholder')}
 					type='number'
-					step='0.01'
-					max='100'
-					value={formData.percentage_off}
-					error={errors.percentage_off}
-					onChange={(e) => setFormData({ ...formData, percentage_off: e })}
-					description={t('coupons.drawer.percentageHelp')}
+					value={formData.max_redemptions?.toString()}
+					onChange={(e) => setFormData({ ...formData, max_redemptions: e ? parseInt(e) : undefined })}
+					description={t('coupons.drawer.maxRedemptionsHelp')}
 				/>
-			)}
 
-			<Spacer height={'20px'} />
-			<Select
-				label={t('coupons.drawer.cadence')}
-				placeholder={t('coupons.drawer.selectCadence')}
-				options={cadenceOptions}
-				value={formData.cadence}
-				onChange={(e) => setFormData({ ...formData, cadence: e as COUPON_CADENCE })}
-				error={errors.cadence}
-				description={t('coupons.drawer.cadenceHelp')}
-			/>
-
-			<Spacer height={'20px'} />
-			<div>
-				<DatePicker
-					label={t('coupons.drawer.redeemAfter')}
-					date={formData.redeem_after ? new Date(formData.redeem_after) : undefined}
-					setDate={(date) => setFormData({ ...formData, redeem_after: date?.toISOString() })}
-					placeholder={t('coupons.drawer.selectStartDate')}
-				/>
-				<p className='text-xs text-muted-foreground mt-1'>{t('coupons.drawer.redeemAfterHelp')}</p>
-				{errors.redeem_after && <p className='text-xs text-danger-bright mt-1'>{errors.redeem_after}</p>}
-			</div>
-
-			<Spacer height={'20px'} />
-			<div>
-				<DatePicker
-					label={t('coupons.drawer.redeemBefore')}
-					date={formData.redeem_before ? new Date(formData.redeem_before) : undefined}
-					setDate={(date) => setFormData({ ...formData, redeem_before: date?.toISOString() })}
-					placeholder={t('coupons.drawer.selectExpiryDate')}
-				/>
-				<p className='text-xs text-muted-foreground mt-1'>{t('coupons.drawer.redeemBeforeHelp')}</p>
-				{errors.redeem_before && <p className='text-xs text-danger-bright mt-1'>{errors.redeem_before}</p>}
-			</div>
-
-			<Spacer height={'20px'} />
-			<Input
-				label={t('coupons.drawer.maxRedemptions')}
-				placeholder={t('coupons.drawer.maxRedemptionsPlaceholder')}
-				type='number'
-				value={formData.max_redemptions?.toString()}
-				onChange={(e) => setFormData({ ...formData, max_redemptions: e ? parseInt(e) : undefined })}
-				description={t('coupons.drawer.maxRedemptionsHelp')}
-			/>
-
-			{formData.cadence === COUPON_CADENCE.REPEATED && (
-				<>
-					<Spacer height={'20px'} />
+				{formData.cadence === COUPON_CADENCE.REPEATED && (
 					<Input
 						label={t('coupons.drawer.durationInPeriods')}
 						placeholder={t('coupons.drawer.durationPlaceholder')}
@@ -295,33 +284,33 @@ const CouponDrawer: FC<Props> = ({ data, open, onOpenChange, trigger, refetchQue
 						error={errors.duration_in_periods}
 						description={t('coupons.drawer.durationHelp')}
 					/>
-				</>
-			)}
+				)}
 
-			<Spacer height={'20px'} />
-			<Textarea
-				value={formData.metadata ? JSON.stringify(formData.metadata, null, 2) : ''}
-				onChange={(e) => {
-					try {
-						const metadata = e ? JSON.parse(e) : undefined;
-						setFormData({ ...formData, metadata });
-					} catch {
-						setErrors({ ...errors, metadata: t('coupons.drawer.invalidMetadata') });
+				<Textarea
+					value={formData.metadata ? JSON.stringify(formData.metadata, null, 2) : ''}
+					onChange={(e) => {
+						try {
+							const metadata = e ? JSON.parse(e) : undefined;
+							setFormData({ ...formData, metadata });
+						} catch {
+							setErrors({ ...errors, metadata: t('coupons.drawer.invalidMetadata') });
+						}
+					}}
+					className='min-h-[100px]'
+					placeholder={t('shared.metadataPlaceholder')}
+					label={t('shared.metadataOptional')}
+					description={t('shared.metadataJsonAdditional')}
+				/>
+
+				<Button
+					isLoading={isPending}
+					disabled={
+						isPending || !formData.name?.trim() || !formData.type || !formData.cadence || (!isEdit && !formData.coupon_code?.trim())
 					}
-				}}
-				className='min-h-[100px]'
-				placeholder={t('shared.metadataPlaceholder')}
-				label={t('shared.metadataOptional')}
-				description={t('shared.metadataJsonAdditional')}
-			/>
-
-			<Spacer height={'20px'} />
-			<Button
-				isLoading={isPending}
-				disabled={isPending || !formData.name?.trim() || !formData.type || !formData.cadence || (!isEdit && !formData.coupon_code?.trim())}
-				onClick={handleSave}>
-				{isEdit ? t('common:actions.save') : t('common:actions.create')}
-			</Button>
+					onClick={handleSave}>
+					{isEdit ? t('common:actions.save') : t('common:actions.create')}
+				</Button>
+			</div>
 		</Sheet>
 	);
 };

--- a/src/components/molecules/TaxDrawer/TaxDrawer.tsx
+++ b/src/components/molecules/TaxDrawer/TaxDrawer.tsx
@@ -196,7 +196,10 @@ const TaxDrawer: FC<Props> = ({ data, open, onOpenChange, trigger, refetchQueryK
 						type='number'
 						placeholder={t('taxes.drawer.numericPlaceholder')}
 						value={formData.percentage_value?.toString() || ''}
-						onChange={(e) => setFormData({ ...formData, percentage_value: parseFloat(e) || undefined })}
+						onChange={(e) => {
+							const parsed = parseFloat(e);
+							setFormData({ ...formData, percentage_value: Number.isFinite(parsed) ? parsed : undefined });
+						}}
 						error={errors.percentage_value}
 						description={isEdit ? t('taxes.drawer.percentageHintEdit') : t('taxes.drawer.percentageHintCreate')}
 						suffix={t('taxes.drawer.percentSuffix')}
@@ -208,7 +211,10 @@ const TaxDrawer: FC<Props> = ({ data, open, onOpenChange, trigger, refetchQueryK
 						type='number'
 						placeholder={t('taxes.drawer.numericPlaceholder')}
 						value={formData.fixed_value?.toString() || ''}
-						onChange={(e) => setFormData({ ...formData, fixed_value: parseFloat(e) || undefined })}
+						onChange={(e) => {
+							const parsed = parseFloat(e);
+							setFormData({ ...formData, fixed_value: Number.isFinite(parsed) ? parsed : undefined });
+						}}
 						error={errors.fixed_value}
 						description={isEdit ? t('taxes.drawer.fixedHintEdit') : t('taxes.drawer.fixedHintCreate')}
 						inputPrefix={t('taxes.drawer.fixedAmountPrefix')}

--- a/src/components/molecules/TaxDrawer/TaxDrawer.tsx
+++ b/src/components/molecules/TaxDrawer/TaxDrawer.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Sheet, Spacer, Textarea, Select, SelectOption } from '@/components/atoms';
+import { Button, Input, Sheet, Textarea, Select, SelectOption } from '@/components/atoms';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import TaxApi from '@/api/TaxApi';
@@ -161,82 +161,78 @@ const TaxDrawer: FC<Props> = ({ data, open, onOpenChange, trigger, refetchQueryK
 			title={isEdit ? t('taxes.drawer.titleEdit') : t('taxes.drawer.titleCreate')}
 			description={isEdit ? t('taxes.drawer.descEdit') : t('taxes.drawer.descCreate')}
 			trigger={trigger}>
-			<Spacer height={'20px'} />
-			<Input
-				placeholder={t('taxes.drawer.namePlaceholder')}
-				description={t('taxes.drawer.nameHint')}
-				label={t('taxes.drawer.nameLabel')}
-				value={formData.name}
-				error={errors.name}
-				onChange={handleNameChange}
-			/>
-
-			<Spacer height={'20px'} />
-			<Input
-				label={t('taxes.drawer.codeLabel')}
-				disabled={isEdit}
-				error={errors.code}
-				onChange={(e) => setFormData({ ...formData, code: e })}
-				value={formData.code}
-				placeholder={t('taxes.drawer.codePlaceholder')}
-				description={isEdit ? t('taxes.drawer.codeHintEdit') : t('taxes.drawer.codeHintCreate')}
-			/>
-
-			<Spacer height={'20px'} />
-			<Select
-				label={t('taxes.drawer.taxTypeLabel')}
-				options={taxTypeOptions}
-				value={formData.tax_rate_type}
-				onChange={(e) => setFormData({ ...formData, tax_rate_type: e as TAX_RATE_TYPE })}
-				description={isEdit ? t('taxes.drawer.taxTypeHintEdit') : t('taxes.drawer.taxTypeHintCreate')}
-				disabled={isEdit}
-			/>
-
-			<Spacer height={'20px'} />
-			{formData.tax_rate_type === TAX_RATE_TYPE.PERCENTAGE ? (
+			<div className='space-y-5 mt-4'>
 				<Input
-					label={t('taxes.drawer.percentageLabel')}
-					type='number'
-					placeholder={t('taxes.drawer.numericPlaceholder')}
-					value={formData.percentage_value?.toString() || ''}
-					onChange={(e) => setFormData({ ...formData, percentage_value: parseFloat(e) || undefined })}
-					error={errors.percentage_value}
-					description={isEdit ? t('taxes.drawer.percentageHintEdit') : t('taxes.drawer.percentageHintCreate')}
-					suffix={t('taxes.drawer.percentSuffix')}
+					placeholder={t('taxes.drawer.namePlaceholder')}
+					description={t('taxes.drawer.nameHint')}
+					label={t('taxes.drawer.nameLabel')}
+					value={formData.name}
+					error={errors.name}
+					onChange={handleNameChange}
+				/>
+
+				<Input
+					label={t('taxes.drawer.codeLabel')}
+					disabled={isEdit}
+					error={errors.code}
+					onChange={(e) => setFormData({ ...formData, code: e })}
+					value={formData.code}
+					placeholder={t('taxes.drawer.codePlaceholder')}
+					description={isEdit ? t('taxes.drawer.codeHintEdit') : t('taxes.drawer.codeHintCreate')}
+				/>
+
+				<Select
+					label={t('taxes.drawer.taxTypeLabel')}
+					options={taxTypeOptions}
+					value={formData.tax_rate_type}
+					onChange={(e) => setFormData({ ...formData, tax_rate_type: e as TAX_RATE_TYPE })}
+					description={isEdit ? t('taxes.drawer.taxTypeHintEdit') : t('taxes.drawer.taxTypeHintCreate')}
 					disabled={isEdit}
 				/>
-			) : (
-				<Input
-					label={t('taxes.drawer.fixedAmountLabel')}
-					type='number'
-					placeholder={t('taxes.drawer.numericPlaceholder')}
-					value={formData.fixed_value?.toString() || ''}
-					onChange={(e) => setFormData({ ...formData, fixed_value: parseFloat(e) || undefined })}
-					error={errors.fixed_value}
-					description={isEdit ? t('taxes.drawer.fixedHintEdit') : t('taxes.drawer.fixedHintCreate')}
-					inputPrefix={t('taxes.drawer.fixedAmountPrefix')}
-					disabled={isEdit}
-				/>
-			)}
 
-			<Spacer height={'20px'} />
-			<Textarea
-				value={formData.description}
-				onChange={(e) => {
-					setFormData({ ...formData, description: e });
-				}}
-				className='min-h-[100px]'
-				placeholder={t('taxes.drawer.descriptionPlaceholder')}
-				label={t('taxes.drawer.descriptionLabel')}
-				description={t('taxes.drawer.descriptionHint')}
-			/>
-			<Spacer height={'20px'} />
-			<Button
-				isLoading={isPending}
-				disabled={isPending || !formData.name?.trim() || (!isEdit && !formData.code?.trim())}
-				onClick={handleSave}>
-				{isEdit ? t('taxes.drawer.saveChanges') : t('taxes.drawer.createSubmit')}
-			</Button>
+				{formData.tax_rate_type === TAX_RATE_TYPE.PERCENTAGE ? (
+					<Input
+						label={t('taxes.drawer.percentageLabel')}
+						type='number'
+						placeholder={t('taxes.drawer.numericPlaceholder')}
+						value={formData.percentage_value?.toString() || ''}
+						onChange={(e) => setFormData({ ...formData, percentage_value: parseFloat(e) || undefined })}
+						error={errors.percentage_value}
+						description={isEdit ? t('taxes.drawer.percentageHintEdit') : t('taxes.drawer.percentageHintCreate')}
+						suffix={t('taxes.drawer.percentSuffix')}
+						disabled={isEdit}
+					/>
+				) : (
+					<Input
+						label={t('taxes.drawer.fixedAmountLabel')}
+						type='number'
+						placeholder={t('taxes.drawer.numericPlaceholder')}
+						value={formData.fixed_value?.toString() || ''}
+						onChange={(e) => setFormData({ ...formData, fixed_value: parseFloat(e) || undefined })}
+						error={errors.fixed_value}
+						description={isEdit ? t('taxes.drawer.fixedHintEdit') : t('taxes.drawer.fixedHintCreate')}
+						inputPrefix={t('taxes.drawer.fixedAmountPrefix')}
+						disabled={isEdit}
+					/>
+				)}
+
+				<Textarea
+					value={formData.description}
+					onChange={(e) => {
+						setFormData({ ...formData, description: e });
+					}}
+					className='min-h-[100px]'
+					placeholder={t('taxes.drawer.descriptionPlaceholder')}
+					label={t('taxes.drawer.descriptionLabel')}
+					description={t('taxes.drawer.descriptionHint')}
+				/>
+				<Button
+					isLoading={isPending}
+					disabled={isPending || !formData.name?.trim() || (!isEdit && !formData.code?.trim())}
+					onClick={handleSave}>
+					{isEdit ? t('taxes.drawer.saveChanges') : t('taxes.drawer.createSubmit')}
+				</Button>
+			</div>
 		</Sheet>
 	);
 };


### PR DESCRIPTION
## **User description**
…x rate form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and vertical layout in the tax drawer for a more consistent appearance.
  * Form fields and button behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Keep drawer form spacing stable while entering tax and coupon details

### What Changed
- Tax and coupon drawer fields now use consistent spacing that does not change as fields appear, disappear, or become scrollable
- Tax percentage and fixed-amount inputs handle empty and invalid numeric entries without introducing invalid values
- Drawer content is rendered directly, preventing layout changes caused by automatic scrollability adjustments

### Impact
`✅ No tax form spacing jumps while typing`
`✅ No coupon form spacing jumps when options change`
`✅ Stable drawer layouts during validation and scrolling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
