### PR TITLE
fix(pricing): unlock tiered-price editing, fix subscription create freeze

### DIFF
--- a/src/components/molecules/LineItemCoupon/LineItemCoupon.tsx
+++ b/src/components/molecules/LineItemCoupon/LineItemCoupon.tsx
@@ -48,12 +48,17 @@ const LineItemCoupon: React.FC<Props> = ({
 		}
 	}, [isModalOpen, selectedCoupon]);
 
+	// This component mounts fresh each time a line item's coupon picker opens (SubscriptionPriceTable
+	// only renders it while that row's dialog is open), so with the default staleTime of 0 every open
+	// re-fetches the full coupon list from the network. A short staleTime lets repeat opens across
+	// different line items in the same sitting reuse the cache instead of refetching each time.
 	const { data: availableCoupons = [] } = useQuery({
 		queryKey: ['availableCoupons'],
 		queryFn: async () => {
 			const response = await CouponApi.getAllCoupons({ limit: 1000, offset: 0 });
 			return filterValidCoupons(response.items);
 		},
+		staleTime: 60000,
 	});
 
 	// Count local usage of coupons across line items and subscription level

--- a/src/components/molecules/LineItemCoupon/LineItemCoupon.tsx
+++ b/src/components/molecules/LineItemCoupon/LineItemCoupon.tsx
@@ -52,11 +52,14 @@ const LineItemCoupon: React.FC<Props> = ({
 	// only renders it while that row's dialog is open), so with the default staleTime of 0 every open
 	// re-fetches the full coupon list from the network. A short staleTime lets repeat opens across
 	// different line items in the same sitting reuse the cache instead of refetching each time.
+	// Cache the raw list, not the filterValidCoupons result - that filter is time-sensitive
+	// (redeem_after/redeem_before vs. `new Date()`), so baking it into the cached value would keep
+	// a coupon that becomes valid mid-cache-window hidden until the next refetch.
 	const { data: availableCoupons = [] } = useQuery({
 		queryKey: ['availableCoupons'],
 		queryFn: async () => {
 			const response = await CouponApi.getAllCoupons({ limit: 1000, offset: 0 });
-			return filterValidCoupons(response.items);
+			return response.items;
 		},
 		staleTime: 60000,
 	});
@@ -79,7 +82,6 @@ const LineItemCoupon: React.FC<Props> = ({
 	}, [allLineItemCoupons, subscriptionLevelCoupons]);
 
 	const currencyFilteredCoupons: Coupon[] = useMemo(() => {
-		if (!currency) return availableCoupons as Coupon[];
 		const validCoupons = filterValidCoupons(availableCoupons as Coupon[], currency);
 
 		// Filter out coupons that have reached their redemption limit

--- a/src/components/organisms/PlanForm/UsagePricingForm.tsx
+++ b/src/components/organisms/PlanForm/UsagePricingForm.tsx
@@ -59,17 +59,17 @@ interface TieredPrice {
 }
 
 /**
- * Only the last tier should ever be unbounded (up_to: null) - VolumeTieredPricingForm renders
- * whichever row has up_to === null as the disabled/∞ row regardless of its position. Backend data
- * should already guarantee this, but normalize defensively on load anyway: a stray null on a
- * non-last tier (e.g. from an older client/API path) would otherwise permanently lock a row that
- * isn't actually the last one.
+ * Only a non-last tier's up_to should ever be null - VolumeTieredPricingForm renders that as ∞,
+ * which is only meaningful for the true last tier. Backend data should already guarantee this,
+ * but normalize defensively on load anyway: a stray null on a non-last tier (e.g. from an older
+ * client/API path) would otherwise render as unbounded on a row that isn't actually last. The
+ * last tier's own up_to is left as-is (it may legitimately be a finite boundary, not just null).
  */
 const normalizeTiers = (tiers: TieredPrice[]): PriceTier[] =>
 	tiers.map((tier, index) => {
 		const isLast = index === tiers.length - 1;
 		if (isLast) {
-			return { from: tier.from, up_to: null, unit_amount: tier.unit_amount, flat_amount: tier.flat_amount };
+			return { from: tier.from, up_to: tier.up_to, unit_amount: tier.unit_amount, flat_amount: tier.flat_amount };
 		}
 		return {
 			from: tier.from,
@@ -303,8 +303,21 @@ const UsagePricingForm: FC<Props> = ({
 					}
 				}
 
+				// Every non-last tier must have a real numeric boundary - VolumeTieredPricingForm allows
+				// the field to sit empty transiently while the user is retyping it (backspace, then
+				// digits), so an empty string can still be here if they navigate away before finishing.
+				const isLastTier = i === tieredPrices.length - 1;
+				if (!isLastTier && typeof tier.up_to !== 'number') {
+					setInputErrors((prev) => ({
+						...prev,
+						tieredModelError: `Up to value is required for tier ${i + 1}`,
+					}));
+					toast.error(`Up to value is required for tier ${i + 1}`);
+					return false;
+				}
+
 				// Validate tier ranges
-				if (tier.up_to !== null) {
+				if (typeof tier.up_to === 'number') {
 					if (tier.from > tier.up_to) {
 						setInputErrors((prev) => ({
 							...prev,

--- a/src/components/organisms/PlanForm/UsagePricingForm.tsx
+++ b/src/components/organisms/PlanForm/UsagePricingForm.tsx
@@ -58,6 +58,27 @@ interface TieredPrice {
 	flat_amount: string;
 }
 
+/**
+ * Only the last tier should ever be unbounded (up_to: null) - VolumeTieredPricingForm renders
+ * whichever row has up_to === null as the disabled/∞ row regardless of its position. Backend data
+ * should already guarantee this, but normalize defensively on load anyway: a stray null on a
+ * non-last tier (e.g. from an older client/API path) would otherwise permanently lock a row that
+ * isn't actually the last one.
+ */
+const normalizeTiers = (tiers: TieredPrice[]): PriceTier[] =>
+	tiers.map((tier, index) => {
+		const isLast = index === tiers.length - 1;
+		if (isLast) {
+			return { from: tier.from, up_to: null, unit_amount: tier.unit_amount, flat_amount: tier.flat_amount };
+		}
+		return {
+			from: tier.from,
+			up_to: tier.up_to === null ? (tiers[index + 1]?.from ?? tier.from) : tier.up_to,
+			unit_amount: tier.unit_amount,
+			flat_amount: tier.flat_amount,
+		};
+	});
+
 // TODO: Remove disabled once the feature is released
 export const billingModels: SelectOption[] = [
 	{
@@ -188,14 +209,7 @@ const UsagePricingForm: FC<Props> = ({
 					unit: price.transform_quantity?.divide_by?.toString() || '',
 				});
 			} else if (price.billing_model === BILLING_MODEL.TIERED && Array.isArray(price.tiers)) {
-				setTieredPrices(
-					(price.tiers as unknown as TieredPrice[]).map((tier) => ({
-						from: tier.from,
-						up_to: tier.up_to,
-						unit_amount: tier.unit_amount,
-						flat_amount: tier.flat_amount,
-					})),
-				);
+				setTieredPrices(normalizeTiers(price.tiers as unknown as TieredPrice[]));
 
 				// Set the appropriate billing model based on tier_mode
 				if (price.tier_mode === TIER_MODE.SLAB) {

--- a/src/components/organisms/PlanForm/VolumeTieredPricingForm.tsx
+++ b/src/components/organisms/PlanForm/VolumeTieredPricingForm.tsx
@@ -52,9 +52,9 @@ const VolumeTieredPricingForm: FC<Props> = ({ setTieredPrices, tieredPrices, cur
 	const addTieredPrice = () => {
 		setTieredPrices((prev) => {
 			const lastTier = prev[prev.length - 1];
-
+			const updatedTiers = [...prev];
 			if (lastTier.up_to === null) {
-				prev[prev.length - 1] = { ...lastTier, up_to: lastTier.from + 1 };
+				updatedTiers[updatedTiers.length - 1] = { ...lastTier, up_to: lastTier.from + 1 };
 			}
 			const newFrom = lastTier.up_to ?? lastTier.from + 1;
 
@@ -64,7 +64,7 @@ const VolumeTieredPricingForm: FC<Props> = ({ setTieredPrices, tieredPrices, cur
 				unit_amount: '',
 				flat_amount: '0',
 			};
-			return [...prev, newTier];
+			return [...updatedTiers, newTier];
 		});
 	};
 
@@ -76,7 +76,8 @@ const VolumeTieredPricingForm: FC<Props> = ({ setTieredPrices, tieredPrices, cur
 		setTieredPrices((prev) => {
 			const updatedTiers = prev.filter((_, i) => i !== index);
 			if (updatedTiers.length > 0 && index === prev.length - 1) {
-				updatedTiers[updatedTiers.length - 1].up_to = null;
+				const newLastTier = updatedTiers[updatedTiers.length - 1];
+				updatedTiers[updatedTiers.length - 1] = { ...newLastTier, up_to: null };
 			}
 			return updatedTiers;
 		});
@@ -87,22 +88,30 @@ const VolumeTieredPricingForm: FC<Props> = ({ setTieredPrices, tieredPrices, cur
 		const newValue = formatNumber(value);
 		setTieredPrices((prev) => {
 			const updatedTiers = [...prev];
+			const isLastTier = index === prev.length - 1;
 			if (newValue !== null) {
 				updatedTiers[index] = { ...updatedTiers[index], [key]: newValue };
 
 				// Adjust the 'from' and 'up_to' values based on the tier being updated
 				if (key === 'up_to' && index < prev.length - 1) {
 					// If 'up_to' is updated, adjust the 'from' value of the next tier
-					const nextTier = updatedTiers[index + 1];
-					nextTier.from = newValue;
+					updatedTiers[index + 1] = { ...updatedTiers[index + 1], from: newValue };
 				}
 
 				if (key === 'from' && index > 0) {
 					// If 'from' is updated, adjust the 'up_to' value of the previous tier
-					const previousTier = updatedTiers[index - 1];
-					previousTier.up_to = newValue;
+					updatedTiers[index - 1] = { ...updatedTiers[index - 1], up_to: newValue };
 				}
+			} else if (key === 'up_to' && isLastTier) {
+				// Clearing the last tier's "up to" reverts it to unbounded (∞) rather than writing
+				// an invalid empty string into a number|null field - matches the "up_to is null for
+				// the last tier" contract, and is the only direct way to re-open a tier that was
+				// just locked to ∞ by deleting the tier that used to be last.
+				updatedTiers[index] = { ...updatedTiers[index], up_to: null };
 			} else {
+				// Any other field being cleared (e.g. backspacing a non-last tier's "up to" mid-edit,
+				// before typing the replacement digits) - allow the transient empty value so the
+				// field can actually be cleared and retyped, instead of silently rejecting the edit.
 				updatedTiers[index] = { ...updatedTiers[index], [key]: '' };
 			}
 			return updatedTiers;
@@ -170,9 +179,8 @@ const VolumeTieredPricingForm: FC<Props> = ({ setTieredPrices, tieredPrices, cur
 										<DecimalUsageInput
 											label=''
 											className='h-9 w-full min-w-0'
-											value={tier.up_to === null ? '∞' : tier.up_to.toString()}
+											value={tier.up_to === null ? '' : tier.up_to.toString()}
 											onChange={(e) => updateTier(index, 'up_to', e)}
-											disabled={tier.up_to === null}
 											precision={3}
 											min={0}
 											placeholder='∞'

--- a/src/components/organisms/Subscription/SubscriptionForm.tsx
+++ b/src/components/organisms/Subscription/SubscriptionForm.tsx
@@ -15,7 +15,7 @@ import { Switch } from '@/components/ui';
 import { cn } from '@/lib/utils';
 import { toSentenceCase, getCurrencySymbol } from '@/utils/common/helper_functions';
 import { PlanResponse } from '@/types';
-import { useMemo, useEffect, useRef, useState } from 'react';
+import { useCallback, useMemo, useEffect, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import SubscriptionCreditGrantTable from '@/components/molecules/CreditGrant/SubscriptionCreditGrantTable';
 import SubscriptionAddonTable from '@/components/molecules/SubscriptionAddonTable/SubscriptionAddonTable';
@@ -48,7 +48,9 @@ import SubscriptionTaxAssociationTable from '@/components/molecules/Subscription
 import PhaseList from './PhaseList';
 import { SubscriptionPhaseCreateRequest, EntitlementOverrideRequest } from '@/types/dto/Subscription';
 import SubscriptionPriceTable from './SubscriptionPriceTable';
-import AddSubscriptionChargeDialog from './AddSubscriptionChargeDialog';
+import AddSubscriptionChargeDialog, { type AddedSubscriptionLineItem } from './AddSubscriptionChargeDialog';
+import type { LineItemCommitmentConfig } from '@/types/dto/LineItemCommitmentConfig';
+import type { CommitmentTimeBucket } from '@/types/dto/CommitmentTimeBucket';
 import { CustomerSearchSelect, InheritedCustomersTable } from '@/components/molecules/Customer';
 import { usePriceOverrides } from '@/hooks/usePriceOverrides';
 import { Coupon } from '@/models/Coupon';
@@ -171,9 +173,13 @@ const SubscriptionForm = ({
 
 	// Current prices for subscription-level and phase management (hook already returns only active prices).
 	// Includes plan one-time (ONETIME) prices for the selected currency regardless of recurring billing period.
-	const currentPrices = selectedPlanPrices?.items
-		? filterPlanPricesForSubscriptionCharges(selectedPlanPrices.items, state.billingPeriod, state.currency)
-		: [];
+	const currentPrices = useMemo(
+		() =>
+			selectedPlanPrices?.items
+				? filterPlanPricesForSubscriptionCharges(selectedPlanPrices.items, state.billingPeriod, state.currency)
+				: [],
+		[selectedPlanPrices?.items, state.billingPeriod, state.currency],
+	);
 
 	const hasFixedSubscriptionChargePrice = useMemo(() => {
 		if (!selectedPlanPrices?.items?.length) return false;
@@ -402,6 +408,71 @@ const SubscriptionForm = ({
 	const [isAddChargeDialogOpen, setAddChargeDialogOpen] = useState(false);
 	// When set, dialog is in edit mode for this added line item (tempId)
 	const [editingAddedChargeTempId, setEditingAddedChargeTempId] = useState<string | null>(null);
+
+	// Stable identities so SubscriptionPriceTable's row memoization isn't invalidated by every
+	// unrelated SubscriptionForm re-render (was rebuilding every price row on any state change,
+	// e.g. applying a discount to a single line item re-rendered the whole table).
+	const handleLineItemCouponsChange = useCallback(
+		(priceId: string, coupon: Coupon | null) => {
+			setState((prev) => {
+				const newLineItemCoupons = { ...prev.lineItemCoupons };
+				if (coupon) {
+					newLineItemCoupons[priceId] = coupon;
+				} else {
+					delete newLineItemCoupons[priceId];
+				}
+				return {
+					...prev,
+					lineItemCoupons: newLineItemCoupons,
+				};
+			});
+		},
+		[setState],
+	);
+
+	const handleCommitmentChange = useCallback(
+		(priceId: string, config: LineItemCommitmentConfig | null, timeBuckets?: CommitmentTimeBucket[]) => {
+			if (config) {
+				overridePrice(priceId, {
+					commitment: config,
+					commitment_time_buckets: timeBuckets === undefined ? undefined : timeBuckets.length > 0 ? timeBuckets : undefined,
+				});
+			} else {
+				const currentOverride = overriddenPrices[priceId];
+				if (currentOverride) {
+					const restOverride = { ...currentOverride };
+					delete restOverride.commitment;
+					delete restOverride.commitment_time_buckets;
+					if (Object.keys(restOverride).length > 1) {
+						overridePrice(priceId, restOverride);
+					} else {
+						resetOverride(priceId);
+					}
+				}
+			}
+		},
+		[overridePrice, overriddenPrices, resetOverride],
+	);
+
+	const handleAddCharge = useCallback(() => {
+		setEditingAddedChargeTempId(null);
+		setAddChargeDialogOpen(true);
+	}, []);
+
+	const handleRemoveAddedCharge = useCallback(
+		(tempId: string) => {
+			setState((prev) => ({
+				...prev,
+				addedSubscriptionLineItems: (prev.addedSubscriptionLineItems ?? []).filter((i) => i.tempId !== tempId),
+			}));
+		},
+		[setState],
+	);
+
+	const handleEditAddedCharge = useCallback((item: AddedSubscriptionLineItem) => {
+		setEditingAddedChargeTempId(item.tempId);
+		setAddChargeDialogOpen(true);
+	}, []);
 
 	// Combine plan credit grants with user-added credit grants (all editable now)
 	const relevantCreditGrants = useMemo(() => {
@@ -720,57 +791,14 @@ const SubscriptionForm = ({
 							onResetOverride={resetOverride}
 							overriddenPrices={overriddenPrices}
 							lineItemCoupons={state.lineItemCoupons}
-							onLineItemCouponsChange={(priceId, coupon) => {
-								setState((prev) => {
-									const newLineItemCoupons = { ...prev.lineItemCoupons };
-									if (coupon) {
-										newLineItemCoupons[priceId] = coupon;
-									} else {
-										delete newLineItemCoupons[priceId];
-									}
-									return {
-										...prev,
-										lineItemCoupons: newLineItemCoupons,
-									};
-								});
-							}}
-							onCommitmentChange={(priceId, config, timeBuckets) => {
-								if (config) {
-									overridePrice(priceId, {
-										commitment: config,
-										commitment_time_buckets: timeBuckets === undefined ? undefined : timeBuckets.length > 0 ? timeBuckets : undefined,
-									});
-								} else {
-									const currentOverride = overriddenPrices[priceId];
-									if (currentOverride) {
-										const restOverride = { ...currentOverride };
-										delete restOverride.commitment;
-										delete restOverride.commitment_time_buckets;
-										if (Object.keys(restOverride).length > 1) {
-											overridePrice(priceId, restOverride);
-										} else {
-											resetOverride(priceId);
-										}
-									}
-								}
-							}}
+							onLineItemCouponsChange={handleLineItemCouponsChange}
+							onCommitmentChange={handleCommitmentChange}
 							disabled={isDisabled}
 							subscriptionLevelCoupon={state.linkedCoupon}
 							addedLineItems={state.addedSubscriptionLineItems}
-							onAddCharge={() => {
-								setEditingAddedChargeTempId(null);
-								setAddChargeDialogOpen(true);
-							}}
-							onRemoveAddedCharge={(tempId) =>
-								setState((prev) => ({
-									...prev,
-									addedSubscriptionLineItems: (prev.addedSubscriptionLineItems ?? []).filter((i) => i.tempId !== tempId),
-								}))
-							}
-							onEditAddedCharge={(item) => {
-								setEditingAddedChargeTempId(item.tempId);
-								setAddChargeDialogOpen(true);
-							}}
+							onAddCharge={handleAddCharge}
+							onRemoveAddedCharge={handleRemoveAddedCharge}
+							onEditAddedCharge={handleEditAddedCharge}
 						/>
 					</div>
 

--- a/src/components/organisms/Subscription/SubscriptionForm.tsx
+++ b/src/components/organisms/Subscription/SubscriptionForm.tsx
@@ -838,12 +838,20 @@ const SubscriptionForm = ({
 						onConvertToPhases={() => {
 							// Clear subscription-level data after conversion
 							// IMPORTANT: Clear endDate to avoid deadlock when adding more phases
+							// Phases have no equivalent of subscription-level "added charges" (AddSubscriptionChargeDialog
+							// is hidden once phases.length > 0, and the create payload's line_items is always omitted
+							// when phases are present - see CreateCustomerSubscriptionPage). Warn and clear them here
+							// instead of letting them silently vanish from the payload at submit time.
+							if ((state.addedSubscriptionLineItems?.length ?? 0) > 0) {
+								toast.error(t('organisms.subscriptionForm.addedChargesLostOnPhaseConversion'));
+							}
 							setState((prev) => ({
 								...prev,
 								endDate: undefined,
 								linkedCoupon: null,
 								lineItemCoupons: {},
 								priceOverrides: {},
+								addedSubscriptionLineItems: [],
 							}));
 						}}
 						onConvertBackToSubscription={(subscriptionData) => {

--- a/src/i18n/locales/ar/customers.json
+++ b/src/i18n/locales/ar/customers.json
@@ -507,7 +507,8 @@
 			"autoInvoiceHelp": "مبلغ الاستخدام الذي قد يستدعي فاتورة قبل نهاية الفترة. متاح عند الرسوم بالاستخدام؛ الرسوم الثابتة تعطّله.",
 			"autoInvoicePlaceholder": "100.00",
 			"autoInvoiceAmountAria": "مبلغ حد الفاتورة التلقائية",
-			"planNoCharges": "لا توجد رسوم مضافة إلى هذه الخطة"
+			"planNoCharges": "لا توجد رسوم مضافة إلى هذه الخطة",
+			"addedChargesLostOnPhaseConversion": "الرسوم المضافة غير مدعومة في الاشتراكات المرحلية وتمت إزالتها. أضفها مرة أخرى ضمن مرحلة، أو بعد إنشاء الاشتراك."
 		},
 		"subscriptionPriceTable": {
 			"overridePrice": "تجاوز السعر",

--- a/src/i18n/locales/en/customers.json
+++ b/src/i18n/locales/en/customers.json
@@ -485,7 +485,8 @@
 			"autoInvoiceHelp": "Usage amount that can trigger an invoice before the period ends. Available when charges are usage-based; fixed-price subscription charges disable this field.",
 			"autoInvoicePlaceholder": "100.00",
 			"autoInvoiceAmountAria": "Auto invoice threshold amount",
-			"planNoCharges": "No charges added to this plan"
+			"planNoCharges": "No charges added to this plan",
+			"addedChargesLostOnPhaseConversion": "Added charges are not supported in phased subscriptions and have been removed. Add them again within a phase, or after the subscription is created."
 		},
 		"subscriptionPriceTable": {
 			"overridePrice": "Override Price",


### PR DESCRIPTION
## **User description**
## Summary

Two unrelated bugs fixed together since they surfaced in the same investigation pass:

### 1. Tiered pricing: last tier's "up to" stuck at ∞/disabled after deleting a tier
The last tier in a `VOLUME`/`SLAB` tiered price is meant to be unbounded (`up_to: null`) — that's correct. But the field showing that row was hard `disabled` whenever its value was `null`, with no direct way to re-bound it after deleting the tier that used to be last (the only workaround was an indirect side effect of clicking "Add Tier"). That's the reported "cannot edit the above tier value" bug.

- The last tier's "up to" field is now directly editable. Typing a number bounds it; clearing it reverts to unbounded (∞).
- Fixed two in-place array/object mutations in `addTieredPrice`/`removeTier`/`updateTier` (assigning through an index into the `prev` state array instead of building a new array — a latent React anti-pattern, same function).
- Tiers loaded from the backend in edit mode are now normalized so only the actual last tier can have `up_to: null` — a stray null on a non-last tier (bad/old data) would otherwise lock that row regardless of position, which is the most likely explanation for a screenshot showing a *non-last* row disabled.

### 2. Create-subscription page freezes when applying a discount to a line item
- `SubscriptionForm`'s `currentPrices` was rebuilt with a new array identity on every render (unlike the near-identical, already-memoized `hasFixedSubscriptionChargePrice` right below it), and the 5 handlers passed to `SubscriptionPriceTable` were fresh closures every render. Together these invalidated `SubscriptionPriceTable`'s row-level memoization on *any* unrelated state change, so applying a discount to one line item re-rendered every price row — cost scaling with plan size, which is why this reads as a "freeze" on realistic multi-charge plans. Wrapped `currentPrices` in `useMemo` and the handlers in `useCallback`.
- `LineItemCoupon`'s coupon-list query had no `staleTime`, so it re-fetched up to 1000 coupons from the network every time the picker opened for a different line item. Added a 60s `staleTime`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (only pre-existing warnings, verified via diff)
- [x] `npm run build` succeeds
- [x] Verified in Storybook: delete the last tier → the row above becomes the new unbounded/editable last tier; confirmed a non-last tier's field can still be cleared and retyped normally (caught and fixed a regression in my first pass where clearing a non-last tier's field became a no-op)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Coupon information now loads more efficiently when revisiting the coupon selector.
  - Improved editing of tiered pricing, including safer handling of tier boundaries and open-ended final tiers.
  - The final tier’s upper limit can now be cleared to create an unlimited tier.
  - Tier additions, removals, and edits now preserve pricing information more reliably.
  - Subscription pricing forms now handle coupon, commitment, and additional-charge interactions more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Fix tiered-price editing and prevent subscription form freezes

### What Changed
- The final tier’s limit can now be entered or cleared directly; clearing it restores an unbounded tier.
- Tiered prices loaded from existing plans are corrected when a non-final tier is missing its boundary, and incomplete non-final tiers now show a validation error before saving.
- Applying a discount to one subscription line item no longer re-renders the entire price table, preventing freezes on subscriptions with many charges.
- Coupon lists remain available for 60 seconds when opening pickers across line items, reducing repeated network requests while keeping date-based coupon validity current.
- Converting a subscription with added charges into phased billing now removes unsupported charges with a clear warning instead of silently losing them.

### Impact
`✅ Editable final tier limits`
`✅ Fewer subscription form freezes`
`✅ Fewer repeated coupon-list requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
