### PR TITLE
fix: address CodeRabbit review comments on PR #1250

### DIFF
--- a/.github/workflows/publish-flexprice-ui.yml
+++ b/.github/workflows/publish-flexprice-ui.yml
@@ -56,10 +56,10 @@ jobs:
           NAME=$(node -p "require('./package.json').name")
           VER=$(node -p "require('./package.json').version")
           # Only main (prod) publishes — guards workflow_dispatch runs triggered from any other
-          # branch too, not just the push trigger above. $GITHUB_REF_NAME is a built-in env var —
-          # read it here instead of interpolating ${{ github.ref_name }} into the script (avoids
-          # a shell-injection surface).
-          if [ "$GITHUB_REF_NAME" != "main" ]; then
+          # ref too, not just the push trigger above. Compare the full ref so a tag named "main"
+          # can't slip through, and read it via the built-in GITHUB_REF env var instead of an
+          # inline expression (avoids a shell-injection surface).
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
             echo "Not on main ($GITHUB_REF_NAME) — skipping publish."
             exit 0
           fi

--- a/docs/superpowers/specs/2026-08-08-exportable-usage-credits-invoices-design.md
+++ b/docs/superpowers/specs/2026-08-08-exportable-usage-credits-invoices-design.md
@@ -32,7 +32,7 @@ The target UI already exists as dashboard-internal widgets in `src/components/cu
 
 Four new top-level feature directories, each mirroring `src/pricing/`'s shape (this is also what the placeholder comments in `src/exportable/index.ts` already anticipate — `@/usage/lib`, etc.):
 
-```
+```text
 src/usage/
   types.ts / adapters.ts / schema.ts / i18n.ts / lib.ts
   components/
@@ -72,7 +72,7 @@ All new components use Tailwind utility classes bound to the existing `--brand` 
 
 ## Data flow & validation boundary
 
-```
+```text
 Internal (dashboard) path:
   API DTO → adapter (validates + normalizes + maps to Presentational Model) → Container → Component → normalize() safety-net (no-op on already-valid data) → render
 

--- a/packages/flexprice-ui/README.md
+++ b/packages/flexprice-ui/README.md
@@ -1,8 +1,8 @@
 # @flexprice/ui
 
-Drop-in **React** components for pricing pages, extracted from the Flexprice dashboard so your
-app renders the exact same pricing UI. **Bring your own data** — the components are purely
-presentational (no fetching, no auth, no routing).
+Drop-in **React** components extracted from the Flexprice dashboard, so your app renders the
+exact same UI: pricing, usage, and credits widgets. **Bring your own data** — the components are
+purely presentational (no fetching, no auth, no routing).
 
 ## Install
 
@@ -10,7 +10,7 @@ presentational (no fetching, no auth, no routing).
 npm install @flexprice/ui
 ```
 
-`react` and `react-dom` (v18) are peer dependencies.
+`react` and `react-dom` (v18 or v19) are peer dependencies.
 
 ## Usage
 
