### PR TITLE
fix: address CodeRabbit review comments from PR #1235

### DIFF
--- a/src/components/molecules/Customer/CustomerSearchSelect.tsx
+++ b/src/components/molecules/Customer/CustomerSearchSelect.tsx
@@ -36,7 +36,7 @@ const CustomerSearchSelect: React.FC<CustomerSearchSelectProps> = ({
 	includeNoneOption = true,
 	...props
 }) => {
-	const { t } = useTranslation('customers');
+	const { t, i18n } = useTranslation('customers');
 	const resolvedPlaceholder = searchPlaceholder ?? t('select.searchCustomer');
 	const noneLabel = t('select.none');
 	const selfLabel = t('select.self');
@@ -106,7 +106,7 @@ const CustomerSearchSelect: React.FC<CustomerSearchSelectProps> = ({
 			{...props}
 			search={{
 				searchFn,
-				queryKeyPrefix: ['customer', limit, excludeIdsForKey.slice().sort().join(','), selfCustomer?.id, includeNoneOption],
+				queryKeyPrefix: ['customer', limit, excludeIdsForKey.slice().sort().join(','), selfCustomer?.id, includeNoneOption, i18n.language],
 				placeholder: resolvedPlaceholder,
 			}}
 			extractors={{

--- a/src/components/molecules/QueryBuilder/PropertyFilterPopover.tsx
+++ b/src/components/molecules/QueryBuilder/PropertyFilterPopover.tsx
@@ -319,6 +319,15 @@ const PropertyFilterPopover: React.FC<Props> = ({
 								<Button size='sm' onClick={handleAddFilter} className='w-fit h-9 text-sm px-2.5'>
 									{t('queryBuilder.addFilter')}
 								</Button>
+								{propertyFilters && (
+									<Button
+										variant='outline'
+										size='sm'
+										className='h-9 text-sm px-2.5'
+										onClick={() => propertyFilters.setRows((prev) => [...prev, propertyFilters.createEmpty()])}>
+										{t('queryBuilder.addPropertyFilter')}
+									</Button>
+								)}
 								{(onResetCallback != null || propertyFilters != null) && (
 									<Button
 										variant='outline'

--- a/src/lib/modal-scroll-lock.ts
+++ b/src/lib/modal-scroll-lock.ts
@@ -41,12 +41,19 @@ export function hasOpenOverlayInDom(): boolean {
 	return !!document.querySelector(OPEN_OVERLAY_SELECTOR);
 }
 
+/**
+ * Require `data-state="open"` so a `forceMount`-ed overlay that's actually closed (kept in the
+ * DOM for its own exit animation) doesn't get mistaken for something open — that would make
+ * useSheetOutsideDismissGuards block every outside-click dismissal indefinitely. Radix puts
+ * `data-state` on the content element itself, not on the outer `data-radix-popper-content-wrapper`
+ * positioning div, hence the descendant combinator (space) for that one selector.
+ */
 const PORTALED_OVERLAY_SELECTOR = [
-	'[data-radix-popper-content-wrapper]',
-	'[data-radix-select-content]',
-	'[data-radix-menu-content]',
-	'[data-radix-dropdown-menu-content]',
-	'[data-radix-popover-content]',
+	'[data-radix-popper-content-wrapper] [data-state="open"]',
+	'[data-radix-select-content][data-state="open"]',
+	'[data-radix-menu-content][data-state="open"]',
+	'[data-radix-dropdown-menu-content][data-state="open"]',
+	'[data-radix-popover-content][data-state="open"]',
 ].join(', ');
 
 const isPortaledOverlayTarget = (target: EventTarget | null) => target instanceof Element && !!target.closest(PORTALED_OVERLAY_SELECTOR);


### PR DESCRIPTION
## **User description**
## Summary
Addresses the actionable CodeRabbit findings left on #1235:

- **CustomerSearchSelect**: the cache key now includes `i18n.language`, since `searchFn` embeds translated "None"/"Self" labels into the cached results — a language switch within the 30s staleTime window could otherwise serve stale labels from the previous locale.
- **PropertyFilterPopover**: the empty-state branch now also offers "Add Property Filter". Removing the last property row with no other filters active landed on the empty state, which only had "Add Filter" — no way back to adding a property filter without first adding an unrelated regular filter.
- **modal-scroll-lock**: `PORTALED_OVERLAY_SELECTOR` now requires `data-state="open"`, so a `forceMount`-ed-but-closed overlay (kept in the DOM for its own exit animation) can't be mistaken for an open one and block outside-click dismissal indefinitely. No current `forceMount` usage in the app, so this is defensive, but it was cheap to close.

**Skipped**: the Zod-validation suggestion for `PlanPriceTable`'s `searchPrices` response — grepped `src/api/` and found zero endpoints validate responses with Zod at the API boundary; the existing convention across the codebase is TypeScript-generic typing only (the same pattern as the 4 other `useQuery<...Response>` call sites). Adding it to just this one endpoint would be inconsistent scope creep rather than a fix.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all touched files


___

## **CodeAnt-AI Description**
Prevent stale customer labels and restore property-filter access in empty states

### What Changed
- Customer search results refresh when the app language changes, preventing translated “None” and “Self” labels from showing in the previous language
- The empty property-filter state now lets users add a property filter directly
- Closed overlays kept in the page for exit animations no longer block outside-click dismissal

### Impact
`✅ Correct customer labels after language changes`
`✅ Direct access to adding property filters`
`✅ Fewer blocked outside-click dismissals`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “Add Property Filter” action to empty filter states, allowing users to create a filter row directly.

- **Bug Fixes**
  - Search results now remain correctly separated by selected language.
  - Improved modal scrolling behavior by ignoring closed, force-mounted overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->