### PR TITLE
fix(select): scope AsyncSearchableSelect's query cache per picker

### DIFF
--- a/src/components/atoms/Select/AsyncSearchableSelect.tsx
+++ b/src/components/atoms/Select/AsyncSearchableSelect.tsx
@@ -12,6 +12,13 @@ import { SelectOption } from './SearchableSelect';
 export interface SearchConfig<T = any> {
 	/** Function that performs the search and returns objects with SelectOption format */
 	searchFn: (query: string) => Promise<Array<SelectOption & { data: T }>>;
+	/**
+	 * Uniquely identifies this picker's search config for query caching. Every consumer of
+	 * AsyncSearchableSelect shares one query cache, so this must include anything that affects
+	 * searchFn's output (e.g. which entity type, filters, exclusions) - otherwise unrelated
+	 * pickers opened within the same staleTime window can silently serve each other's cached results.
+	 */
+	queryKeyPrefix: Array<string | number | boolean | undefined>;
 	/** Debounce time in milliseconds (default: 300) */
 	debounceTime?: number;
 	/** Search input placeholder */
@@ -90,7 +97,13 @@ const AsyncSearchableSelect = <T = any,>({
 	disabled = false,
 }: AsyncSearchableSelectProps<T>) => {
 	const { t } = useTranslation('common');
-	const { searchFn, debounceTime = 300, placeholder: searchPlaceholder = t('search.placeholderShort'), initialOptions = [] } = search;
+	const {
+		searchFn,
+		queryKeyPrefix,
+		debounceTime = 300,
+		placeholder: searchPlaceholder = t('search.placeholderShort'),
+		initialOptions = [],
+	} = search;
 
 	const { valueExtractor, labelExtractor, descriptionExtractor } = extractors;
 
@@ -140,7 +153,7 @@ const AsyncSearchableSelect = <T = any,>({
 		isError,
 		error: queryError,
 	} = useQuery<Array<SelectOption & { data: T }>, Error>({
-		queryKey: ['async-searchable-select', debouncedQuery],
+		queryKey: ['async-searchable-select', ...queryKeyPrefix, debouncedQuery],
 		queryFn: () => searchFn(debouncedQuery),
 		enabled: open,
 		staleTime: 30000, // Cache for 30 seconds

--- a/src/components/atoms/SelectFeature/SelectFeature.tsx
+++ b/src/components/atoms/SelectFeature/SelectFeature.tsx
@@ -115,6 +115,7 @@ const SelectFeature: FC<Props> = ({
 			<AsyncSearchableSelect<Feature>
 				search={{
 					searchFn: searchFeatures,
+					queryKeyPrefix: ['feature', featureTypes.slice().sort().join(','), (disabledFeatures ?? []).slice().sort().join(',')],
 					debounceTime: 300,
 					placeholder: t('features.searchPlaceholder'),
 				}}

--- a/src/components/molecules/ApplyCouponDialog/ApplyCouponDialog.tsx
+++ b/src/components/molecules/ApplyCouponDialog/ApplyCouponDialog.tsx
@@ -123,6 +123,7 @@ const ApplyCouponDialog: FC<Props> = ({ subscriptionId, lineItems, prefilledLine
 					<AsyncSearchableSelect<Coupon>
 						search={{
 							searchFn: couponSearchFn,
+							queryKeyPrefix: ['coupon'],
 							placeholder: t('subscriptions.applyCouponDialog.couponCodePlaceholder', 'Search by name or code…'),
 						}}
 						extractors={{

--- a/src/components/molecules/Customer/CustomerSearchSelect.tsx
+++ b/src/components/molecules/Customer/CustomerSearchSelect.tsx
@@ -99,11 +99,14 @@ const CustomerSearchSelect: React.FC<CustomerSearchSelectProps> = ({
 		return items;
 	};
 
+	const excludeIdsForKey = excludeId ? (Array.isArray(excludeId) ? excludeId : [excludeId]) : [];
+
 	return (
 		<AsyncSearchableSelect<Customer>
 			{...props}
 			search={{
 				searchFn,
+				queryKeyPrefix: ['customer', limit, excludeIdsForKey.slice().sort().join(','), selfCustomer?.id, includeNoneOption],
 				placeholder: resolvedPlaceholder,
 			}}
 			extractors={{


### PR DESCRIPTION
## **User description**
AsyncSearchableSelect cached every picker's results under the same TanStack Query key (['async-searchable-select', debouncedQuery]), with no identifier for which consumer/searchFn produced them. Any two pickers opened with the same search text (almost always '' on first open) within the 30s staleTime window would silently share -- and serve -- each other's cached results.

This explains "can't select any feature" when adding a charge to a subscription: the Add Charge feature picker (metered features only) and the Add Entitlement feature picker (all types, with already-added features flagged disabled) hit the identical cache key, so whichever opened first could serve its results -- including its disabled flags -- to the other. The same collision happens on subscription create between the Customer picker and the Add Charge feature picker, since both funnel through this one shared cache slot.

Add a required queryKeyPrefix to SearchConfig that each consumer fills with whatever distinguishes its search (entity type, filters, exclusions), and thread it into the query key. Updated all four current consumers: SelectFeature, CustomerSearchSelect, and ApplyCouponDialog.


___

## **CodeAnt-AI Description**
Prevent unrelated search pickers from sharing cached results

### What Changed
- Search results are now kept separate for each picker and its filters, exclusions, and entity type
- Customer, feature, and coupon pickers no longer reuse results from another picker when searching for the same text
- Feature selections show the correct available and disabled options for the current context

### Impact
`✅ Correct feature options when adding charges or entitlements`
`✅ Fewer incorrect customer and coupon search results`
`✅ Reliable picker behavior across repeated searches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
