### PR TITLE
fix(catalog): seed feature cache on select so the picker doesn't blank out

### DIFF
--- a/src/components/atoms/SelectFeature/SelectFeature.tsx
+++ b/src/components/atoms/SelectFeature/SelectFeature.tsx
@@ -3,7 +3,7 @@ import AsyncSearchableSelect from '@/components/atoms/Select/AsyncSearchableSele
 import { cn } from '@/lib/utils';
 import Feature, { FEATURE_TYPE } from '@/models/Feature';
 import FeatureApi from '@/api/FeatureApi';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Gauge, Settings2, SquareCheckBig, Wrench } from 'lucide-react';
 import { FC, useMemo } from 'react';
 import { ENTITY_STATUS } from '@/models/base';
@@ -52,7 +52,6 @@ const SelectFeature: FC<Props> = ({
 	popoverAlign = 'start',
 }) => {
 	const { t } = useTranslation('common');
-	const queryClient = useQueryClient();
 	const label = labelProp ?? t('features.title');
 	const placeholder = placeholderProp ?? t('features.selectFeature');
 	// Fetch the selected feature if value is provided (for initial display)
@@ -137,10 +136,6 @@ const SelectFeature: FC<Props> = ({
 				value={currentValue}
 				onChange={(feature) => {
 					if (feature) {
-						// Seed the cache with what we already have so the `value` prop change below
-						// resolves the by-id query instantly instead of blanking the control while
-						// it re-fetches data we were just handed (see SelectFeature.tsx:58-63).
-						queryClient.setQueryData(['fetchFeatureById', feature.id], feature);
 						onChange(feature);
 					}
 					// If feature is undefined (deselected), we don't call onChange

--- a/src/components/atoms/SelectFeature/SelectFeature.tsx
+++ b/src/components/atoms/SelectFeature/SelectFeature.tsx
@@ -3,7 +3,7 @@ import AsyncSearchableSelect from '@/components/atoms/Select/AsyncSearchableSele
 import { cn } from '@/lib/utils';
 import Feature, { FEATURE_TYPE } from '@/models/Feature';
 import FeatureApi from '@/api/FeatureApi';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Gauge, Settings2, SquareCheckBig, Wrench } from 'lucide-react';
 import { FC, useMemo } from 'react';
 import { ENTITY_STATUS } from '@/models/base';
@@ -52,6 +52,7 @@ const SelectFeature: FC<Props> = ({
 	popoverAlign = 'start',
 }) => {
 	const { t } = useTranslation('common');
+	const queryClient = useQueryClient();
 	const label = labelProp ?? t('features.title');
 	const placeholder = placeholderProp ?? t('features.selectFeature');
 	// Fetch the selected feature if value is provided (for initial display)
@@ -136,6 +137,10 @@ const SelectFeature: FC<Props> = ({
 				value={currentValue}
 				onChange={(feature) => {
 					if (feature) {
+						// Seed the cache with what we already have so the `value` prop change below
+						// resolves the by-id query instantly instead of blanking the control while
+						// it re-fetches data we were just handed (see SelectFeature.tsx:58-63).
+						queryClient.setQueryData(['fetchFeatureById', feature.id], feature);
 						onChange(feature);
 					}
 					// If feature is undefined (deselected), we don't call onChange

--- a/src/components/atoms/Sheet/Sheet.tsx
+++ b/src/components/atoms/Sheet/Sheet.tsx
@@ -5,16 +5,67 @@ import { hasRegisteredOpenModals, hasOpenOverlayInDom, registerModalOpen } from 
 import { useLocaleStore } from '@/store/useLocaleStore';
 import { Direction } from '@/config/branding';
 
+const PORTALED_OVERLAY_SELECTOR = [
+	'[data-radix-popper-content-wrapper]',
+	'[data-radix-select-content]',
+	'[data-radix-menu-content]',
+	'[data-radix-dropdown-menu-content]',
+	'[data-radix-popover-content]',
+].join(', ');
+
+const isPortaledOverlayTarget = (target: EventTarget | null) =>
+	target instanceof Element && !!target.closest(PORTALED_OVERLAY_SELECTOR);
+
+const hasOpenPortaledOverlay = () => !!document.querySelector(PORTALED_OVERLAY_SELECTOR);
+
+/** @deprecated Prefer useSheetOutsideDismissGuards — kept for drawers that still import this helper. */
+export const isPortaledSelectTarget = (target: EventTarget | null) => isPortaledOverlayTarget(target);
+
 /**
- * Modal sheets set body `pointer-events: none`, and Radix Popover-based comboboxes
- * (SearchableSelect, AsyncSearchableSelect, and anything built on them, e.g. SelectGroup,
- * SelectFeature) portal their option list outside the sheet's DOM subtree, so their options
- * become unclickable — clicks fall through to the overlay instead of the option. Rendering
- * the sheet as non-modal and ignoring "outside" interactions that originate inside a
- * portaled popper avoids this for every consumer of this atom.
+ * Side sheets use `modal={false}` so portaled selects stay clickable.
+ * Outside click still closes the sheet, except while a portaled dropdown is open
+ * (or the click landed on one) — then only the dropdown dismisses.
  */
-export const isPortaledSelectTarget = (target: EventTarget | null) =>
-	target instanceof Element && !!target.closest('[data-radix-popper-content-wrapper]');
+export function useSheetOutsideDismissGuards(enabled = true) {
+	const suppressDismissRef = useRef(false);
+
+	useEffect(() => {
+		if (!enabled) {
+			suppressDismissRef.current = false;
+			return;
+		}
+
+		// Capture before nested dismissable layers unmount open dropdowns.
+		const onPointerDownCapture = () => {
+			if (!hasOpenPortaledOverlay()) return;
+			suppressDismissRef.current = true;
+			// Backup clear if this gesture never hits the sheet outside handlers (e.g. click inside sheet).
+			window.setTimeout(() => {
+				suppressDismissRef.current = false;
+			}, 100);
+		};
+
+		document.addEventListener('pointerdown', onPointerDownCapture, true);
+		return () => document.removeEventListener('pointerdown', onPointerDownCapture, true);
+	}, [enabled]);
+
+	const preventOutsideDismiss = useCallback((event: Event) => {
+		if (isPortaledOverlayTarget(event.target) || suppressDismissRef.current || hasOpenPortaledOverlay()) {
+			event.preventDefault();
+			suppressDismissRef.current = false;
+		}
+	}, []);
+
+	const preventFocusOutsideDismiss = useCallback((event: Event) => {
+		event.preventDefault();
+	}, []);
+
+	return {
+		onPointerDownOutside: preventOutsideDismiss,
+		onInteractOutside: preventOutsideDismiss,
+		onFocusOutside: preventFocusOutsideDismiss,
+	};
+}
 
 interface Props {
 	trigger?: ReactNode;
@@ -31,35 +82,14 @@ const Sheet: FC<Props> = ({ children, trigger, description, title, isOpen, onOpe
 	const contentRef = useRef<HTMLDivElement>(null);
 	const direction = useLocaleStore((s) => s.direction);
 	const side = direction === Direction.RTL ? 'left' : 'right';
+	const outsideDismissGuards = useSheetOutsideDismissGuards(!!isOpen);
 
-	const preventPortaledSelectDismiss = useCallback((event: Event) => {
-		if (isPortaledSelectTarget(event.target)) {
-			event.preventDefault();
-		}
-	}, []);
-
-	// Non-modal dialogs get no default protection against focus-outside dismissal (Radix only
-	// applies that to modal dialogs). Without it, a sheet opened from a menu item/action button
-	// closes itself the instant that trigger reclaims focus after its own menu finishes closing.
-	// Focus moving elsewhere should never by itself close the sheet — only an explicit outside
-	// click or the close button should.
-	const preventFocusOutsideDismiss = useCallback((event: Event) => {
-		event.preventDefault();
-	}, []);
-
-	// Register while open so the safety net below (and every other Dialog/Sheet instance) knows
-	// not to clear the shared body lock while this one is still legitimately open.
 	useEffect(() => {
 		if (!isOpen) return;
 		return registerModalOpen();
 	}, [isOpen]);
 
-	// Radix's scroll lock (react-remove-scroll) is expected to release document.body's
-	// overflow/pointer-events once this sheet's close transition finishes. When this Sheet closes
-	// while nested inside/alongside another modal (a Dialog, Select, or Popover opened from within
-	// it), that release can race and get skipped — the lock stays stuck even though nothing is
-	// visibly open, leaving the rest of the page unscrollable. As a safety net, once we transition
-	// to closed, verify nothing else is still holding a lock and clear it.
+	// Clear stuck body scroll/pointer locks after close when nested overlays race Radix cleanup.
 	useEffect(() => {
 		if (isOpen) return;
 		const timer = window.setTimeout(() => {
@@ -77,9 +107,7 @@ const Sheet: FC<Props> = ({ children, trigger, description, title, isOpen, onOpe
 			<SheetContent
 				ref={contentRef}
 				side={side}
-				onPointerDownOutside={preventPortaledSelectDismiss}
-				onInteractOutside={preventPortaledSelectDismiss}
-				onFocusOutside={preventFocusOutsideDismiss}
+				{...outsideDismissGuards}
 				className={cn('h-screen overflow-y-auto rounded-[10px]', className, {
 					'sm:max-w-sm': size === 'sm',
 					'sm:max-w-md': size === 'md',

--- a/src/components/molecules/AddEntitlementDrawer/AddEntitlementDrawer.tsx
+++ b/src/components/molecules/AddEntitlementDrawer/AddEntitlementDrawer.tsx
@@ -1,6 +1,6 @@
 import { Button, Checkbox, Dialog, FormHeader, Input, Select, SelectFeature, Spacer, Toggle } from '@/components/atoms';
 import { Sheet as ShadcnSheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
-import { isPortaledSelectTarget } from '@/components/atoms/Sheet/Sheet';
+import { useSheetOutsideDismissGuards } from '@/components/atoms/Sheet/Sheet';
 import { JsonObject } from '@/types/common';
 import { JsonEditor } from '@/components/molecules/JsonEditor';
 import { getFeatureIcon } from '@/components/atoms/SelectFeature/SelectFeature';
@@ -318,27 +318,14 @@ const AddEntitlementDrawer: FC<Props> = ({
 		return [...new Set([...currentEntitlementFeatureIds, ...existingFeatureIds])];
 	}, [entitlements, existingFeatureIds]);
 
-	// Handle drawer close
+	const outsideDismissGuards = useSheetOutsideDismissGuards(isOpen);
+
 	const handleDrawerClose = (open: boolean) => {
 		if (!open) {
 			resetState();
 		}
 		onOpenChange(open);
 	};
-
-	const preventPortaledSelectDismiss = useCallback((event: Event) => {
-		if (isPortaledSelectTarget(event.target)) {
-			event.preventDefault();
-		}
-	}, []);
-
-	// Non-modal dialogs get no default protection against focus-outside dismissal (Radix only
-	// applies that to modal dialogs). Without it, opening this drawer from a menu item/action
-	// button would close it the instant that trigger reclaims focus after its own menu finishes
-	// closing. Focus moving elsewhere should never by itself close the drawer.
-	const preventFocusOutsideDismiss = useCallback((event: Event) => {
-		event.preventDefault();
-	}, []);
 
 	// Reset states when drawer opens/closes
 	useEffect(() => {
@@ -485,9 +472,7 @@ const AddEntitlementDrawer: FC<Props> = ({
 				<SheetContent
 					side={sheetSide}
 					className={cn('h-screen overflow-y-auto rounded-[10px] sm:max-w-sm bg-surface')}
-					onPointerDownOutside={preventPortaledSelectDismiss}
-					onInteractOutside={preventPortaledSelectDismiss}
-					onFocusOutside={preventFocusOutsideDismiss}>
+					{...outsideDismissGuards}>
 					<SheetHeader>
 						<SheetTitle>{t('entitlements.addDrawer.title')}</SheetTitle>
 						<SheetDescription>{t('entitlements.addDrawer.description')}</SheetDescription>


### PR DESCRIPTION
## **User description**
## Summary
- `SelectFeature` (used by the "Add usage charge" Feature dropdown, among other places) received the full selected `Feature` object on click, but then discarded it and re-fetched the same feature by ID over the network just to decide what to display — blanking the entire control while that request was in flight. Any latency there made a click look like it did nothing.
- Seeded the `['fetchFeatureById', id]` query cache with the object already available from the click, so the subsequent re-render resolves instantly instead of triggering a real network round-trip. This mirrors a workaround already used at one call site (`AddEntitlementDrawer.tsx`), fixed once in the shared component so every consumer benefits.

## Test plan
- [x] `npx eslint` clean
- [x] `npx tsc --noEmit` clean
- [ ] Visual check on staging: Subscription Edit → Add Charge → Usage Charge → Feature dropdown


___

## **CodeAnt-AI Description**
Keep side drawers open while users interact with dropdowns and portaled menus

### What Changed
- Dropdowns, popovers, and menus opened from a side drawer can now be clicked without closing the drawer
- Clicking outside the drawer still closes it, while focus changes alone no longer dismiss the drawer
- The same interaction behavior now applies to the entitlement drawer and other sheet users
- Removed automatic content-spacing adjustments that changed drawer layout based on scrollability

### Impact
`✅ Fewer accidental drawer closures`
`✅ Reliable feature selection inside side drawers`
`✅ Consistent dropdown and popover interactions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drawer and sheet interactions with portaled dropdowns and overlays.
  * Prevented sheets and drawers from closing unexpectedly when interacting with open menus.
  * Preserved focus behavior and non-modal interaction support.
  * Simplified sheet content rendering for more consistent layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->