### PR TITLE
Release (11-Aug-2026)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10207,9 +10207,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7977,9 +7977,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/src/components/molecules/WhopConnectionDrawer/WhopConnectionDrawer.tsx
+++ b/src/components/molecules/WhopConnectionDrawer/WhopConnectionDrawer.tsx
@@ -23,6 +23,7 @@ interface WhopFormData {
 	api_key: string;
 	company_id: string;
 	product_id: string;
+	webhook_secret: string;
 	sync_config: {
 		invoice: boolean;
 	};
@@ -43,6 +44,7 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 		api_key: '',
 		company_id: '',
 		product_id: '',
+		webhook_secret: '',
 		sync_config: {
 			invoice: false,
 		},
@@ -59,6 +61,7 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 					api_key: '',
 					company_id: encryptedData.company_id || '',
 					product_id: encryptedData.product_id || '',
+					webhook_secret: '',
 					sync_config: {
 						invoice: syncConfig.invoice?.outbound || false,
 					},
@@ -69,6 +72,7 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 					api_key: '',
 					company_id: '',
 					product_id: '',
+					webhook_secret: '',
 					sync_config: { invoice: false },
 				});
 			}
@@ -92,6 +96,7 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 		if (!connection) {
 			if (!formData.api_key.trim()) newErrors.api_key = t('connection.validation.apiKeyRequiredUpper');
 			if (!formData.company_id.trim()) newErrors.company_id = t('connection.whop.companyIdRequired');
+			if (!formData.webhook_secret.trim()) newErrors.webhook_secret = t('connection.validation.webhookSecretRequired');
 		}
 		setErrors(newErrors);
 		return Object.keys(newErrors).length === 0;
@@ -104,8 +109,9 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 				provider_type: CONNECTION_PROVIDER_TYPE.WHOP,
 				encrypted_secret_data: {
 					provider_type: CONNECTION_PROVIDER_TYPE.WHOP,
-					api_key: formData.api_key,
-					company_id: formData.company_id,
+					api_key: formData.api_key.trim(),
+					company_id: formData.company_id.trim(),
+					webhook_secret: formData.webhook_secret.trim(),
 					...(formData.product_id.trim() ? { product_id: formData.product_id.trim() } : {}),
 				},
 				sync_config: {} as Record<string, { inbound: boolean; outbound: boolean }>,
@@ -134,8 +140,19 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 			if (formData.sync_config.invoice) {
 				payload.sync_config.invoice = { inbound: false, outbound: true };
 			}
-			if (formData.product_id.trim()) {
-				payload.encrypted_secret_data = { product_id: formData.product_id.trim() };
+			// EE UpdateConnection merges Whop webhook_secret only (flat or nested). Always send
+			// product_id (including "") so a clear is explicit if/when the backend persists it.
+			const originalProductId = String(connection?.encrypted_secret_data?.product_id ?? '').trim();
+			const nextProductId = formData.product_id.trim();
+			const whopUpdate: Record<string, string> = {};
+			if (nextProductId !== originalProductId) {
+				whopUpdate.product_id = nextProductId;
+			}
+			if (formData.webhook_secret.trim()) {
+				whopUpdate.webhook_secret = formData.webhook_secret.trim();
+			}
+			if (Object.keys(whopUpdate).length > 0) {
+				payload.encrypted_secret_data = { whop: whopUpdate };
 			}
 			return await ConnectionApi.Update(connection.id, payload);
 		},
