### PR TITLE
fix(events): simplify Events Debugger filter UX

### DIFF
--- a/src/components/molecules/QueryBuilder/PropertyFilterPopover.tsx
+++ b/src/components/molecules/QueryBuilder/PropertyFilterPopover.tsx
@@ -425,7 +425,7 @@ const PropertyFilterPopover: React.FC<Props> = ({
 									</SortableOverlay>
 								</Sortable>
 
-								{propertyFilters ? (
+								{propertyFilters && propertyFilters.rows.length > 0 ? (
 									<div className='pt-3 mt-2 border-t border-border flex flex-col gap-1.5'>
 										<h4 className='text-sm font-medium leading-none'>{t('queryBuilder.propertyFiltersHeading')}</h4>
 										<div className='space-y-3'>
@@ -455,9 +455,7 @@ const PropertyFilterPopover: React.FC<Props> = ({
 														variant='ghost'
 														size='icon'
 														className='h-7 w-7 shrink-0 hover:bg-destructive/10 hover:text-destructive'
-														onClick={() =>
-															propertyFilters.setRows((prev) => (prev.length > 1 ? prev.filter((r) => r.id !== row.id) : prev))
-														}
+														onClick={() => propertyFilters.setRows((prev) => prev.filter((r) => r.id !== row.id))}
 														aria-label={t('queryBuilder.removePropertyFilterAria')}>
 														<Trash2 className='h-3.5 w-3.5' />
 													</Button>
@@ -486,7 +484,7 @@ const PropertyFilterPopover: React.FC<Props> = ({
 									size='sm'
 									onClick={() => {
 										onChange([]);
-										if (propertyFilters) propertyFilters.setRows([propertyFilters.createEmpty()]);
+										if (propertyFilters) propertyFilters.setRows([]);
 										onResetCallback?.();
 									}}
 									className='h-9 text-sm px-2.5'>

--- a/src/components/molecules/QueryBuilder/PropertyFilterPopover.tsx
+++ b/src/components/molecules/QueryBuilder/PropertyFilterPopover.tsx
@@ -304,7 +304,7 @@ const PropertyFilterPopover: React.FC<Props> = ({
 				className={cn('w-screen border-border/70 shadow-lg bg-surface-panel', POPOVER_PADDING)}
 				style={{ maxWidth: '600px', minWidth: MIN_POPOVER_WIDTH }}>
 				<div className='flex flex-col gap-1.5'>
-					{value.length === 0 ? (
+					{value.length === 0 && (!propertyFilters || propertyFilters.rows.length === 0) ? (
 						<div className='flex flex-col gap-2 p-2'>
 							<div className='flex justify-between items-start'>
 								<div className='flex flex-col gap-1'>
@@ -324,9 +324,12 @@ const PropertyFilterPopover: React.FC<Props> = ({
 										variant='outline'
 										size='sm'
 										onClick={() => {
-											onChange([]);
-											if (propertyFilters) propertyFilters.setRows([propertyFilters.createEmpty()]);
-											onResetCallback?.();
+											if (onResetCallback) {
+												onResetCallback();
+											} else {
+												onChange([]);
+											}
+											if (propertyFilters) propertyFilters.setRows([]);
 										}}
 										className='h-9 text-sm px-2.5'>
 										{t('queryBuilder.resetFilters')}
@@ -483,9 +486,12 @@ const PropertyFilterPopover: React.FC<Props> = ({
 									variant='outline'
 									size='sm'
 									onClick={() => {
-										onChange([]);
+										if (onResetCallback) {
+											onResetCallback();
+										} else {
+											onChange([]);
+										}
 										if (propertyFilters) propertyFilters.setRows([]);
-										onResetCallback?.();
 									}}
 									className='h-9 text-sm px-2.5'>
 									{t('queryBuilder.resetFilters')}

--- a/src/pages/usage/events/Events.tsx
+++ b/src/pages/usage/events/Events.tsx
@@ -232,17 +232,9 @@ const EventsPage: React.FC = () => {
 		[apiParams, hasMore, loading],
 	);
 
-	const refetchEvents = () => {
-		setEvents([]);
-		setIterLastKey(undefined);
-		setHasMore(true);
-		fetchEvents(undefined);
-	};
-
 	const resetFilters = () => {
 		setFilters(initialFilters);
 		setPropertyFilters([]);
-		refetchEvents();
 	};
 
 	// Reset pagination when filters change

--- a/src/pages/usage/events/Events.tsx
+++ b/src/pages/usage/events/Events.tsx
@@ -7,15 +7,7 @@ import { Event } from '@/models/Event';
 import EventsApi from '@/api/EventsApi';
 import { Skeleton } from '@/components/ui/skeleton';
 import { RefreshCw } from 'lucide-react';
-import {
-	FilterField,
-	FilterFieldType,
-	DEFAULT_OPERATORS_PER_DATA_TYPE,
-	DataType,
-	FilterOperator,
-	SortOption,
-	SortDirection,
-} from '@/types/common/QueryBuilder';
+import { FilterField, FilterFieldType, DataType, FilterOperator, SortOption, SortDirection } from '@/types/common/QueryBuilder';
 import useFilterSorting from '@/hooks/useFilterSorting';
 import usePagination from '@/hooks/usePagination';
 import { TypedBackendFilter } from '@/types/formatters/QueryBuilder';
@@ -95,7 +87,7 @@ const EventsPage: React.FC = () => {
 	const [hasMore, setHasMore] = useState(true);
 	const [loading, setLoading] = useState(false);
 	const [iterLastKey, setIterLastKey] = useState<string | undefined>(undefined);
-	const [propertyFilters, setPropertyFilters] = useState<PropertyFilterRow[]>(() => [createEmptyPropertyFilter()]);
+	const [propertyFilters, setPropertyFilters] = useState<PropertyFilterRow[]>([]);
 	const observer = useRef<IntersectionObserver | null>(null);
 
 	const sortingOptions: SortOption[] = useMemo(
@@ -120,28 +112,28 @@ const EventsPage: React.FC = () => {
 				field: 'event_id',
 				label: t('events.queryBuilder.filters.eventId'),
 				fieldType: FilterFieldType.INPUT,
-				operators: DEFAULT_OPERATORS_PER_DATA_TYPE[DataType.STRING],
+				operators: [FilterOperator.EQUAL],
 				dataType: DataType.STRING,
 			},
 			{
 				field: 'event_name',
 				label: t('events.queryBuilder.filters.eventName'),
 				fieldType: FilterFieldType.INPUT,
-				operators: DEFAULT_OPERATORS_PER_DATA_TYPE[DataType.STRING],
+				operators: [FilterOperator.EQUAL],
 				dataType: DataType.STRING,
 			},
 			{
 				field: 'external_customer_id',
 				label: t('events.queryBuilder.filters.externalCustomerId'),
 				fieldType: FilterFieldType.INPUT,
-				operators: DEFAULT_OPERATORS_PER_DATA_TYPE[DataType.STRING],
+				operators: [FilterOperator.EQUAL],
 				dataType: DataType.STRING,
 			},
 			{
 				field: 'source',
 				label: t('events.queryBuilder.filters.source'),
 				fieldType: FilterFieldType.INPUT,
-				operators: DEFAULT_OPERATORS_PER_DATA_TYPE[DataType.STRING],
+				operators: [FilterOperator.EQUAL],
 				dataType: DataType.STRING,
 			},
 			{
@@ -165,46 +157,11 @@ const EventsPage: React.FC = () => {
 	const initialFilters = useMemo(() => {
 		return [
 			{
-				field: 'event_id',
-				operator: FilterOperator.EQUAL,
-				valueString: '',
-				dataType: DataType.STRING,
-				id: 'initial-event-id',
-			},
-			{
-				field: 'event_name',
-				operator: FilterOperator.EQUAL,
-				valueString: '',
-				dataType: DataType.STRING,
-				id: 'initial-event-name',
-			},
-			{
-				field: 'external_customer_id',
-				operator: FilterOperator.EQUAL,
-				valueString: '',
-				dataType: DataType.STRING,
-				id: 'initial-customer-id',
-			},
-			{
-				field: 'source',
-				operator: FilterOperator.EQUAL,
-				valueString: '',
-				dataType: DataType.STRING,
-				id: 'initial-source',
-			},
-			{
 				field: 'start_time',
 				operator: FilterOperator.AFTER,
 				valueDate: new Date(new Date().setDate(new Date().getDate() - 30)),
 				dataType: DataType.DATE,
 				id: 'initial-start-time',
-			},
-			{
-				field: 'end_time',
-				operator: FilterOperator.BEFORE,
-				valueDate: undefined,
-				dataType: DataType.DATE,
-				id: 'initial-end-time',
 			},
 		];
 	}, []);
@@ -284,7 +241,7 @@ const EventsPage: React.FC = () => {
 
 	const resetFilters = () => {
 		setFilters(initialFilters);
-		setPropertyFilters([createEmptyPropertyFilter()]);
+		setPropertyFilters([]);
 		refetchEvents();
 	};
 

--- a/src/pages/usage/events/Events.tsx
+++ b/src/pages/usage/events/Events.tsx
@@ -89,6 +89,7 @@ const EventsPage: React.FC = () => {
 	const [iterLastKey, setIterLastKey] = useState<string | undefined>(undefined);
 	const [propertyFilters, setPropertyFilters] = useState<PropertyFilterRow[]>([]);
 	const observer = useRef<IntersectionObserver | null>(null);
+	const requestIdRef = useRef(0);
 
 	const sortingOptions: SortOption[] = useMemo(
 		() => [
@@ -206,10 +207,12 @@ const EventsPage: React.FC = () => {
 		return params;
 	}, [sanitizedFilters, propertyFilters]);
 
-	// Fetch events from API
+	// Fetch events from API. `force` bypasses the in-flight guard so a filter/sort
+	// change always supersedes a stale in-flight pagination request instead of being dropped by it.
 	const fetchEvents = useCallback(
-		async (iterLastKey?: string) => {
-			if (!hasMore || loading) return;
+		async (iterLastKey?: string, force = false) => {
+			if (!force && (!hasMore || loading)) return;
+			const requestId = ++requestIdRef.current;
 			setLoading(true);
 			try {
 				const response = await EventsApi.getRawEvents({
@@ -217,6 +220,8 @@ const EventsPage: React.FC = () => {
 					page_size: 10,
 					...apiParams,
 				});
+
+				if (requestIdRef.current !== requestId) return;
 
 				if (response.events) {
 					setEvents((prevEvents) => (iterLastKey ? [...prevEvents, ...response.events] : response.events));
@@ -226,7 +231,7 @@ const EventsPage: React.FC = () => {
 			} catch (error) {
 				logger.error('Error fetching events:', error);
 			} finally {
-				setLoading(false);
+				if (requestIdRef.current === requestId) setLoading(false);
 			}
 		},
 		[apiParams, hasMore, loading],
@@ -247,7 +252,7 @@ const EventsPage: React.FC = () => {
 		setEvents([]);
 		setIterLastKey(undefined);
 		setHasMore(true);
-		fetchEvents(undefined);
+		fetchEvents(undefined, true);
 	}, [apiParams]);
 
 	return (


### PR DESCRIPTION
## **User description**
- Restrict string filter fields (event_id, event_name, external_customer_id, source) to Equals only
- Stop pre-seeding empty filter rows; only start_time (with its 30-day default) shows initially
- Hide the "Property filters" section until a row is actually added


___

## **CodeAnt-AI Description**
Simplify event search filters and property-filter interactions

### What Changed
- Event ID, event name, customer ID, and source filters now support exact matches only
- The Events Debugger opens with only the last 30 days selected; unused text and end-date filters are no longer shown
- Property filters stay hidden until one is added and can be removed completely
- Resetting filters clears all property-filter rows instead of leaving an empty row

### Impact
`✅ Less clutter in the Events Debugger`
`✅ Clearer exact-match event searches`
`✅ Cleaner filter reset behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified event filtering by using the equality operator for text-based fields.
  * Removed unnecessary empty filters from the initial event search state.
  * Resetting filters now clears all property rows, including the final row.
  * Property filter sections are hidden when no rows remain.
  * Event searches now default to a 30-day start-time filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->