@@ -59,6 +59,34 @@ const cards = filterAndSortPlans(plansWithData, 'USD', 'MONTHLY').map((p) => ada
 ```
 
 Or build the `Plan` objects yourself — see the exported `Plan` / `Feature` types.
+
+## Usage widgets
+
+`UsageQuota`, `MetricCards`, `UsageTrendChart`, and `UsageBreakdown` render usage/cost analytics.
+Each takes a presentational prop shape (`UsageQuotaItem`, `MetricCardItem`, `UsageTrendSeries`,
+`UsageBreakdownRow`) — map your own data to these, or use the exported adapters
+(`adaptUsageQuotaItems`, `adaptMetricCards`, `adaptUsageTrendSeries`, `adaptUsageBreakdownRows`)
+against raw Flexprice API responses. `normalizeUsageQuotaItems` and friends are a runtime safety
+net you can call on untrusted/BYO data before rendering.
+
+```tsx
+import { UsageQuota, adaptUsageQuotaItems } from '@flexprice/ui';
+
+<UsageQuota items={adaptUsageQuotaItems(customerUsageFromApi)} />;
+```
+
+## Credits widgets
+
+`CreditBalance` and `CreditHistory` render wallet balance and transaction history. They take
+`CreditBalanceData` / `CreditTransaction[]` — map your own data, or use `adaptCreditBalance`,
+`adaptCreditTransactions`, and `adaptWalletOptions` against raw Flexprice wallet responses.
+`normalizeCreditBalanceData` and `normalizeCreditTransactions` are the same runtime safety net.
+
+```tsx
+import { CreditBalance, adaptCreditBalance } from '@flexprice/ui';
+
+<CreditBalance wallet={adaptCreditBalance(walletFromApi)} />;
+```
 
 ## Theming
 

--- a/packages/flexprice-ui/package.json
+++ b/packages/flexprice-ui/package.json
@@ -31,8 +31,8 @@
 		"dist"
 	],
 	"peerDependencies": {
-		"react": "^18",
-		"react-dom": "^18"
+		"react": "^18 || ^19",
+		"react-dom": "^18 || ^19"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/src/components/atoms/ShortPagination/ShortPaginationControls.test.tsx
+++ b/src/components/atoms/ShortPagination/ShortPaginationControls.test.tsx
@@ -41,4 +41,18 @@ describe('ShortPaginationControls', () => {
 		render(<ShortPaginationControls page={1} pageSize={10} totalItems={25} onPageChange={vi.fn()} unit='items' />);
 		expect(screen.getByText('Showing 1 to 10 of 25 items')).toBeInTheDocument();
 	});
+
+	it('resyncs the controlled page to 1 when the total shrinks below the current page (page 2 -> page 1)', () => {
+		const onPageChange = vi.fn();
+		// page=2 with pageSize=10 was valid when totalItems was e.g. 15; after a delete/filter drops
+		// totalItems to 5, page 2 no longer exists — the component must clamp and notify the parent.
+		render(<ShortPaginationControls page={2} pageSize={10} totalItems={5} onPageChange={onPageChange} unit='items' />);
+		expect(onPageChange).toHaveBeenCalledWith(1);
+	});
+
+	it('does not call onPageChange when the current page is already in range', () => {
+		const onPageChange = vi.fn();
+		render(<ShortPaginationControls page={1} pageSize={10} totalItems={25} onPageChange={onPageChange} unit='items' />);
+		expect(onPageChange).not.toHaveBeenCalled();
+	});
 });

--- a/src/components/atoms/ShortPagination/ShortPaginationControls.tsx
+++ b/src/components/atoms/ShortPagination/ShortPaginationControls.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -26,6 +27,12 @@ export const ShortPaginationControls = ({
 	const effectivePageSize = Math.max(1, pageSize);
 	const totalPages = Math.max(1, Math.ceil(totalItems / effectivePageSize));
 	const clampedPage = Math.min(Math.max(1, page), totalPages);
+
+	// The controlled `page` can go stale (e.g. the total shrinks below it after a delete/filter) —
+	// resync the parent to the clamped value so it doesn't keep requesting an out-of-range page.
+	useEffect(() => {
+		if (page !== clampedPage) onPageChange(clampedPage);
+	}, [page, clampedPage, onPageChange]);
 
 	const handlePageChange = (newPage: number) => {
 		if (newPage < 1 || newPage > totalPages) return;

--- a/src/credits/components/CreditHistory.tsx
+++ b/src/credits/components/CreditHistory.tsx
@@ -98,21 +98,24 @@ const CreditHistory = ({
 				</div>
 				<div className='p-6'>
 					{transactions.length > 0 ? (
-						<>
-							<WalletTransactionsTable data={tableData} />
-							<ShortPaginationControls
-								page={page}
-								onPageChange={onPageChange}
-								totalItems={totalItems}
-								pageSize={pageSize}
-								unit={t('creditWidgets.transactionsUnit')}
-							/>
-						</>
+						<WalletTransactionsTable data={tableData} />
 					) : (
 						<div className='flex flex-col items-center justify-center py-16 px-4'>
 							<p className='text-sm font-medium text-content-secondary mb-1'>{t('creditWidgets.noTransactionsTitle')}</p>
 							<p className='text-xs text-content-muted text-center max-w-sm mt-1'>{t('creditWidgets.noTransactionsDescription')}</p>
 						</div>
+					)}
+					{/* Rendered on totalItems, not the current page's row count, so a stale out-of-range
+					    page (e.g. after a delete/filter shrinks the total) still shows pagination and
+					    lets ShortPaginationControls' own resync effect clamp `page` back into range. */}
+					{totalItems > 0 && (
+						<ShortPaginationControls
+							page={page}
+							onPageChange={onPageChange}
+							totalItems={totalItems}
+							pageSize={pageSize}
+							unit={t('creditWidgets.transactionsUnit')}
+						/>
 					)}
 				</div>
 			</Card>

--- a/src/credits/schema.test.tsx
+++ b/src/credits/schema.test.tsx
@@ -16,8 +16,7 @@ describe('normalizeCreditBalanceData', () => {
 			creditBalance: 1,
 			balance: 1,
 			currency: 'USD',
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any);
+		});
 		expect(result.status).toBe('active');
 	});
 
@@ -29,15 +28,13 @@ describe('normalizeCreditBalanceData', () => {
 			creditBalance: 'oops',
 			balance: null,
 			currency: 'USD',
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any);
+		});
 		expect(result.creditBalance).toBe(0);
 		expect(result.balance).toBe(0);
 	});
 
 	it('repairs a missing id to empty string rather than throwing (single-object path never drops)', () => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const result = normalizeCreditBalanceData({ name: 'X', status: 'active', creditBalance: 1, balance: 1, currency: 'USD' } as any);
+		const result = normalizeCreditBalanceData({ name: 'X', status: 'active', creditBalance: 1, balance: 1, currency: 'USD' });
 		expect(result.id).toBe('');
 	});
 });
@@ -51,16 +48,12 @@ describe('normalizeCreditTransactions', () => {
 	it('normalizes a null currency to undefined, not the string "null"', () => {
 		const result = normalizeCreditTransactions([
 			{ id: 't1', type: 'credit', amount: 1, creditAmount: 1, reason: 'X', createdAt: '', currency: null },
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		] as any);
+		]);
 		expect(result[0].currency).toBeUndefined();
 	});
 
 	it('falls back an invalid type to credit', () => {
-		const result = normalizeCreditTransactions([
-			{ id: 't1', type: 'bogus', amount: 1, creditAmount: 1, reason: 'X', createdAt: '' },
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		] as any);
+		const result = normalizeCreditTransactions([{ id: 't1', type: 'bogus', amount: 1, creditAmount: 1, reason: 'X', createdAt: '' }]);
 		expect(result[0].type).toBe('credit');
 	});
 });

--- a/src/exportable/index.ts
+++ b/src/exportable/index.ts
@@ -1,9 +1,11 @@
 // @flexprice/ui — THE PUBLISHED PACKAGE ENTRY (umbrella).
 //
 // `npm i @flexprice/ui` gives a consumer every exportable Flexprice UI component from
-// one import. Today that's the pricing widget; as more components are made exportable, add one
-// line here (e.g. `export * from '@/checkout/lib';`) and its content globs to
-// tailwind.flexprice-ui.config.js — nothing else changes.
+// one import: pricing (PricingTable, PricingCard), usage (UsageQuota, MetricCards,
+// UsageTrendChart, UsageBreakdown), and credits (CreditBalance, CreditHistory). As more
+// components are made exportable, add one line here (e.g. `export * from '@/checkout/lib';`)
+// plus its content glob to `tailwind.flexprice-ui.config.js` and its `dtsInclude` entry in
+// `vite.flexprice-ui.config.ts` — nothing else changes.
 //
 // Each feature owns its own public surface in `src/<feature>/lib.ts` (UI-only, no data layer).
 // This file only aggregates them and ships the shared stylesheet.

--- a/src/usage/adapters.test.tsx
+++ b/src/usage/adapters.test.tsx
@@ -1,48 +1,108 @@
 import { describe, it, expect } from 'vitest';
-import { FEATURE_TYPE } from '@/models/Feature';
+import { FEATURE_TYPE, type Feature } from '@/models/Feature';
+import { ENTITY_STATUS } from '@/models/base';
+import type { CustomerUsage, UsageAnalyticItem } from '@/models';
+import type { Group } from '@/models/Group';
+import { GROUP_ENTITY_TYPE } from '@/models/Group';
 import { adaptUsageQuotaItems, adaptMetricCards, adaptUsageTrendSeries, adaptUsageBreakdownRows } from './adapters';
+
+function makeFeature(overrides: Partial<Feature> = {}): Feature {
+	return {
+		id: 'feat_x',
+		created_at: '',
+		updated_at: '',
+		created_by: '',
+		updated_by: '',
+		tenant_id: '',
+		status: ENTITY_STATUS.PUBLISHED,
+		environment_id: '',
+		name: '',
+		description: '',
+		meter_id: '',
+		metadata: {},
+		type: FEATURE_TYPE.METERED,
+		unit_plural: '',
+		unit_singular: '',
+		...overrides,
+	};
+}
+
+function makeCustomerUsage(overrides: Partial<CustomerUsage> = {}): CustomerUsage {
+	return {
+		id: 'ent_x',
+		created_at: '',
+		updated_at: '',
+		created_by: '',
+		updated_by: '',
+		tenant_id: '',
+		status: ENTITY_STATUS.PUBLISHED,
+		environment_id: '',
+		feature: makeFeature(),
+		total_limit: null,
+		is_unlimited: false,
+		current_usage: 0,
+		usage_percent: 0,
+		is_enabled: true,
+		is_soft_limit: false,
+		next_usage_reset_at: null,
+		sources: [],
+		...overrides,
+	};
+}
+
+function makeGroup(overrides: Partial<Group> = {}): Group {
+	return {
+		id: 'grp_x',
+		created_at: '',
+		updated_at: '',
+		created_by: '',
+		updated_by: '',
+		tenant_id: '',
+		status: ENTITY_STATUS.PUBLISHED,
+		environment_id: '',
+		name: '',
+		lookup_key: '',
+		entity_type: GROUP_ENTITY_TYPE.FEATURE,
+		entity_ids: [],
+		metadata: null,
+		...overrides,
+	};
+}
+
+function makeUsageAnalyticItem(overrides: Partial<UsageAnalyticItem> = {}): UsageAnalyticItem {
+	return {
+		feature_id: 'feat_x',
+		total_usage: 0,
+		total_cost: 0,
+		event_count: 0,
+		...overrides,
+	};
+}
 
 describe('adaptUsageQuotaItems', () => {
 	it('keeps only metered entitlements and maps limit/unlimited', () => {
 		const result = adaptUsageQuotaItems([
-			{
+			makeCustomerUsage({
 				id: 'ent_1',
-				feature: { id: 'feat_1', name: 'API Calls', type: FEATURE_TYPE.METERED },
+				feature: makeFeature({ id: 'feat_1', name: 'API Calls', type: FEATURE_TYPE.METERED }),
 				total_limit: 1000,
 				is_unlimited: false,
 				current_usage: 250,
 				usage_percent: 25,
-				is_enabled: true,
-				is_soft_limit: false,
-				next_usage_reset_at: null,
-				sources: [],
-			},
-			{
+			}),
+			makeCustomerUsage({
 				id: 'ent_2',
-				feature: { id: 'feat_2', name: 'Seats', type: FEATURE_TYPE.STATIC },
+				feature: makeFeature({ id: 'feat_2', name: 'Seats', type: FEATURE_TYPE.STATIC }),
 				total_limit: null,
-				is_unlimited: false,
-				current_usage: 0,
-				usage_percent: 0,
-				is_enabled: true,
-				is_soft_limit: false,
-				next_usage_reset_at: null,
-				sources: [],
-			},
-			{
+			}),
+			makeCustomerUsage({
 				id: 'ent_3',
-				feature: { id: 'feat_3', name: 'Storage', type: FEATURE_TYPE.METERED },
+				feature: makeFeature({ id: 'feat_3', name: 'Storage', type: FEATURE_TYPE.METERED }),
 				total_limit: null,
 				is_unlimited: true,
 				current_usage: 42,
-				usage_percent: 0,
-				is_enabled: true,
-				is_soft_limit: false,
-				next_usage_reset_at: null,
-				sources: [],
-			},
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		] as any);
+			}),
+		]);
 
 		expect(result).toEqual([
 			{ id: 'feat_1', name: 'API Calls', currentUsage: 250, limit: 1000, isUnlimited: false },
@@ -110,16 +170,15 @@ describe('adaptMetricCards', () => {
 });
 
 describe('adaptUsageTrendSeries', () => {
-	const items = [
-		{
+	const items: UsageAnalyticItem[] = [
+		makeUsageAnalyticItem({
 			feature_id: 'feat_1',
 			source: 'feat_1',
 			name: 'API Calls',
 			points: [{ timestamp: '2026-01-01T00:00:00Z', usage: 10, cost: 1, event_count: 5 }],
-		},
-		{ feature_id: 'feat_2', source: 'feat_2', name: 'Storage', points: [] },
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	] as any;
+		}),
+		makeUsageAnalyticItem({ feature_id: 'feat_2', source: 'feat_2', name: 'Storage', points: [] }),
+	];
 
 	it('maps items to series with no filtering when mode is all', () => {
 		const result = adaptUsageTrendSeries(items, { feature_filter_mode: 'all' });
@@ -143,19 +202,18 @@ describe('adaptUsageTrendSeries', () => {
 describe('adaptUsageBreakdownRows', () => {
 	it('maps group, usage display, and cost fields', () => {
 		const result = adaptUsageBreakdownRows([
-			{
+			makeUsageAnalyticItem({
 				feature_id: 'feat_1',
 				name: 'API Calls',
-				group: { id: 'grp_1', name: 'Core' },
+				group: makeGroup({ id: 'grp_1', name: 'Core' }),
 				total_usage: 1234,
 				total_usage_display: '1,234',
 				unit: 'call',
 				unit_plural: 'calls',
 				total_cost: 12.5,
 				currency: 'USD',
-			},
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		] as any);
+			}),
+		]);
 		expect(result).toEqual([
 			{
 				id: 'feat_1',
@@ -172,8 +230,9 @@ describe('adaptUsageBreakdownRows', () => {
 	});
 
 	it('leaves group fields undefined when the row has no group', () => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const result = adaptUsageBreakdownRows([{ feature_id: 'feat_2', name: 'Storage', total_usage: 0, total_cost: 0 }] as any);
+		const result = adaptUsageBreakdownRows([
+			makeUsageAnalyticItem({ feature_id: 'feat_2', name: 'Storage', total_usage: 0, total_cost: 0 }),
+		]);
 		expect(result[0].groupId).toBeUndefined();
 		expect(result[0].groupName).toBeUndefined();
 	});
@@ -182,16 +241,15 @@ describe('adaptUsageBreakdownRows', () => {
 		// A conversion_rate can make raw total_usage=1000 display as "1" — the unit shown must
 		// agree with what's on screen, not the underlying raw count.
 		const result = adaptUsageBreakdownRows([
-			{
+			makeUsageAnalyticItem({
 				feature_id: 'feat_1',
 				name: 'Storage',
 				total_usage: 1000,
 				total_usage_display: '1',
 				reporting_unit: { unit_singular: 'GB', unit_plural: 'GBs' },
 				total_cost: 5,
-			},
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		] as any);
+			}),
+		]);
 		expect(result[0].unit).toBe('GB');
 	});
 });

--- a/src/usage/components/MetricCards.tsx
+++ b/src/usage/components/MetricCards.tsx
@@ -39,11 +39,12 @@ const MetricCards = ({ metrics: rawMetrics, isLoading = false, className }: Metr
 
 	return (
 		<div
-			className={cn('flexprice-ui', 'grid gap-3', className)}
-			style={{
-				gridTemplateColumns: metrics.length === 1 ? 'auto' : `repeat(${metrics.length}, 1fr)`,
-				width: metrics.length === 1 ? '25%' : '100%',
-			}}>
+			className={cn(
+				'flexprice-ui',
+				'grid gap-3',
+				metrics.length === 1 ? 'grid-cols-1 w-1/4' : 'grid-cols-2 md:grid-cols-4 w-full',
+				className,
+			)}>
 			{metrics.map((item) => (
 				<MetricCard
 					key={item.id}

--- a/src/usage/components/UsageBreakdown.tsx
+++ b/src/usage/components/UsageBreakdown.tsx
@@ -182,7 +182,9 @@ const UsageBreakdown = ({ rows: rawRows, label, isLoading = false, className }: 
 							{groupedBuckets.map((bucket) => {
 								const isExpanded = expandedGroupIds.has(bucket.groupKey);
 								const aggregateCost = bucket.items.reduce((s, i) => s + i.totalCost, 0);
-								const firstCurrency = bucket.items[0]?.currency;
+								const currencies = new Set(bucket.items.map((i) => i.currency).filter(Boolean));
+								// A mixed-currency bucket has no single valid symbol for the summed total.
+								const firstCurrency = currencies.size === 1 ? bucket.items.find((i) => i.currency)?.currency : undefined;
 								return (
 									<React.Fragment key={bucket.groupKey}>
 										<TableRow

--- a/src/usage/components/UsageQuota.test.tsx
+++ b/src/usage/components/UsageQuota.test.tsx
@@ -57,7 +57,20 @@ describe('UsageQuota', () => {
 			fallbackLng: 'en',
 			ns: ['common'],
 			defaultNS: 'common',
-			resources: { en: { common: enCommon } },
+			// Override the title with a value distinct from both the bundled fallback ("Usage Quota")
+			// and the real dashboard copy — proves the host instance's own resources actually won,
+			// rather than the test passing because both sources happen to agree.
+			resources: {
+				en: {
+					common: {
+						...enCommon,
+						usageWidgets: {
+							...enCommon.usageWidgets,
+							quotaTitle: 'HOST-QUOTA-TITLE',
+						},
+					},
+				},
+			},
 			interpolation: { escapeValue: false },
 		});
 
@@ -67,7 +80,7 @@ describe('UsageQuota', () => {
 			</I18nextProvider>,
 		);
 
-		expect(screen.getByText('Usage Quota')).toBeInTheDocument();
+		expect(screen.getByText('HOST-QUOTA-TITLE')).toBeInTheDocument();
 		expect(screen.queryByText('usageWidgets.quotaTitle')).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## **User description**
## Summary
Resolves all 11 unresolved CodeRabbit review threads on #1250:

- **`.github/workflows/publish-flexprice-ui.yml`**: strip the raw `${{ github.ref_name }}` expression from a shell comment (zizmor template-injection finding) and compare the full ref (`refs/heads/main`) instead of the short ref name, so a tag named `main` can't trigger a publish.
- **Design doc**: add `text` language identifiers to fenced code blocks (MD040).
- **`@flexprice/ui`**: widen `react`/`react-dom` peer deps to `^18 || ^19` to match the repo's React 19 build baseline; document the new usage/credits widget exports in the package README and `src/exportable/index.ts`.
- **`ShortPaginationControls`**: resync the controlled `page` back into range when the total shrinks below it; `CreditHistory` renders pagination based on `totalItems` rather than the current page's row count. Added regression tests.
- Removed `any` casts from `credits/schema.test.tsx` and `usage/adapters.test.tsx`, replacing the latter's fixtures with typed builder functions.
- **`MetricCards`**: replaced inline `width`/`gridTemplateColumns` with Tailwind classes, matching the loading skeleton's responsive `grid-cols-2 md:grid-cols-4` layout.
- **`UsageBreakdown`**: no longer labels a mixed-currency group total with the first row's currency symbol.
- **`UsageQuota.test`**: host-precedence test now asserts on a value distinct from the bundled fallback, so it can't pass for the wrong reason.

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npx eslint src/` — 0 errors (pre-existing warnings only, none in touched files)
- [x] `npx vitest run` — 437/437 tests passing across 68 files
- [x] `npm run build` — passes
- [x] `npm run build:ui` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix credit history pagination and expand the UI package for usage and credits widgets

### What Changed
- Credit history pagination now remains visible when totals shrink and automatically returns to a valid page.
- Usage breakdown totals no longer show an incorrect currency symbol when a group contains multiple currencies.
- Metric cards use a responsive two-column/four-column layout consistent with their loading state.
- The published UI package now supports React 18 and 19 and documents usage and credits widget exports, adapters, and examples.
- Publishing is restricted to the main branch, preventing tags named `main` from triggering a release.
- Added regression coverage for pagination, host translations, data normalization, and usage adapters.

### Impact
`✅ Fewer empty credit history pages after filtering or deletion`
`✅ Accurate currency display for mixed-currency usage totals`
`✅ React 19-compatible usage and credits widgets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for React 18 and React 19.
  - Expanded documentation for pricing, usage, and credits widgets, including setup and usage examples.
  - Documented additional exportable components and required styling configuration.

- **Bug Fixes**
  - Pagination now recovers correctly when filtered or removed items reduce available pages.
  - Mixed-currency usage groups no longer display an incorrect currency symbol.
  - Improved responsive layouts for usage metric cards.
  - Host-provided translations now display correctly in usage quota components.

- **Chores**
  - Publication safeguards now restrict releases to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->