### PR TITLE
Feat/whop secret

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7977,9 +7977,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/src/components/molecules/WhopConnectionDrawer/WhopConnectionDrawer.tsx
+++ b/src/components/molecules/WhopConnectionDrawer/WhopConnectionDrawer.tsx
@@ -1,6 +1,6 @@
 import { config } from '@/config/config';
 import { FC, useState, useEffect } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { Button, Input, Sheet, Spacer } from '@/components/atoms';
 import { Switch } from '@/components/ui';
 import { useMutation } from '@tanstack/react-query';
@@ -255,9 +255,6 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 				{/* Webhook Section */}
 				<div className='p-4 bg-info-muted border border-info-line rounded-lg'>
 					<h3 className='text-sm font-medium text-info-deep mb-2'>{t('connection.webhook.sectionTitle')}</h3>
-					<p className='text-xs text-info-strong mb-3'>
-						<Trans ns='settings' i18nKey='connection.whop.webhookIntroHtml' components={{ event: <code className='font-mono' /> }} />
-					</p>
 					<div className='mb-3 space-y-2'>
 						<Input
 							label={t('connection.whop.webhookSecret')}

--- a/src/components/molecules/WhopConnectionDrawer/WhopConnectionDrawer.tsx
+++ b/src/components/molecules/WhopConnectionDrawer/WhopConnectionDrawer.tsx
@@ -1,6 +1,6 @@
 import { config } from '@/config/config';
 import { FC, useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { Button, Input, Sheet, Spacer } from '@/components/atoms';
 import { Switch } from '@/components/ui';
 import { useMutation } from '@tanstack/react-query';
@@ -23,6 +23,7 @@ interface WhopFormData {
 	api_key: string;
 	company_id: string;
 	product_id: string;
+	webhook_secret: string;
 	sync_config: {
 		invoice: boolean;
 	};
@@ -43,6 +44,7 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 		api_key: '',
 		company_id: '',
 		product_id: '',
+		webhook_secret: '',
 		sync_config: {
 			invoice: false,
 		},
@@ -59,6 +61,7 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 					api_key: '',
 					company_id: encryptedData.company_id || '',
 					product_id: encryptedData.product_id || '',
+					webhook_secret: '',
 					sync_config: {
 						invoice: syncConfig.invoice?.outbound || false,
 					},
@@ -69,6 +72,7 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 					api_key: '',
 					company_id: '',
 					product_id: '',
+					webhook_secret: '',
 					sync_config: { invoice: false },
 				});
 			}
@@ -92,6 +96,7 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 		if (!connection) {
 			if (!formData.api_key.trim()) newErrors.api_key = t('connection.validation.apiKeyRequiredUpper');
 			if (!formData.company_id.trim()) newErrors.company_id = t('connection.whop.companyIdRequired');
+			if (!formData.webhook_secret.trim()) newErrors.webhook_secret = t('connection.validation.webhookSecretRequired');
 		}
 		setErrors(newErrors);
 		return Object.keys(newErrors).length === 0;
@@ -106,6 +111,7 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 					provider_type: CONNECTION_PROVIDER_TYPE.WHOP,
 					api_key: formData.api_key,
 					company_id: formData.company_id,
+					webhook_secret: formData.webhook_secret,
 					...(formData.product_id.trim() ? { product_id: formData.product_id.trim() } : {}),
 				},
 				sync_config: {} as Record<string, { inbound: boolean; outbound: boolean }>,
@@ -134,8 +140,15 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 			if (formData.sync_config.invoice) {
 				payload.sync_config.invoice = { inbound: false, outbound: true };
 			}
+			const secretUpdates: Record<string, string> = {};
 			if (formData.product_id.trim()) {
-				payload.encrypted_secret_data = { product_id: formData.product_id.trim() };
+				secretUpdates.product_id = formData.product_id.trim();
+			}
+			if (formData.webhook_secret.trim()) {
+				secretUpdates.webhook_secret = formData.webhook_secret.trim();
+			}
+			if (Object.keys(secretUpdates).length > 0) {
+				payload.encrypted_secret_data = secretUpdates;
 			}
 			return await ConnectionApi.Update(connection.id, payload);
 		},
@@ -243,11 +256,23 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 				<div className='p-4 bg-info-muted border border-info-line rounded-lg'>
 					<h3 className='text-sm font-medium text-info-deep mb-2'>{t('connection.webhook.sectionTitle')}</h3>
 					<p className='text-xs text-info-strong mb-3'>
-						{t('connection.whop.webhookIntroPrefix')} <code className='font-mono'>{t('connection.whop.webhookEventName')}</code>{' '}
-						{t('connection.whop.webhookIntroSuffix')}
+						<Trans ns='settings' i18nKey='connection.whop.webhookIntroHtml' components={{ event: <code className='font-mono' /> }} />
 					</p>
