### PR TITLE
fix(wallet): keep alert threshold UI visible and greyed-out instead of popping in on toggle

### DIFF
--- a/src/components/molecules/WalletAlertDialog/WalletAlertDialog.tsx
+++ b/src/components/molecules/WalletAlertDialog/WalletAlertDialog.tsx
@@ -131,27 +131,25 @@ const WalletAlertDialog: React.FC<WalletAlertDialogProps> = ({ open, alertSettin
 					disabled={isSaving}
 				/>
 
-				{localAlertSettings.alert_enabled && (
-					<div className='space-y-4'>
-						{ALERT_LEVELS.map((level) => (
-							<WalletAlertThresholdCard
-								key={level}
-								threshold={localAlertSettings[level]}
-								labels={getLevelLabels(level)}
-								conditionDisabled={isWalletAlertConditionDisabled(level, localAlertSettings)}
-								disabled={isSaving}
-								onAdd={() => setLocalAlertSettings((prev) => addWalletAlertThreshold(prev, level))}
-								onRemove={() => setLocalAlertSettings((prev) => updateWalletAlertThreshold(prev, level, null))}
-								onThresholdChange={(value) =>
-									setLocalAlertSettings((prev) => applyWalletAlertThresholdChange(prev, level, 'threshold', value))
-								}
-								onConditionChange={(value) =>
-									setLocalAlertSettings((prev) => applyWalletAlertThresholdChange(prev, level, 'condition', value))
-								}
-							/>
-						))}
-					</div>
-				)}
+				<div className='space-y-4'>
+					{ALERT_LEVELS.map((level) => (
+						<WalletAlertThresholdCard
+							key={level}
+							threshold={localAlertSettings[level]}
+							labels={getLevelLabels(level)}
+							conditionDisabled={isWalletAlertConditionDisabled(level, localAlertSettings)}
+							disabled={isSaving || !localAlertSettings.alert_enabled}
+							onAdd={() => setLocalAlertSettings((prev) => addWalletAlertThreshold(prev, level))}
+							onRemove={() => setLocalAlertSettings((prev) => updateWalletAlertThreshold(prev, level, null))}
+							onThresholdChange={(value) =>
+								setLocalAlertSettings((prev) => applyWalletAlertThresholdChange(prev, level, 'threshold', value))
+							}
+							onConditionChange={(value) =>
+								setLocalAlertSettings((prev) => applyWalletAlertThresholdChange(prev, level, 'condition', value))
+							}
+						/>
+					))}
+				</div>
 
 				<div className='mt-6 flex justify-end gap-2'>
 					<Button variant='outline' onClick={handleClose} disabled={isSaving}>

--- a/src/pages/settings/alerts/WalletAlertSettings.tsx
+++ b/src/pages/settings/alerts/WalletAlertSettings.tsx
@@ -69,33 +69,33 @@ const WalletAlertSettingsSection = () => {
 						<Switch
 							checked={draft.alert_enabled ?? false}
 							onCheckedChange={(enabled) => setDraft((prev) => ({ ...prev, alert_enabled: enabled }))}
-							disabled={updateSettings.isPending}
+							disabled={isLoading || updateSettings.isPending}
 							aria-label={alertsTitle}
 						/>
 					}
 				/>
 			</div>
 			{isLoading ? (
-				<Loader />
+				<div className='flex min-h-[200px] items-center justify-center'>
+					<Loader />
+				</div>
 			) : (
 				<div className='space-y-6 px-6 pb-6 pt-6'>
-					{draft.alert_enabled && (
-						<div className='space-y-4'>
-							{ALERT_LEVELS.map((level) => (
-								<WalletAlertThresholdCard
-									key={level}
-									threshold={draft[level]}
-									labels={getLevelLabels(level)}
-									conditionDisabled={isWalletAlertConditionDisabled(level, draft)}
-									disabled={isDisabled}
-									onAdd={() => setDraft((prev) => addWalletAlertThreshold(prev, level))}
-									onRemove={() => setDraft((prev) => updateWalletAlertThreshold(prev, level, null))}
-									onThresholdChange={(value) => setDraft((prev) => updateWalletAlertThreshold(prev, level, { threshold: value }))}
-									onConditionChange={(value) => setDraft((prev) => updateWalletAlertThreshold(prev, level, { condition: value }))}
-								/>
-							))}
-						</div>
-					)}
+					<div className='space-y-4'>
+						{ALERT_LEVELS.map((level) => (
+							<WalletAlertThresholdCard
+								key={level}
+								threshold={draft[level]}
+								labels={getLevelLabels(level)}
+								conditionDisabled={isWalletAlertConditionDisabled(level, draft)}
+								disabled={isDisabled}
+								onAdd={() => setDraft((prev) => addWalletAlertThreshold(prev, level))}
+								onRemove={() => setDraft((prev) => updateWalletAlertThreshold(prev, level, null))}
+								onThresholdChange={(value) => setDraft((prev) => updateWalletAlertThreshold(prev, level, { threshold: value }))}
+								onConditionChange={(value) => setDraft((prev) => updateWalletAlertThreshold(prev, level, { condition: value }))}
+							/>
+						))}
+					</div>
 					<div className='flex justify-end'>
 						<Button onClick={handleSave} isLoading={updateSettings.isPending} disabled={updateSettings.isPending}>
 							{t('alerts.walletAlerts.saveChanges')}


### PR DESCRIPTION
## **User description**
## Summary
- `WalletAlertThresholdCard` already supported a greyed-out, disabled-but-visible rendering mode (opacity dimming, all inputs disabled), but the dialog unmounted the entire threshold-cards section whenever the alert toggle was off, so toggling it on made the whole UI pop in out of nowhere.
- Removed the conditional mount; threshold cards are now always rendered and simply disabled (`isSaving || !alert_enabled`) when the alert is off, matching the requested "greyed out, not hidden" flow.

## Test plan
- [x] `npx eslint` clean
- [x] `npx tsc --noEmit` clean
- [ ] Visual check on staging: Wallet → Alert Settings dialog, toggle on/off


___

## **CodeAnt-AI Description**
Keep wallet alert thresholds visible while alerts are disabled

### What Changed
- Wallet alert threshold controls remain visible when wallet alerts are turned off
- Threshold controls appear disabled until alerts are enabled, preventing accidental edits
- Loading and saving states now disable the related controls, with the loading indicator centered in the settings card

### Impact
`✅ No threshold UI pop-in when toggling alerts`
`✅ Clearer disabled alert settings`
`✅ Prevented edits while alerts are disabled or saving`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
