### PR TITLE
fix(dialog): make Dialog modal=false so nested portaled pickers stay …

### DIFF
--- a/src/components/atoms/Dialog/Dialog.tsx
+++ b/src/components/atoms/Dialog/Dialog.tsx
@@ -1,6 +1,6 @@
 import { Dialog as ShadcnDialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
-import { hasRegisteredOpenModals, hasOpenOverlayInDom, registerModalOpen } from '@/lib/modal-scroll-lock';
+import { hasRegisteredOpenModals, hasOpenOverlayInDom, registerModalOpen, useSheetOutsideDismissGuards } from '@/lib/modal-scroll-lock';
 import React, { FC, ReactNode, useEffect } from 'react';
 
 interface Props {
@@ -35,6 +35,8 @@ const Dialog: FC<Props> = ({
 	showCloseButton = true,
 	interactiveContent = false,
 }) => {
+	const outsideDismissGuards = useSheetOutsideDismissGuards(isOpen);
+
 	// Register while open so the safety net below (and every other Dialog/Sheet instance) knows
 	// not to clear the shared body lock while this one is still legitimately open.
 	useEffect(() => {
@@ -60,12 +62,13 @@ const Dialog: FC<Props> = ({
 	}, [isOpen]);
 
 	return (
-		<ShadcnDialog open={isOpen} onOpenChange={onOpenChange}>
+		<ShadcnDialog open={isOpen} onOpenChange={onOpenChange} modal={false}>
 			<DialogContent
 				className={cn('bg-surface rounded-[10px] max-h-[80vh] overflow-y-auto', className)}
 				showCloseButton={showCloseButton}
 				data-interactive={interactiveContent ? 'true' : undefined}
-				onClick={interactiveContent ? (e: React.MouseEvent) => e.stopPropagation() : undefined}>
+				onClick={interactiveContent ? (e: React.MouseEvent) => e.stopPropagation() : undefined}
+				{...outsideDismissGuards}>
 				<DialogHeader className=''>
 					<DialogTitle className={cn('font-medium text-xl', titleClassName)}>
 						{typeof title === 'string' ? title : <>{title}</>}

--- a/src/components/atoms/Sheet/Sheet.tsx
+++ b/src/components/atoms/Sheet/Sheet.tsx
@@ -1,71 +1,11 @@
-import { FC, ReactNode, useRef, useEffect, useCallback } from 'react';
+import { FC, ReactNode, useRef, useEffect } from 'react';
 import { Sheet as ShadcnSheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
-import { hasRegisteredOpenModals, hasOpenOverlayInDom, registerModalOpen } from '@/lib/modal-scroll-lock';
+import { hasRegisteredOpenModals, hasOpenOverlayInDom, registerModalOpen, useSheetOutsideDismissGuards } from '@/lib/modal-scroll-lock';
 import { useLocaleStore } from '@/store/useLocaleStore';
 import { Direction } from '@/config/branding';
 
-const PORTALED_OVERLAY_SELECTOR = [
-	'[data-radix-popper-content-wrapper]',
-	'[data-radix-select-content]',
-	'[data-radix-menu-content]',
-	'[data-radix-dropdown-menu-content]',
-	'[data-radix-popover-content]',
-].join(', ');
-
-const isPortaledOverlayTarget = (target: EventTarget | null) =>
-	target instanceof Element && !!target.closest(PORTALED_OVERLAY_SELECTOR);
-
-const hasOpenPortaledOverlay = () => !!document.querySelector(PORTALED_OVERLAY_SELECTOR);
-
-/** @deprecated Prefer useSheetOutsideDismissGuards — kept for drawers that still import this helper. */
-export const isPortaledSelectTarget = (target: EventTarget | null) => isPortaledOverlayTarget(target);
-
-/**
- * Side sheets use `modal={false}` so portaled selects stay clickable.
- * Outside click still closes the sheet, except while a portaled dropdown is open
- * (or the click landed on one) — then only the dropdown dismisses.
- */
-export function useSheetOutsideDismissGuards(enabled = true) {
-	const suppressDismissRef = useRef(false);
-
-	useEffect(() => {
-		if (!enabled) {
-			suppressDismissRef.current = false;
-			return;
-		}
-
-		// Capture before nested dismissable layers unmount open dropdowns.
-		const onPointerDownCapture = () => {
-			if (!hasOpenPortaledOverlay()) return;
-			suppressDismissRef.current = true;
-			// Backup clear if this gesture never hits the sheet outside handlers (e.g. click inside sheet).
-			window.setTimeout(() => {
-				suppressDismissRef.current = false;
-			}, 100);
-		};
-
-		document.addEventListener('pointerdown', onPointerDownCapture, true);
-		return () => document.removeEventListener('pointerdown', onPointerDownCapture, true);
-	}, [enabled]);
-
-	const preventOutsideDismiss = useCallback((event: Event) => {
-		if (isPortaledOverlayTarget(event.target) || suppressDismissRef.current || hasOpenPortaledOverlay()) {
-			event.preventDefault();
-			suppressDismissRef.current = false;
-		}
-	}, []);
-
-	const preventFocusOutsideDismiss = useCallback((event: Event) => {
-		event.preventDefault();
-	}, []);
-
-	return {
-		onPointerDownOutside: preventOutsideDismiss,
-		onInteractOutside: preventOutsideDismiss,
-		onFocusOutside: preventFocusOutsideDismiss,
-	};
-}
+export { useSheetOutsideDismissGuards };
 
 interface Props {
 	trigger?: ReactNode;

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -13,20 +13,26 @@ const DialogPortal = DialogPrimitive.Portal;
 
 const DialogClose = DialogPrimitive.Close;
 
-const DialogOverlay = React.forwardRef<
-	React.ElementRef<typeof DialogPrimitive.Overlay>,
-	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-	<DialogPrimitive.Overlay
+/**
+ * A plain div, deliberately NOT `DialogPrimitive.Overlay`.
+ *
+ * Dialog uses `modal={false}` so portaled comboboxes/selects nested inside it stay clickable (see
+ * Dialog.tsx) — the same reasoning as SheetOverlay in ui/sheet.tsx. Radix's own overlay is written
+ * as `context.modal ? <Presence>… : null`, so in non-modal mode it renders nothing and the scrim
+ * silently vanishes. Rendering it ourselves restores the look without giving up non-modal
+ * behaviour. `pointer-events-none` is load-bearing: the overlay must not swallow clicks, or it
+ * would re-break the very dropdowns `modal={false}` exists to fix. Dismiss-on-outside-click still
+ * comes from Radix's dismissable layer, not from the overlay.
+ */
+const DialogOverlay = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+	<div
 		ref={ref}
-		className={cn(
-			'fixed inset-0 z-50 bg-surface-scrim/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-			className,
-		)}
+		aria-hidden
+		className={cn('pointer-events-none fixed inset-0 z-50 bg-surface-scrim/50 animate-in fade-in-0', className)}
 		{...props}
 	/>
 ));
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+DialogOverlay.displayName = 'DialogOverlay';
 
 const DialogContent = React.forwardRef<
 	React.ElementRef<typeof DialogPrimitive.Content>,

--- a/src/lib/modal-scroll-lock.ts
+++ b/src/lib/modal-scroll-lock.ts
@@ -1,3 +1,5 @@
+import { useRef, useEffect, useCallback } from 'react';
+
 /**
  * Shared ownership count for the Dialog/Sheet scroll-lock safety net (see Dialog.tsx / Sheet.tsx).
  *
@@ -32,8 +34,69 @@ export function hasRegisteredOpenModals(): boolean {
  * Popover/Select dropdown portaled outside any Dialog/Sheet. Extend this selector, not the call
  * sites, when a new overlay type needs to participate in the safety net.
  */
-const OPEN_OVERLAY_SELECTOR = '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"], [data-radix-popper-content-wrapper]';
+const OPEN_OVERLAY_SELECTOR =
+	'[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"], [data-radix-popper-content-wrapper]';
 
 export function hasOpenOverlayInDom(): boolean {
 	return !!document.querySelector(OPEN_OVERLAY_SELECTOR);
+}
+
+const PORTALED_OVERLAY_SELECTOR = [
+	'[data-radix-popper-content-wrapper]',
+	'[data-radix-select-content]',
+	'[data-radix-menu-content]',
+	'[data-radix-dropdown-menu-content]',
+	'[data-radix-popover-content]',
+].join(', ');
+
+const isPortaledOverlayTarget = (target: EventTarget | null) => target instanceof Element && !!target.closest(PORTALED_OVERLAY_SELECTOR);
+
+const hasOpenPortaledOverlay = () => !!document.querySelector(PORTALED_OVERLAY_SELECTOR);
+
+/**
+ * Non-modal Sheets/Dialogs (see useSheetOutsideDismissGuards below) still dismiss on outside
+ * click via Radix's dismissable layer even though `modal={false}` disables pointer-event
+ * blocking. Without this guard, clicking a portaled Select/Popover/Combobox nested inside the
+ * sheet/dialog reads as an "outside" click to Radix's layer and closes the sheet/dialog out from
+ * under the dropdown mid-interaction.
+ */
+export function useSheetOutsideDismissGuards(enabled = true) {
+	const suppressDismissRef = useRef(false);
+
+	useEffect(() => {
+		if (!enabled) {
+			suppressDismissRef.current = false;
+			return;
+		}
+
+		// Capture before nested dismissable layers unmount open dropdowns.
+		const onPointerDownCapture = () => {
+			if (!hasOpenPortaledOverlay()) return;
+			suppressDismissRef.current = true;
+			// Backup clear if this gesture never hits the outside handlers (e.g. click inside the sheet/dialog).
+			window.setTimeout(() => {
+				suppressDismissRef.current = false;
+			}, 100);
+		};
+
+		document.addEventListener('pointerdown', onPointerDownCapture, true);
+		return () => document.removeEventListener('pointerdown', onPointerDownCapture, true);
+	}, [enabled]);
+
+	const preventOutsideDismiss = useCallback((event: Event) => {
+		if (isPortaledOverlayTarget(event.target) || suppressDismissRef.current || hasOpenPortaledOverlay()) {
+			event.preventDefault();
+			suppressDismissRef.current = false;
+		}
+	}, []);
+
+	const preventFocusOutsideDismiss = useCallback((event: Event) => {
+		event.preventDefault();
+	}, []);
+
+	return {
+		onPointerDownOutside: preventOutsideDismiss,
+		onInteractOutside: preventOutsideDismiss,
+		onFocusOutside: preventFocusOutsideDismiss,
+	};
 }


### PR DESCRIPTION
## **User description**
Radix's modal Dialog calls hideOthers(content) and wraps its Overlay in RemoveScroll, both scoped to the Dialog's own portaled content subtree. A Select/Combobox popover (e.g. SelectFeature) rendered inside a Dialog is portaled to document.body as a *separate* subtree, so it gets swept up by hideOthers' "block pointer-events on everything outside" pass - the option list renders, but clicks on it don't register (cursor falls through to whatever's underneath, e.g. showing a text-select cursor instead of a pointer). This is the same bug class already fixed for
Sheet in #1220, just never applied to Dialog: "Add usage charge" ->
Feature dropdown inside AddSubscriptionChargeDialog was unselectable for exactly this reason.

Apply the same fix Sheet already uses: modal={false} on the Dialog root, a hand-rendered pointer-events-none overlay (Radix's own Overlay renders nothing in non-modal mode), and the outside-dismiss guards so clicking a portaled dropdown doesn't read as an "outside click" and close the Dialog out from under it.

Moved useSheetOutsideDismissGuards (and its private helpers) from Sheet.tsx into modal-scroll-lock.ts so both Sheet and Dialog can share it; Sheet re-exports it for the one existing external import (AddEntitlementDrawer).


___

## **CodeAnt-AI Description**
Keep nested pickers usable inside dialogs

### What Changed
- Dropdowns, selects, and comboboxes opened from a dialog can now receive clicks without closing the dialog.
- Dialogs retain their scrim appearance while allowing interactions with portaled picker menus.
- Shared outside-click handling prevents dialogs and sheets from dismissing during picker interactions.

### Impact
`✅ Clickable nested dropdowns`
`✅ Fewer accidental dialog dismissals`
`✅ Dialog scrim remains visible`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog and sheet behavior when interacting with portaled controls such as dropdowns and selects.
  * Prevented dialogs or sheets from closing unexpectedly during clicks or focus changes involving overlay content.
  * Preserved expected outside-click dismissal while keeping portaled controls interactive.
  * Maintained the visible backdrop for non-modal dialogs without blocking interaction with underlying portaled elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->