-					<div>
+					<div className='mb-3 space-y-2'>
+						<Input
+							label={t('connection.whop.webhookSecret')}
+							type='password'
+							placeholder={
+								connection ? t('connection.whop.webhookSecretPlaceholderEdit') : t('connection.whop.webhookSecretPlaceholderCreate')
+							}
+							value={formData.webhook_secret}
+							onChange={(value) => handleChange('webhook_secret', value)}
+							error={errors.webhook_secret}
+							className='text-info-deep'
+							description={connection ? t('connection.whop.webhookSecretDescEdit') : t('connection.whop.webhookSecretDescCreate')}
+						/>
 						<label className='text-sm font-medium text-info-deep mb-2 block'>{t('connection.webhook.url')}</label>
+
 						<div className='flex items-center gap-2 p-2 bg-surface border border-info-line rounded-md'>
 							<code className='flex-1 text-xs text-content-heading font-mono break-all'>{webhookUrl}</code>
 							<Button size='xs' variant='outline' onClick={handleCopyWebhookUrl} className='flex items-center gap-1'>

--- a/src/components/molecules/WhopConnectionDrawer/WhopConnectionDrawer.tsx
+++ b/src/components/molecules/WhopConnectionDrawer/WhopConnectionDrawer.tsx
@@ -109,9 +109,9 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 				provider_type: CONNECTION_PROVIDER_TYPE.WHOP,
 				encrypted_secret_data: {
 					provider_type: CONNECTION_PROVIDER_TYPE.WHOP,
-					api_key: formData.api_key,
-					company_id: formData.company_id,
-					webhook_secret: formData.webhook_secret,
+					api_key: formData.api_key.trim(),
+					company_id: formData.company_id.trim(),
+					webhook_secret: formData.webhook_secret.trim(),
 					...(formData.product_id.trim() ? { product_id: formData.product_id.trim() } : {}),
 				},
 				sync_config: {} as Record<string, { inbound: boolean; outbound: boolean }>,
@@ -140,15 +140,19 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 			if (formData.sync_config.invoice) {
 				payload.sync_config.invoice = { inbound: false, outbound: true };
 			}