@@ -242,12 +259,21 @@ const WhopConnectionDrawer: FC<WhopConnectionDrawerProps> = ({ isOpen, onOpenCha
 				{/* Webhook Section */}
 				<div className='p-4 bg-info-muted border border-info-line rounded-lg'>
 					<h3 className='text-sm font-medium text-info-deep mb-2'>{t('connection.webhook.sectionTitle')}</h3>
-					<p className='text-xs text-info-strong mb-3'>
-						{t('connection.whop.webhookIntroPrefix')} <code className='font-mono'>{t('connection.whop.webhookEventName')}</code>{' '}
-						{t('connection.whop.webhookIntroSuffix')}
-					</p>
-					<div>
+					<div className='mb-3 space-y-2'>
+						<Input
+							label={t('connection.whop.webhookSecret')}
+							type='password'
+							placeholder={
+								connection ? t('connection.whop.webhookSecretPlaceholderEdit') : t('connection.whop.webhookSecretPlaceholderCreate')
+							}
+							value={formData.webhook_secret}
+							onChange={(value) => handleChange('webhook_secret', value)}
+							error={errors.webhook_secret}
+							className='text-info-deep'
+							description={connection ? t('connection.whop.webhookSecretDescEdit') : t('connection.whop.webhookSecretDescCreate')}
+						/>
 						<label className='text-sm font-medium text-info-deep mb-2 block'>{t('connection.webhook.url')}</label>
+
 						<div className='flex items-center gap-2 p-2 bg-surface border border-info-line rounded-md'>
 							<code className='flex-1 text-xs text-content-heading font-mono break-all'>{webhookUrl}</code>
 							<Button size='xs' variant='outline' onClick={handleCopyWebhookUrl} className='flex items-center gap-1'>

--- a/src/i18n/locales/ar/settings.json
+++ b/src/i18n/locales/ar/settings.json
@@ -958,9 +958,11 @@
 			"productIdPlaceholder": "prod_... — اتركه فارغاً للإنشاء التلقائي",
 			"productIdHint": "منتج Whop المستخدم للفواتير. اتركه فارغاً لينشئ Flexprice واحداً تلقائياً.",
 			"invoiceSyncHint": "ادفع فواتير Flexprice إلى Whop كمدفوعات send_invoice",
-			"webhookIntroPrefix": "سجّل هذا العنوان في لوحة Whop ضمن Webhooks. سيتابع Flexprice",
-			"webhookEventName": "invoice.paid",
-			"webhookIntroSuffix": "لتحديث حالة الفاتورة تلقائياً عند الدفع."
+			"webhookSecret": "سرّ الويب هوك",
+			"webhookSecretPlaceholderCreate": "سرّ توقيع الويب هوك من Whop",
+			"webhookSecretPlaceholderEdit": "اتركه فارغاً للإبقاء على السرّ، أو أدخل سراً جديداً للتدوير",
+			"webhookSecretDescCreate": "مطلوب للتحقق من توقيع الويب هوك. يجب أن يطابق السرّ المُعدّ في Whop، ويُخزَّن مشفّراً بأمان مع الاتصال.",
+			"webhookSecretDescEdit": "مُخزَّن مشفّراً. اتركه فارغاً عند التحديث للإبقاء على السرّ الحالي."
 		},
 		"tabs": {
 			"description": "اضبط تكامل Tabs باستخدام بيانات الاعتماد المطلوبة.",
@@ -1308,6 +1310,31 @@
 						"webhooksPaddle": {
 							"title": "تكامل الويبهوك",
 							"paragraphs": ["استقبل إشعارات فورية عن أحداث الدفع عبر الويبهوك؛ اشترك في حدث transactions.completed لمتابعة حالة الدفع."]
+						}
+					}
+				},
+				"whop": {
+					"name": "Whop",
+					"description": "زامن الفواتير مع Whop مع تحديثات تلقائية لحالة الدفع.",
+					"sections": {
+						"overview": {
+							"title": "نظرة عامة",
+							"paragraphs": [
+								"يتيح تكامل Flexprice مع Whop إرسال الفواتير مباشرة إلى Whop كمدفوعات send_invoice لمرة واحدة. يدفع العملاء عبر صفحة الدفع المستضافة على Whop، ويتحدّث Flexprice تلقائياً عند استلام الدفع."
+							]
+						},
+						"invoiceSync": {
+							"title": "مزامنة الفواتير",
+							"paragraphs": [
+								"عند تفعيل مزامنة الفواتير، ينشئ Flexprice تلقائياً فاتورة مقابلة في Whop كلما اكتملت فاتورة في Flexprice. يضمن التكامل وجود منتج Whop (وينشئ واحداً عند الحاجة).",
+								"يمكنك أيضاً تعليم فاتورة Whop كمدفوعة من Flexprice، والذي يستدعي واجهة mark_paid في Whop نيابةً عنك."
+							]
+						},
+						"webhooks": {
+							"title": "الويبهوك",
+							"paragraphs": [
+								"سجّل عنوان ويبهوك Flexprice في إعدادات مطور Whop، واشترك في invoice.paid، واستخدم نفس سرّ توقيع الويبهوك في Flexprice. عند إطلاق Whop لهذا الحدث، يتحقق Flexprice من التوقيع، ويعلّم الفاتورة المقابلة كمدفوعة، ويسجّل الدفع."
+							]
 						}
 					}
 				},

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -955,9 +955,11 @@
 			"productIdPlaceholder": "prod_... — leave blank to auto-create",
 			"productIdHint": "Whop product used for invoices. Leave blank to have Flexprice create one automatically.",
 			"invoiceSyncHint": "Push Flexprice invoices to Whop as send_invoice payments",
