### PR TITLE
fix(datepicker): open calendar on selected month, stabilize popover h…

### DIFF
--- a/src/components/atoms/DatePicker/DatePicker.test.tsx
+++ b/src/components/atoms/DatePicker/DatePicker.test.tsx
@@ -84,3 +84,31 @@ describe('DatePicker clear button', () => {
 		expect(screen.queryByRole('grid')).not.toBeInTheDocument();
 	});
 });
+
+describe('DatePicker calendar initial month', () => {
+	it('opens on the selected date’s month/year, not the current month', () => {
+		render(
+			<TestWrapper>
+				<DatePicker date={new Date(2027, 7, 3)} setDate={vi.fn()} />
+			</TestWrapper>,
+		);
+
+		fireEvent.click(screen.getByRole('button'));
+
+		expect(screen.getByText('August 2027')).toBeInTheDocument();
+	});
+
+	it('opens on the current month when no date is selected', () => {
+		render(
+			<TestWrapper>
+				<DatePicker date={undefined} setDate={vi.fn()} />
+			</TestWrapper>,
+		);
+
+		fireEvent.click(screen.getByRole('button'));
+
+		const now = new Date();
+		const expectedCaption = now.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+		expect(screen.getByText(expectedCaption)).toBeInTheDocument();
+	});
+});

--- a/src/components/atoms/DatePicker/DatePicker.tsx
+++ b/src/components/atoms/DatePicker/DatePicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { CalendarIcon, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -88,6 +88,14 @@ const DatePicker = ({
 
 	const displayDate = date ? toCalendarDisplayDate(date, timezone as DateTimezone) : undefined;
 	const displayLabel = date ? formatDateInZone(date, timezone as DateTimezone) : placeholder;
+	// Stable reference so the calendar doesn't recompute "today" (and re-seed react-day-picker's
+	// initial month state) on every render — only when the selected date or timezone actually changes.
+	const dateTime = date?.getTime();
+	const initialCalendarMonth = useMemo(
+		() => (date ? toCalendarDisplayDate(date, timezone as DateTimezone) : new Date()),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[dateTime, timezone],
+	);
 
 	const dateBounds = [...(minDate ? [{ before: minDate }] : []), ...(maxDate ? [{ after: maxDate }] : [])];
 
@@ -129,6 +137,11 @@ const DatePicker = ({
 					mode='single'
 					disabled={disabled || (dateBounds.length ? dateBounds : undefined)}
 					selected={displayDate}
+					defaultMonth={initialCalendarMonth}
+					// Keeps every month at a constant 6-row height so the popover doesn't reposition
+					// itself (Radix's collision avoidance reacts to height changes) as you navigate
+					// between months of different lengths/day-of-week alignments.
+					fixedWeeks
 					onSelect={handleSelect}
 					autoFocus
 					startMonth={minDate}

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -36,13 +36,16 @@ function Calendar({ className, classNames, showOutsideDays = true, timezone, onT
 					// on the DayPicker's own className) rather than to `month_caption` — pin `top`
 					// explicitly rather than relying on the absolute-positioning "static position"
 					// fallback, which put them on top of the day grid instead of the caption row.
+					// `z-10`: day cells are also `position: relative` (for focus/selection styling) and
+					// sit later in the DOM, so without an explicit stacking order the day grid's top
+					// row paints over part of these buttons, leaving only their outer edge clickable.
 					button_previous: cn(
 						buttonVariants({ variant: 'outline' }),
-						'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute left-1 top-3',
+						'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute left-1 top-3 z-10',
 					),
 					button_next: cn(
 						buttonVariants({ variant: 'outline' }),
-						'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute right-1 top-3',
+						'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute right-1 top-3 z-10',
 					),
 					month_grid: 'w-full border-collapse space-y-1',
 					weekdays: 'flex',


### PR DESCRIPTION
## **User description**
…eight, fix nav button hit-area


___

## **CodeAnt-AI Description**
Open the date picker on the relevant month and keep calendar controls usable

### What Changed
- A selected date now opens the calendar to its month and year instead of the current month
- An unselected date still opens to the current month
- Calendar popovers keep a consistent height while navigating between months
- Previous and next month buttons remain fully clickable
- Added coverage for the initial month behavior

### Impact
`✅ Faster date selection for existing dates`
`✅ Stable calendar popover positioning`
`✅ Fully clickable month navigation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
