### PR TITLE
security: send anti-framing and hardening headers

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,4 +5,10 @@ server {
         index index.html;
         try_files $uri $uri/ /index.html;
     }
+
+    # Security Headers
+    add_header Content-Security-Policy "frame-ancestors 'self';" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,15 @@
     ],
     "headers": [
         {
+            "source": "/(.*)",
+            "headers": [
+                { "key": "Content-Security-Policy", "value": "frame-ancestors 'self';" },
+                { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+                { "key": "X-Content-Type-Options", "value": "nosniff" },
+                { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+            ]
+        },
+        {
             "source": "/.well-known/agent-skills/index.json",
             "headers": [
                 { "key": "Content-Type", "value": "application/json" },


### PR DESCRIPTION
## **User description**
## Context

An external security report flagged that `admin.flexprice.io/auth?tab=login` can be embedded in a cross-origin iframe.

Verified against the live site:

| Header | Before |
|---|---|
| `x-frame-options` | missing |
| `content-security-policy` | missing |
| `x-content-type-options` | missing |
| `referrer-policy` | missing |
| `strict-transport-security` | present |

`admin.flexprice.io` is served by Vercel (`server: Vercel`), and `vercel.json` scoped its only `headers` block to `/.well-known/agent-skills/index.json` — so app routes shipped no anti-framing header at all.

Note that the rest of the report (XSS, DOM XSS, CSRF, account deletion, malware execution, "victim PC hijack") is not substantiated and was not reproducible; a cross-origin iframe cannot read the framed page's DOM or inputs. This PR addresses only the real finding: the missing header. Triaged **Low**, not Critical.

## Change

- `vercel.json` — add a global `/(.*)` header block. This is the only file that affects the deployed `admin.flexprice.io`.
- `nginx.conf` — same headers; this file previously had none.

Headers added:

```
Content-Security-Policy: frame-ancestors 'self';
X-Frame-Options: SAMEORIGIN
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
```

## Notes for review

- **`'self'`, not `'none'`** — matches the policy `nginx/nginx.conf` already sets, rather than tightening unilaterally. If nothing same-origin embeds the app, `'none'` is stronger and is a one-word change.
- **`nginx/nginx.conf` untouched** — it already had `frame-ancestors 'self'`.
- **Both nginx files are dead config for the deployed path** — the Dockerfile copies neither and has no nginx stage. The root `nginx.conf` was updated for consistency with the self-hosted setup, but will not change any live header.

## Verification

`npm run build` passes (8.07s). The chunk-size warning is pre-existing and unrelated.

Post-merge, confirm on the deployed URL:

```
curl -sSI https://admin.flexprice.io/auth\?tab=login | grep -iE 'frame-ancestors|x-frame-options'
```


___

## **CodeAnt-AI Description**
Prevent cross-origin framing and add browser security protections

### What Changed
- App routes now prevent pages from being embedded in cross-origin iframes while allowing same-origin embedding
- Browsers are instructed to block MIME-type sniffing
- Referrer details are limited when navigating across origins
- The same protections apply when the app is served through nginx

### Impact
`✅ Blocks cross-origin iframe embedding`
`✅ Reduces content-type spoofing risk`
`✅ Limits cross-origin referrer exposure`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced application security with policies that help prevent clickjacking, MIME-type sniffing, and unsafe content execution.
  * Improved referrer handling to limit cross-origin information sharing.
  * Applied these protections consistently across server and hosted deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->