### PR TITLE
fix(saml): show SSO whenever the link names a tenant, and honour its token

### DIFF
--- a/src/core/auth/AuthService.saml.test.ts
+++ b/src/core/auth/AuthService.saml.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * These cover a hosted deployment — one whose app.env is NOT self-hosted, so the
+ * Supabase branch is the default source of a session. SAML is a per-tenant
+ * feature that a hosted deployment may also offer, so a token minted by the
+ * backend's SAML callback has to be honoured there too; resolving the session
+ * purely from the environment meant a completed SSO login was silently ignored
+ * and the dashboard loaded signed-out.
+ */
+
+const supabaseSession = { access_token: 'supabase-access-token' };
+const supabaseUser = { id: 'supabase-user', email: 'supabase@example.com' };
+
+const signOut = vi.fn();
+const getSession = vi.fn(async () => ({ data: { session: supabaseSession } }));
+const getUser = vi.fn(async () => ({ data: { user: supabaseUser } }));
+
+vi.mock('@/config/config', () => ({
+	// "production" is what the staging/production frontend builds resolve to.
+	config: { app: { env: 'production' } },
+	APP_ENV: { SelfHosted: 'self-hosted' },
+}));
+
+vi.mock('../services/supbase/config', () => ({
+	default: { auth: { signOut, getSession, getUser } },
+}));
+
+vi.mock('../routes/Routes', () => ({ RouteNames: { login: '/login' } }));
+
+// jsdom 26 does not allow window.location to be assigned, and redefining it on
+// `window` detaches the other window-scoped globals (localStorage among them).
+// A plain in-memory store keeps this file independent of that.
+const store = new Map<string, string>();
+
+beforeEach(() => {
+	vi.resetModules();
+	signOut.mockClear();
+	getSession.mockClear();
+	getUser.mockClear();
+	store.clear();
+
+	vi.stubGlobal('localStorage', {
+		getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+		setItem: (key: string, value: string) => void store.set(key, String(value)),
+		removeItem: (key: string) => void store.delete(key),
+		clear: () => store.clear(),
+		key: (index: number) => Array.from(store.keys())[index] ?? null,
+		get length() {
+			return store.size;
+		},
+	});
+});
+
+async function importService() {
+	const mod = await import('./AuthService');
+	return mod.default;
+}
+
+// The shape SamlCallback writes.
+function storeSamlToken(token = 'saml-minted-token', tenantId = 'tenant_123') {
+	localStorage.setItem('token', JSON.stringify({ token, tenant_id: tenantId }));
+}
+
+describe('AuthService on a hosted deployment with a SAML token present', () => {
+	it('returns the SAML token rather than the Supabase session', async () => {
+		storeSamlToken();
+
+		const AuthService = await importService();
+
+		expect(await AuthService.getAcessToken()).toBe('saml-minted-token');
+	});
+
+	it('does not consult Supabase at all when a SAML token is present', async () => {
+		storeSamlToken();
+
+		const AuthService = await importService();
+		await AuthService.getAcessToken();
+
+		expect(getSession).not.toHaveBeenCalled();
+	});
+
+	it('still uses Supabase when no SAML token was stored', async () => {
+		const AuthService = await importService();
+
+		expect(await AuthService.getAcessToken()).toBe('supabase-access-token');
+		expect(getSession).toHaveBeenCalled();
+	});
+
+	// A half-written or corrupted entry must not strand the user with no way to
+	// authenticate: fall back to the provider rather than throwing.
+	it('falls back to Supabase when the stored token is not valid JSON', async () => {
+		localStorage.setItem('token', 'not-json{');
+
+		const AuthService = await importService();
+
+		expect(await AuthService.getAcessToken()).toBe('supabase-access-token');
+	});
+
+	// The Supabase-shaped entry has no `token` field; treat it as absent.
+	it('falls back to Supabase when the stored object carries no token field', async () => {
+		localStorage.setItem('token', JSON.stringify({ tenant_id: 'tenant_123' }));
+
+		const AuthService = await importService();
+
+		expect(await AuthService.getAcessToken()).toBe('supabase-access-token');
+	});
+
+	// getUser has no SAML equivalent stored — SamlCallback deliberately omits
+	// user_id — so the user is loaded from the API against the token instead.
+	it('reports no Supabase user when the session came from SAML', async () => {
+		storeSamlToken();
+
+		const AuthService = await importService();
+
+		expect(await AuthService.getUser()).toBeNull();
+		expect(getUser).not.toHaveBeenCalled();
+	});
+
+	it('returns the Supabase user when no SAML token was stored', async () => {
+		const AuthService = await importService();
+
+		expect(await AuthService.getUser()).toEqual(supabaseUser);
+	});
+
+	// Logout must end BOTH sessions. Clearing only one leaves a usable
+	// credential behind and the next visit silently signs back in.
+	it('clears the SAML token and signs out of Supabase', async () => {
+		storeSamlToken();
+
+		const AuthService = await importService();
+		await AuthService.logout();
+
+		expect(localStorage.getItem('token')).toBeNull();
+		expect(signOut).toHaveBeenCalled();
+	});
+});

