### PR TITLE
fix(plan-builder): restore light-theme toggle color and remove one-time billing for usage charges

### DIFF
--- a/scripts/theme-tokens.mjs
+++ b/scripts/theme-tokens.mjs
@@ -37,9 +37,9 @@ export const TOKEN_GROUPS = [
 			{ name: 'surface-inverse-zinc', light: 'zinc.900', dark: '#eeeff1', note: 'inverted tooltips built on zinc rather than gray' },
 			{
 				name: 'surface-track',
-				light: 'slate.800',
+				light: 'neutral.200',
 				dark: '#e8e8ea',
-				note: 'switch track when off — dark on light cards, light on dark cards',
+				note: 'switch track when off — matches the original --input light value',
 			},
 			{ name: 'surface-scrim', light: 'black', dark: '#000000', note: 'modal scrim — black in both themes' },
 		],

--- a/src/components/organisms/PlanForm/UsagePricingForm.tsx
+++ b/src/components/organisms/PlanForm/UsagePricingForm.tsx
@@ -554,7 +554,7 @@ const UsagePricingForm: FC<Props> = ({
 			<Spacer height='8px' />
 			<Select
 				value={billingPeriod}
-				options={billlingPeriodOptions}
+				options={billlingPeriodOptions.filter((option) => option.value !== BILLING_PERIOD.ONETIME)}
 				onChange={(value) => {
 					setBillingPeriod(value as BILLING_PERIOD);
 				}}

--- a/src/components/organisms/PlanForm/UsagePricingForm.tsx
+++ b/src/components/organisms/PlanForm/UsagePricingForm.tsx
@@ -103,6 +103,11 @@ export const billingModels: SelectOption[] = [
 	}, // Maps to TIERED with SLAB tier_mode
 ];
 
+// ONETIME isn't offered for usage charges (they're inherently metered/recurring), but older prices
+// may still have it saved — fall back to MONTHLY rather than leaving the Select without a matching option.
+const normalizeUsageBillingPeriod = (billingPeriod?: BILLING_PERIOD): BILLING_PERIOD =>
+	billingPeriod && billingPeriod !== BILLING_PERIOD.ONETIME ? billingPeriod : BILLING_PERIOD.MONTHLY;
+
 const UsagePricingForm: FC<Props> = ({
 	onAdd,
 	onUpdate,
@@ -127,7 +132,7 @@ const UsagePricingForm: FC<Props> = ({
 		{ from: 0, up_to: 1, unit_amount: '', flat_amount: '0' },
 		{ from: 1, up_to: null, unit_amount: '', flat_amount: '0' },
 	]);
-	const [billingPeriod, setBillingPeriod] = useState(price.billing_period || BILLING_PERIOD.MONTHLY);
+	const [billingPeriod, setBillingPeriod] = useState(normalizeUsageBillingPeriod(price.billing_period));
 	const [flatFee, setFlatFee] = useState<string>(price.amount || '');
 	const [packagedFee, setPackagedFee] = useState<{ unit: string; price: string }>({
 		unit: '',
@@ -198,7 +203,7 @@ const UsagePricingForm: FC<Props> = ({
 			setBillingModel(price.billing_model || billingModels[0].value);
 			// Set display_name from price or feature name (will be set when feature is loaded)
 			setDisplayName(price.display_name || '');
-			setBillingPeriod(price.billing_period || BILLING_PERIOD.MONTHLY);
+			setBillingPeriod(normalizeUsageBillingPeriod(price.billing_period));
 			setStartDate(price.start_date ? new Date(price.start_date) : undefined);
 
 			if (price.billing_model === BILLING_MODEL.FLAT_FEE) {

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -13,7 +13,7 @@ const Switch = React.forwardRef<
 			'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200 border-2 border-transparent',
 			'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
 			'disabled:cursor-not-allowed disabled:opacity-50',
-			// Track: primary when on; surface-track when off (dark track in light, light track in dark — token-driven).
+			// Track: primary when on; surface-track when off (light track in light, light track in dark — token-driven).
 			'data-[state=checked]:bg-primary data-[state=unchecked]:bg-surface-track',
 			className,
 		)}

--- a/src/exportable/styles.css
+++ b/src/exportable/styles.css
@@ -127,7 +127,7 @@
 	--fp-surface-cool: 248 250 252;
 	--fp-surface-inverse: 17 24 39;
 	--fp-surface-inverse-zinc: 24 24 27;
-	--fp-surface-track: 30 41 59;
+	--fp-surface-track: 229 229 229;
 	--fp-surface-scrim: 0 0 0;
 	--fp-content: 17 24 39;
 	--fp-content-heading: 31 41 55;

--- a/src/index.css
+++ b/src/index.css
@@ -85,7 +85,7 @@
 		--fp-surface-cool: 248 250 252; /* #f8fafc */
 		--fp-surface-inverse: 17 24 39; /* #111827 — dark-on-light chips invert */
 		--fp-surface-inverse-zinc: 24 24 27; /* #18181b — inverted tooltips built on zinc rather than gray */
-		--fp-surface-track: 30 41 59; /* #1e293b — switch track when off — dark on light cards, must lighten on dark ones */
+		--fp-surface-track: 229 229 229; /* #e5e5e5 — switch track when off — matches the original --input light value */
 		--fp-surface-scrim: 0 0 0; /* #000000 — modal scrim — black in both themes */
 
 		/* Content — text, icons, fills. The light ramp inverts to the Midnight text ramp. */


### PR DESCRIPTION
## **User description**
## Summary
- Restore the switch/toggle off-track color in light theme to the original `--input` gray (`#e5e5e5`). The dark-theme token migration had unintentionally changed it to a dark navy (`#1e293b`); dark theme is untouched.
- Remove "One-time" from the billing period options for usage-based charges in the plan builder, since usage charges are inherently metered/recurring. Fixed/recurring charges keep "One-time" as before.

## Test plan
- [x] `npx tsc -b` passes
- [x] `npm run build` passes
- [x] Verified via dev server that `--fp-surface-track` resolves to `rgb(229, 229, 229)` in light theme and remains `rgb(232, 232, 234)` in dark theme
- [x] Confirmed usage-charge default billing period (`MONTHLY`) is unaffected by the option removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Usage pricing forms no longer offer the one-time billing period.
  * Existing one-time usage prices are automatically converted to monthly billing when loaded.

* **Style**
  * Updated light-theme switch tracks to use a light gray appearance.
  * Synchronized light-theme surface colors across the application and exported styles for a more consistent visual experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Restore light-theme switch contrast and prevent one-time usage billing

### What Changed
- Switches now use a light gray track when turned off in the light theme, while dark-theme behavior remains unchanged.
- Usage-based charges no longer offer the invalid “One-time” billing period.
- Existing usage charges saved with “One-time” are converted to monthly billing when opened, preventing an unavailable value from being submitted.
- Fixed and recurring charge billing options remain unchanged.

### Impact
`✅ Clearer light-theme switch states`
`✅ Fewer invalid usage-charge configurations`
`✅ Safe editing of legacy usage charges`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