-			"webhookIntroPrefix": "Register this URL in your Whop dashboard under Webhooks. Flexprice will listen for",
-			"webhookEventName": "invoice.paid",
-			"webhookIntroSuffix": "events to automatically mark invoices as paid."
+			"webhookSecret": "Webhook Secret",
+			"webhookSecretPlaceholderCreate": "Webhook signing secret from Whop",
+			"webhookSecretPlaceholderEdit": "Leave blank to keep existing secret, or enter a new secret to rotate",
+			"webhookSecretDescCreate": "Required for webhook verification. Must match the secret configured in Whop. Stored encrypted.",
+			"webhookSecretDescEdit": "Stored encrypted. Leave blank to keep the current secret when updating."
 		},
 		"tabs": {
 			"description": "Configure your Tabs integration with the required credentials.",
@@ -1374,7 +1376,7 @@
 						"webhooks": {
 							"title": "Webhooks",
 							"paragraphs": [
-								"Register the Flexprice webhook URL in your Whop developer settings to receive invoice.paid events. When Whop fires this event, Flexprice automatically marks the corresponding invoice as paid and records the payment."
+								"Register the Flexprice webhook URL in your Whop developer settings, subscribe to invoice.paid, and use the same webhook signing secret in Flexprice. When Whop fires this event, Flexprice verifies the signature, marks the corresponding invoice as paid, and records the payment."
 							]
 						}
 					}

--- a/src/types/dto/Connection.ts
+++ b/src/types/dto/Connection.ts
@@ -104,6 +104,13 @@ export interface CreateConnectionPayload {
 				client_secret?: string;
 		  }
 		| {
+				provider_type: CONNECTION_PROVIDER_TYPE.WHOP;
+				api_key?: string;
+				company_id?: string;
+				product_id?: string;
+				webhook_secret?: string;
+		  }
+		| {
 				api_key?: string;
 				webhook_secret?: string;
 		  };


### PR DESCRIPTION
* fix(deps): bump dompurify to 3.4.13 to patch XSS advisory (#1240)

Resolves GHSA-55q2-fjhq-7xh7 (Dependabot alert #151): a hook-detached subtree could skip IN_PLACE sanitization neutralization, leaving an attacker-controlled onload handler executable after sanitize() returns. Transitive via posthog-js (dompurify: ^3.3.2), so only the lockfile resolution changes.




* feat(whop): add webhook secret field to Whop connection drawer

* refactor(whop): remove unused translation and update webhook descriptions in WhopConnectionDrawer

* fix(whop): trim whitespace from API keys and update payload structure for Whop connection

---------