-			const secretUpdates: Record<string, string> = {};
-			if (formData.product_id.trim()) {
-				secretUpdates.product_id = formData.product_id.trim();
+			// EE UpdateConnection merges Whop webhook_secret only (flat or nested). Always send
+			// product_id (including "") so a clear is explicit if/when the backend persists it.
+			const originalProductId = String(connection?.encrypted_secret_data?.product_id ?? '').trim();
+			const nextProductId = formData.product_id.trim();
+			const whopUpdate: Record<string, string> = {};
+			if (nextProductId !== originalProductId) {
+				whopUpdate.product_id = nextProductId;
 			}
 			if (formData.webhook_secret.trim()) {
-				secretUpdates.webhook_secret = formData.webhook_secret.trim();
+				whopUpdate.webhook_secret = formData.webhook_secret.trim();
 			}
-			if (Object.keys(secretUpdates).length > 0) {
-				payload.encrypted_secret_data = secretUpdates;
+			if (Object.keys(whopUpdate).length > 0) {
+				payload.encrypted_secret_data = { whop: whopUpdate };
 			}
 			return await ConnectionApi.Update(connection.id, payload);
 		},

--- a/src/i18n/locales/ar/settings.json
+++ b/src/i18n/locales/ar/settings.json
@@ -958,9 +958,12 @@
 			"productIdPlaceholder": "prod_... — اتركه فارغاً للإنشاء التلقائي",
 			"productIdHint": "منتج Whop المستخدم للفواتير. اتركه فارغاً لينشئ Flexprice واحداً تلقائياً.",
 			"invoiceSyncHint": "ادفع فواتير Flexprice إلى Whop كمدفوعات send_invoice",
-			"webhookIntroPrefix": "سجّل هذا العنوان في لوحة Whop ضمن Webhooks. سيتابع Flexprice",
-			"webhookEventName": "invoice.paid",
-			"webhookIntroSuffix": "لتحديث حالة الفاتورة تلقائياً عند الدفع."
+			"webhookIntroHtml": "في Whop، أنشئ ويب هوك بهذا العنوان واشترك في <event>invoice.paid</event>. الصق نفس سرّ التوقيع أدناه ليتحقق Flexprice من الأحداث ويحدّث الفواتير كمدفوعة.",
+			"webhookSecret": "سرّ الويب هوك",
+			"webhookSecretPlaceholderCreate": "سرّ توقيع الويب هوك من Whop",
+			"webhookSecretPlaceholderEdit": "اتركه فارغاً للإبقاء على السرّ، أو أدخل سراً جديداً للتدوير",
+			"webhookSecretDescCreate": "مطلوب. يجب أن يطابق سرّ Whop ليتحقق Flexprice من التوقيع. يُخزَّن مشفّراً مع الاتصال.",
+			"webhookSecretDescEdit": "مُخزَّن مشفّراً. اتركه فارغاً عند التحديث للإبقاء على السرّ الحالي."
 		},
 		"tabs": {
 			"description": "اضبط تكامل Tabs باستخدام بيانات الاعتماد المطلوبة.",
@@ -1308,6 +1311,31 @@
 						"webhooksPaddle": {
 							"title": "تكامل الويبهوك",
 							"paragraphs": ["استقبل إشعارات فورية عن أحداث الدفع عبر الويبهوك؛ اشترك في حدث transactions.completed لمتابعة حالة الدفع."]
+						}
+					}
+				},
+				"whop": {
+					"name": "Whop",
+					"description": "زامن الفواتير مع Whop مع تحديثات تلقائية لحالة الدفع.",
+					"sections": {
+						"overview": {
+							"title": "نظرة عامة",
+							"paragraphs": [
+								"يتيح تكامل Flexprice مع Whop إرسال الفواتير مباشرة إلى Whop كمدفوعات send_invoice لمرة واحدة. يدفع العملاء عبر صفحة الدفع المستضافة على Whop، ويتحدّث Flexprice تلقائياً عند استلام الدفع."
+							]
+						},
+						"invoiceSync": {
+							"title": "مزامنة الفواتير",
+							"paragraphs": [
+								"عند تفعيل مزامنة الفواتير، ينشئ Flexprice تلقائياً فاتورة مقابلة في Whop كلما اكتملت فاتورة في Flexprice. يضمن التكامل وجود منتج Whop (وينشئ واحداً عند الحاجة).",
+								"يمكنك أيضاً تعليم فاتورة Whop كمدفوعة من Flexprice، والذي يستدعي واجهة mark_paid في Whop نيابةً عنك."
+							]
+						},
+						"webhooks": {
+							"title": "الويبهوك",
+							"paragraphs": [
+								"سجّل عنوان ويبهوك Flexprice في إعدادات مطور Whop، واشترك في invoice.paid، واستخدم نفس سرّ توقيع الويبهوك في Flexprice. عند إطلاق Whop لهذا الحدث، يتحقق Flexprice من التوقيع، ويعلّم الفاتورة المقابلة كمدفوعة، ويسجّل الدفع."
+							]
 						}
 					}
 				},

--- a/src/i18n/locales/ar/settings.json
+++ b/src/i18n/locales/ar/settings.json
@@ -958,11 +958,10 @@
 			"productIdPlaceholder": "prod_... — اتركه فارغاً للإنشاء التلقائي",
 			"productIdHint": "منتج Whop المستخدم للفواتير. اتركه فارغاً لينشئ Flexprice واحداً تلقائياً.",
 			"invoiceSyncHint": "ادفع فواتير Flexprice إلى Whop كمدفوعات send_invoice",
-			"webhookIntroHtml": "في Whop، أنشئ ويب هوك بهذا العنوان واشترك في <event>invoice.paid</event>. الصق نفس سرّ التوقيع أدناه ليتحقق Flexprice من الأحداث ويحدّث الفواتير كمدفوعة.",
 			"webhookSecret": "سرّ الويب هوك",
 			"webhookSecretPlaceholderCreate": "سرّ توقيع الويب هوك من Whop",
 			"webhookSecretPlaceholderEdit": "اتركه فارغاً للإبقاء على السرّ، أو أدخل سراً جديداً للتدوير",
