### PR TITLE
fix(webhooks): make activity graph resilient to a single failed getSt…

### DIFF
--- a/src/utils/webhooks/activityStats.test.ts
+++ b/src/utils/webhooks/activityStats.test.ts
@@ -40,6 +40,27 @@ describe('activityStats', () => {
 		expect(summary.points[0]).toMatchObject({ successful: 2, failed: 4 });
 	});
 
+	it('treats a failed getStats call as zero instead of failing the whole summary', async () => {
+		const getStats = vi.fn().mockImplementation((_appId: string, endpointId: string) => {
+			if (endpointId === 'ep_flaky') return Promise.reject(new Error('rate limited'));
+			return Promise.resolve({ success: 1, fail: 2, pending: 0, sending: 0, canceled: 0 });
+		});
+		const svix = { endpoint: { getStats } } as never;
+
+		const summary = await fetchWebhookActivity({
+			svix,
+			appId: 'app_1',
+			endpointIds: ['ep_flaky', 'ep_2'],
+			now: new Date('2026-07-26T18:00:00.000Z'),
+		});
+
+		// ep_flaky rejects every window; ep_2 still contributes its 6 hours of data.
+		expect(summary.successfulAttempts).toBe(6);
+		expect(summary.failedAttempts).toBe(12);
+		expect(summary.points).toHaveLength(6);
+		expect(summary.points[0]).toMatchObject({ successful: 1, failed: 2 });
+	});
+
 	it('returns empty summary when there are no endpoints', async () => {
 		const getStats = vi.fn();
 		const svix = { endpoint: { getStats } } as never;

--- a/src/utils/webhooks/activityStats.ts
+++ b/src/utils/webhooks/activityStats.ts
@@ -58,9 +58,12 @@ export async function fetchWebhookActivity(params: {
 	const windows = buildHourlyWindows(now, HOURS);
 	const points: ActivityPoint[] = await Promise.all(
 		windows.map(async (window) => {
-			const stats = await Promise.all(
+			const results = await Promise.allSettled(
 				endpointIds.map((endpointId) => svix.endpoint.getStats(appId, endpointId, { since: window.start, until: window.end })),
 			);
+			// A single endpoint/window failing (transient error, rate limit, etc.) shouldn't blank
+			// out the whole activity view — treat it as no data for that endpoint/window instead.
+			const stats = results.map((result) => (result.status === 'fulfilled' ? result.value : { success: 0, fail: 0 }));
 			const { successful, failed } = aggregateEndpointStats(stats);
 			return { timestamp: window.label, successful, failed };
 		}),


### PR DESCRIPTION
## **User description**
…ats call


___

## **CodeAnt-AI Description**
Keep webhook activity graphs usable when an endpoint stats request fails

### What Changed
- A failed stats request for one endpoint or time window is treated as zero data instead of failing the entire activity summary
- Activity from other endpoints and time windows continues to appear in the graph
- Added coverage for rate-limited or otherwise failed endpoint requests

### Impact
`✅ Fewer blank webhook activity graphs`
`✅ Partial activity data remains visible during endpoint failures`
`✅ Clearer resilience to transient stats errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook activity summaries now continue loading when individual endpoint statistics fail.
  * Failed statistics requests are recorded as zero, while successful endpoint data remains included.

* **Tests**
  * Added coverage confirming partial failures are handled correctly during activity aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->