### PR TITLE
fix(auth): guard Supabase calls so a misconfigured/unreachable client degrades gracefully

### DIFF
--- a/src/core/auth/AuthService.ts
+++ b/src/core/auth/AuthService.ts
@@ -5,10 +5,16 @@ import { RouteNames } from '../routes/Routes';
 class AuthService {
 	public static async getAcessToken() {
 		if (config.app.env !== APP_ENV.SelfHosted) {
-			const {
-				data: { session },
-			} = await supabase.auth.getSession();
-			return session?.access_token;
+			try {
+				const { data } = await supabase.auth.getSession();
+				return data?.session?.access_token;
+			} catch (error) {
+				// Runs on every outgoing request via the axios interceptor — a network failure or a
+				// misconfigured/unavailable Supabase client must not crash every API call. Falling
+				// through to an unauthenticated request lets the backend reject it with a normal 401.
+				console.error('Error getting access token:', error);
+				return null;
+			}
 		} else {
 			try {
 				const tokenData = localStorage.getItem('token');
@@ -24,8 +30,13 @@ class AuthService {
 
 	public static async getUser() {
 		if (config.app.env !== APP_ENV.SelfHosted) {
-			const { data } = await supabase.auth.getUser();
-			return data.user;
+			try {
+				const { data } = await supabase.auth.getUser();
+				return data?.user ?? null;
+			} catch (error) {
+				console.error('Error getting user:', error);
+				return null;
+			}
 		} else {
 			try {
 				const tokenData = localStorage.getItem('token');

--- a/src/core/services/supbase/config.ts
+++ b/src/core/services/supbase/config.ts
@@ -3,13 +3,23 @@ import { createClient } from '@supabase/supabase-js';
 
 const isSelfHosted = config.app.env === APP_ENV.SelfHosted;
 
+/**
+ * Stands in for the real Supabase client when auth isn't configured for local development
+ * (VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY unset). Every method mirrors the real SDK's
+ * response *shape* (e.g. `{ data: { session: null } }`, not `{ data: null }`) so callers that
+ * destructure nested fields (AuthService.getAcessToken's `data.session?.access_token`, etc.)
+ * don't crash — they just see "nobody's signed in" instead.
+ */
 const createMockClient = () => {
+	const notConfiguredError = { message: 'Authentication is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.' };
 	return {
 		auth: {
-			signIn: async () => ({ user: null, error: null }),
+			signIn: async () => ({ data: { user: null, session: null }, error: notConfiguredError }),
+			signInWithPassword: async () => ({ data: { user: null, session: null }, error: notConfiguredError }),
 			signOut: async () => ({ error: null }),
-			onAuthStateChange: () => ({ data: null, error: null }),
-			getSession: async () => ({ data: null, error: null }),
+			onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } }, error: null }),
+			getSession: async () => ({ data: { session: null }, error: null }),
+			getUser: async () => ({ data: { user: null }, error: null }),
 		},
 		from: () => ({
 			select: async () => [],


### PR DESCRIPTION
## **User description**
## Summary
Fixes two uncaught crashes traced back to `AuthService.getAcessToken()`, which runs on every outgoing request via the axios request interceptor and had no error handling in its non-self-hosted branch (unlike the self-hosted branch right next to it):

1. **`Cannot read properties of null (reading 'session')`** on every request — the mock Supabase client (used when `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` aren't set) returned `{ data: null, error: null }` from `getSession()`, but `getAcessToken()` destructured `data: { session }` directly against that `null`.
2. **`supabase.auth.signInWithPassword is not a function`** on login — the same mock client didn't implement `signInWithPassword` or `getUser` at all.

## Changes
- `AuthService.getAcessToken()` / `getUser()`: wrapped the non-self-hosted branch in try/catch (matching the self-hosted branch's existing pattern) and switched to optional chaining, so a network failure or a broken client returns `null` instead of throwing — the request then goes out unauthenticated and the backend rejects it with a normal 401 instead of the request crashing client-side.
- `createMockClient()`: every method now mirrors the real Supabase SDK's response *shape* (`data.session` / `data.user`, not top-level `null`), and `signInWithPassword`/`getUser` are implemented so calling them surfaces a clear "Authentication is not configured" error instead of a `TypeError`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] existing `AuthService.test.ts` suite passes (4/4)


___

## **CodeAnt-AI Description**
Prevent authentication misconfiguration from crashing requests and login

### What Changed
- Failed or unavailable authentication services now return an unauthenticated state instead of crashing outgoing requests or user lookups
- Login attempts without configured authentication show a clear configuration error instead of a missing-function error
- Unconfigured authentication now behaves like a signed-out user across session, user, login, and logout flows

### Impact
`✅ Fewer client-side request crashes`
`✅ Clearer authentication setup errors`
`✅ Normal unauthorized responses when authentication is unavailable`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