-			"webhookSecretDescCreate": "مطلوب. يجب أن يطابق سرّ Whop ليتحقق Flexprice من التوقيع. يُخزَّن مشفّراً مع الاتصال.",
+			"webhookSecretDescCreate": "مطلوب للتحقق من توقيع الويب هوك. يجب أن يطابق السرّ المُعدّ في Whop، ويُخزَّن مشفّراً بأمان مع الاتصال.",
 			"webhookSecretDescEdit": "مُخزَّن مشفّراً. اتركه فارغاً عند التحديث للإبقاء على السرّ الحالي."
 		},
 		"tabs": {

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -955,9 +955,12 @@
 			"productIdPlaceholder": "prod_... — leave blank to auto-create",
 			"productIdHint": "Whop product used for invoices. Leave blank to have Flexprice create one automatically.",
 			"invoiceSyncHint": "Push Flexprice invoices to Whop as send_invoice payments",
-			"webhookIntroPrefix": "Register this URL in your Whop dashboard under Webhooks. Flexprice will listen for",
-			"webhookEventName": "invoice.paid",
-			"webhookIntroSuffix": "events to automatically mark invoices as paid."
+			"webhookIntroHtml": "In Whop, create a webhook with this URL and subscribe to <event>invoice.paid</event>. Paste the same signing secret below so Flexprice can verify events and mark invoices as paid.",
+			"webhookSecret": "Webhook Secret",
+			"webhookSecretPlaceholderCreate": "Webhook signing secret from Whop",
+			"webhookSecretPlaceholderEdit": "Leave blank to keep existing secret, or enter a new secret to rotate",
+			"webhookSecretDescCreate": "Required. Must match the secret in Whop so Flexprice can verify webhook signatures. Stored encrypted with your connection.",
+			"webhookSecretDescEdit": "Stored encrypted. Leave blank to keep the current secret when updating."
 		},
 		"tabs": {
 			"description": "Configure your Tabs integration with the required credentials.",
@@ -1374,7 +1377,7 @@
 						"webhooks": {
 							"title": "Webhooks",
 							"paragraphs": [
-								"Register the Flexprice webhook URL in your Whop developer settings to receive invoice.paid events. When Whop fires this event, Flexprice automatically marks the corresponding invoice as paid and records the payment."
+								"Register the Flexprice webhook URL in your Whop developer settings, subscribe to invoice.paid, and use the same webhook signing secret in Flexprice. When Whop fires this event, Flexprice verifies the signature, marks the corresponding invoice as paid, and records the payment."
 							]
 						}
 					}

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -955,7 +955,6 @@
 			"productIdPlaceholder": "prod_... — leave blank to auto-create",
 			"productIdHint": "Whop product used for invoices. Leave blank to have Flexprice create one automatically.",
 			"invoiceSyncHint": "Push Flexprice invoices to Whop as send_invoice payments",
-			"webhookIntroHtml": "In Whop, create a webhook with this URL and subscribe to <event>invoice.paid</event>. Paste the same signing secret below so Flexprice can verify events and mark invoices as paid.",
 			"webhookSecret": "Webhook Secret",
 			"webhookSecretPlaceholderCreate": "Webhook signing secret from Whop",
 			"webhookSecretPlaceholderEdit": "Leave blank to keep existing secret, or enter a new secret to rotate",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -959,7 +959,7 @@
 			"webhookSecret": "Webhook Secret",
 			"webhookSecretPlaceholderCreate": "Webhook signing secret from Whop",
 			"webhookSecretPlaceholderEdit": "Leave blank to keep existing secret, or enter a new secret to rotate",
-			"webhookSecretDescCreate": "Required. Must match the secret in Whop so Flexprice can verify webhook signatures. Stored encrypted with your connection.",
+			"webhookSecretDescCreate": "Required for webhook verification. Must match the secret configured in Whop. Stored encrypted.",
 			"webhookSecretDescEdit": "Stored encrypted. Leave blank to keep the current secret when updating."
 		},
 		"tabs": {

--- a/src/types/dto/Connection.ts
+++ b/src/types/dto/Connection.ts
@@ -104,6 +104,13 @@ export interface CreateConnectionPayload {
 				client_secret?: string;
 		  }
 		| {
+				provider_type: CONNECTION_PROVIDER_TYPE.WHOP;
+				api_key?: string;
+				company_id?: string;
+				product_id?: string;
+				webhook_secret?: string;
+		  }
+		| {
 				api_key?: string;
 				webhook_secret?: string;
 		  };


### PR DESCRIPTION
## **CodeAnt-AI Description**
Add secure webhook secret support for Whop connections

### What Changed
- Whop connections now require a webhook signing secret when created and store it encrypted with the connection.
- Existing connections can keep their current secret or replace it by entering a new one.
- Webhook setup guidance now explains how to subscribe to `invoice.paid` and use the matching secret to verify events and mark invoices as paid.
- Updated the sanitization dependency to address a known cross-site scripting vulnerability.

### Impact
`✅ Verified Whop payment webhooks`
`✅ Safer Whop connection credentials`
`✅ Protected webhook event handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook secret support when creating or editing Whop connections.
  * Added password-protected webhook secret fields with clear create, retain, and rotate guidance.
  * Whop connection updates now preserve existing encrypted settings when changing product or webhook details.
  * Added translated webhook setup content and expanded Whop integration information, including invoice synchronization, payment updates, and signature verification.
* **Documentation**
  * Updated Arabic and English localization for webhook configuration and secret management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->