--- a/src/core/auth/AuthService.ts
+++ b/src/core/auth/AuthService.ts
@@ -2,41 +2,72 @@ import { config, APP_ENV } from '@/config/config';
 import supabase from '../services/supbase/config';
 import { RouteNames } from '../routes/Routes';
 
+/**
+ * Reads the locally stored session, which is what both a self-hosted login and a
+ * completed SAML assertion write.
+ *
+ * Returns null for anything unusable — absent, unparseable, or carrying no token
+ * — so a corrupted entry falls through to the identity provider rather than
+ * stranding the user with no way to authenticate.
+ */
+function readStoredSession(): { token?: string; user?: unknown } | null {
+	try {
+		const stored = localStorage.getItem('token');
+		if (!stored) return null;
+		const parsed = JSON.parse(stored);
+		if (!parsed || typeof parsed.token !== 'string' || parsed.token === '') return null;
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
 class AuthService {
+	/**
+	 * A locally stored token wins wherever one exists, in any environment.
+	 *
+	 * SAML is configured per tenant, so a hosted deployment backed by Supabase may
+	 * still serve tenants that sign in through an identity provider. Choosing the
+	 * source from the environment alone meant that on such a deployment a
+	 * completed SSO login was ignored: the assertion validated, the backend minted
+	 * a token, the callback stored it, and every request afterwards asked Supabase
+	 * for a session that was never created — so the dashboard loaded signed out
+	 * with no indication of what had gone wrong.
+	 *
+	 * Preferring the stored token is safe for the Supabase path because only a
+	 * completed login writes it: the SAML callback stores it after the backend has
+	 * validated the assertion, and logout clears it.
+	 */
 	public static async getAcessToken() {
+		const stored = readStoredSession();
+		if (stored) return stored.token;
+
 		if (config.app.env !== APP_ENV.SelfHosted) {
 			const {
 				data: { session },
 			} = await supabase.auth.getSession();
 			return session?.access_token;
-		} else {
-			try {
-				const tokenData = localStorage.getItem('token');
-				if (!tokenData) return null;
-				const parsedToken = JSON.parse(tokenData);
-				return parsedToken.token;
-			} catch (error) {
-				console.error('Error parsing token:', error);
-				return null;
-			}
 		}
+		return null;
 	}
 
+	/**
+	 * Mirrors getAcessToken so the user and the token always describe the same
+	 * session — reading the token from SAML and the user from Supabase would
+	 * otherwise report one identity while acting as another.
+	 *
+	 * A SAML session stores no user: the callback deliberately omits it, and
+	 * callers load the user from /users/me against the token itself.
+	 */
 	public static async getUser() {
+		const stored = readStoredSession();
+		if (stored) return stored.user ?? null;
+
 		if (config.app.env !== APP_ENV.SelfHosted) {
 			const { data } = await supabase.auth.getUser();
 			return data.user;
-		} else {
-			try {
-				const tokenData = localStorage.getItem('token');
-				if (!tokenData) return null;
-				const parsedToken = JSON.parse(tokenData);
-				return parsedToken.user;
-			} catch (error) {
-				console.error('Error parsing user data:', error);
-				return null;
-			}
 		}
+		return null;
 	}
 
 	/**

--- a/src/pages/auth/LoginForm.tsx
+++ b/src/pages/auth/LoginForm.tsx
@@ -161,9 +161,15 @@ const LoginForm: React.FC<LoginFormProps> = ({ switchTab }) => {
 			{/* SAML single sign-on. Shown only when the link names a tenant: SSO is
 			    configured per tenant, so without one there is no identity provider
 			    to send the browser to, and an always-visible button would fail for
-			    everyone who arrived at /login directly. Self-hosted only, since the
-			    Supabase path does not use the backend's SAML endpoints. */}
-			{config.app.env === APP_ENV.SelfHosted && ssoTenantId && (
+			    everyone who arrived at /login directly.
+
+			    Deliberately not restricted by environment. SAML is a per-tenant
+			    feature, so a hosted deployment backed by Supabase may still serve
+			    tenants that sign in through an identity provider; gating the button
+			    on the deployment hid SSO from every such tenant. The button is
+			    still safe to offer on a tenant that has not set SSO up: SamlSignin
+			    asks the endpoint first and reports it as unavailable on a 404. */}
+			{ssoTenantId && (
 				<>
 					<div className='flex items-center justify-center my-6'>
 						<div className='flex-1 h-px bg-surface-strong'></div>


### PR DESCRIPTION
## **User description**
The SSO button never appeared on a hosted deployment. `/login?sso=<tenant>` was
correct and the backend was serving SAML happily; the frontend simply never
rendered the button.

## Why

The render gate required a self-hosted deployment:

```jsx
{config.app.env === APP_ENV.SelfHosted && ssoTenantId && ( <SamlSignin .../> )}
```

But SAML is configured **per tenant**, so a hosted deployment backed by Supabase
can still serve tenants that sign in through an identity provider. Every such
tenant saw a password form and no way to reach their IdP.

## Why the one-line fix would have been worse than the bug

`AuthService` chose its session source from the same flag. Removing only the
render gate would have produced a login that *appears* to succeed and silently
does not:

1. redirect to the IdP ✅
2. assertion validated, token minted ✅
3. `SamlCallback` writes `localStorage.token` ✅
4. every later request asks Supabase for a session that was never created ❌

The user lands on the dashboard signed out, with no indication of what went
wrong. So the render gate and the token lookup change together.

## What changed

**`AuthService`** — a locally stored token wins wherever one exists, in any
environment; Supabase is consulted only when there is none. Safe for the
Supabase path because only a completed login writes that entry: the SAML
callback stores it after the backend has validated the assertion, and logout
clears it.

`getUser` mirrors `getAcessToken` so the user and the token always describe the
same session — reading the token from SAML and the user from Supabase would
report one identity while acting as another. A SAML session stores no user (the
callback deliberately omits it), so callers load it from `/users/me` against the
token itself.

Anything unusable in storage — absent, unparseable, or carrying no `token` —
falls through to the provider rather than throwing, so a corrupted entry cannot
strand someone with no way to authenticate.

**`LoginForm`** — the SAML block is gated on `ssoTenantId` alone. Still not
always visible: without a tenant in the link there is no IdP to send the browser
to. Safe to offer to a tenant that has not set SSO up, because `SamlSignin`
probes the endpoint first and reports it unavailable on a 404.

**`logout` needed no change** — it already clears localStorage unconditionally
and signs out of Supabase on hosted deployments, so both credentials end
together. Covered by a test regardless: a regression there would leave a usable
credential behind and silently sign the next visitor back in.

## Tests

Eight new cases in `AuthService.saml.test.ts`, all against a **hosted**
deployment (`app.env: "production"`) since that is where the bug lived:

- SAML token preferred over a live Supabase session
- Supabase not consulted at all when a SAML token is present
- Supabase still used when no SAML token was stored
- falls back to Supabase on unparseable JSON
- falls back to Supabase when the object carries no `token`
- `getUser` returns no Supabase user when the session came from SAML
- `getUser` returns the Supabase user when it did not
- logout clears the SAML token *and* signs out of Supabase

## Verification

- `tsc --noEmit` clean
- `eslint` 0 errors on changed files (1 warning, pre-existing, in the
  password-in-URL block this PR does not touch)
- production build succeeds
- **compiled bundle check:** the guard before `SamlSignin` is now the tenant id
  alone, with no environment comparison — previously it compared `app.env`
- full suite **449 passed / 30 failed**, against a `develop` baseline of
  **441 passed / 30 failed**. The same four files fail on `develop`
  (`AuthService`, `ThemeSettings`, `useLocaleStore`, `useThemeStore`), all from
  a jsdom 26 `localStorage.clear is not a function` issue unrelated to this
  change. No regressions; +8 from this PR.

The pre-existing jsdom failure is worth a separate fix — `Object.defineProperty(window, 'location', ...)`
in `beforeEach` detaches the other window-scoped globals on jsdom 26. This PR's
own test file works around it locally rather than changing shared setup.

## Verified against staging

Backend is already live and correct — `/v1/auth/saml/<tenant>/metadata` returns
200 and `/login` returns a 302 to the IdP with a valid `SAMLRequest`. This was
the only remaining blocker.


___

## **CodeAnt-AI Description**
Show tenant SSO on hosted deployments and keep SAML users signed in

### What Changed
- Tenant links with SSO now show the SAML sign-in option regardless of deployment type
- Hosted deployments use the completed SAML login token instead of ignoring it and falling back to Supabase
- Invalid or incomplete stored credentials fall back to the normal sign-in provider
- SAML and Supabase session handling is covered by tests, including logout cleanup

### Impact
`✅ SSO works for hosted tenants`
`✅ Fewer successful logins that appear signed out`
`✅ Safer recovery from corrupted login data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SAML single sign-on is now available whenever a tenant is specified in the login URL.
  * Authentication prioritizes valid SAML sessions and falls back to standard sign-in when needed.

* **Bug Fixes**
  * Improved handling of missing, malformed, or tokenless stored sessions.
  * Logging out now clears both SAML and standard authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->