### PR TITLE
fix(cost-sheets): correct search bar icon spacing and align height with filter/sort buttons

### DIFF
--- a/src/pages/product-catalog/cost-sheets/CostSheetDetails.tsx
+++ b/src/pages/product-catalog/cost-sheets/CostSheetDetails.tsx
@@ -346,14 +346,14 @@ const CostSheetDetails = () => {
 						/>
 
 						<div className='mt-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between'>
-							<div className='relative w-full lg:max-w-sm'>
-								<Search className='pointer-events-none absolute start-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground' />
+							<div className='w-full lg:max-w-sm'>
 								<Input
 									type='search'
+									size='sm'
 									placeholder={t('catalog:costSheets.details.searchCharges')}
 									value={searchTerm}
 									onChange={handleSearch}
-									className='ps-9'
+									inputPrefix={<Search className='h-4 w-4 text-muted-foreground' />}
 								/>
 							</div>
 							<QueryBuilder


### PR DESCRIPTION
## **User description**
## Summary
- Search icon had a double-applied left-padding bug via the shared `Input` atom's `className` handling, producing an oversized icon-to-text gap. Switched to `Input`'s existing `inputPrefix` prop (the established pattern used elsewhere in the codebase) instead.
- Search input defaulted to `size='default'` (40px tall) while the adjacent Filter/Sort buttons are 32px (`h-8`). Set `size='sm'` to match.

## Test plan
- [x] `npx eslint` clean
- [x] `npx tsc --noEmit` clean
- [ ] Visual check on staging: Cost Sheet Details → Charges search bar


___

## **CodeAnt-AI Description**
Align the charges search field with the surrounding controls

### What Changed
- Removed the extra spacing around the search icon so it sits correctly beside the search text
- Reduced the search field height to match the Filter and Sort buttons

### Impact
`✅ Consistent charges toolbar alignment`
`✅ Clearer search field spacing`
`✅ More compact cost sheet controls`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
