### PR TITLE
refactor(support-chat): switch Pylon identity verification to HMAC email hash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,10 +33,12 @@ VITE_INTERCOM_APP_ID=your-intercom-app-id-here
 
 # Pylon — https://docs.usepylon.com/pylon-docs/chat-widget/chat-setup
 # App ID comes from the Pylon dashboard under Chat Widget settings.
-# Set Identity Verification to "HMAC email hash" in the Pylon dashboard; the backend
-# signs it at POST /users/chat/verify (chat_support.identity_secret must match).
+# Identity verification is optional. Enable this only when "HMAC email hash" is on in
+# the Pylon dashboard; the backend signs it at POST /users/chat/verify
+# (chat_support.identity_secret must match). When false, email_hash is omitted.
 VITE_PYLON_ENABLED=false
 VITE_PYLON_APP_ID=your-pylon-app-id-here
+VITE_PYLON_IDENTITY_VERIFICATION_ENABLED=false
 
 # Reo
 VITE_REO_ENABLED=false

--- a/.env.example
+++ b/.env.example
@@ -33,15 +33,10 @@ VITE_INTERCOM_APP_ID=your-intercom-app-id-here
 
 # Pylon — https://docs.usepylon.com/pylon-docs/chat-widget/chat-setup
 # App ID comes from the Pylon dashboard under Chat Widget settings.
-# Leave "Identity Verification" OFF in the Pylon dashboard: the frontend does
-# not send a signed JWT yet (no backend signing endpoint exists).
+# Set Identity Verification to "HMAC email hash" in the Pylon dashboard; the backend
+# signs it at POST /users/chat/verify (chat_support.identity_secret must match).
 VITE_PYLON_ENABLED=false
 VITE_PYLON_APP_ID=your-pylon-app-id-here
-# Identity verification. When true the frontend fetches a signed JWT from
-# POST /users/chat/verify and lets it carry ALL identity, so no email or name is
-# sent alongside it (Pylon rejects mismatches).
-# Turn the Pylon dashboard's "Identity Verification" toggle on only AFTER this works.
-VITE_PYLON_IDENTITY_VERIFICATION_ENABLED=false
 
 # Reo
 VITE_REO_ENABLED=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,6 @@
         "@vitejs/plugin-react": "^5.2.0",
         "@vitest/ui": "^3.1.2",
         "autoprefixer": "^10.4.20",
-        "baseline-browser-mapping": "^2.9.15",
         "eslint": "^10.0.1",
         "eslint-plugin-i18next": "^6.1.4",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -7162,13 +7161,16 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.11.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.18.tgz",
+      "integrity": "sha512-1iEmLEYSiE1SeBoAfPo/Mnx3PzfzHUkDK61ASkCpuk3YXugYLH5DYK1SzqV55F8FMI6s0F+/tCP7Polz1QRjxw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -7291,9 +7293,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001768",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001768.tgz",
-      "integrity": "sha512-qY3aDRZC5nWPgHUgIB84WL+nySuo19wk0VJpp/XI9T34lrvkyhRvNVOFJOp2kxClQhiFBu+TaUSudf6oa3vkSA==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "@vitejs/plugin-react": "^5.2.0",
     "@vitest/ui": "^3.1.2",
     "autoprefixer": "^10.4.20",
-    "baseline-browser-mapping": "^2.9.15",
     "eslint": "^10.0.1",
     "eslint-plugin-i18next": "^6.1.4",
     "eslint-plugin-react-hooks": "^7.1.1",
@@ -121,8 +120,8 @@
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.15.0",
     "vite": "^7.3.6",
-    "vitest": "^3.2.6",
-    "vite-plugin-dts": "^4.5.4"
+    "vite-plugin-dts": "^4.5.4",
+    "vitest": "^3.2.6"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/src/api/SupportChatApi.ts
+++ b/src/api/SupportChatApi.ts
@@ -1,16 +1,10 @@
 import { AxiosClient } from '@/core/axios/verbs';
 
 export interface SupportChatTokenResponse {
-	/** Short-lived signed JWT. Never log or persist. */
 	token: string;
-	/** RFC3339 UTC. Informational; the token is re-fetched on every init. */
 	expires_at: string;
 }
 
-/**
- * Mints a support-chat identity token for the authenticated caller. Takes no request body.
- * Callers must treat failure as non-fatal and fall back to an unverified session.
- */
 class SupportChatApi {
 	private static baseUrl = '/users/chat';
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -61,6 +61,8 @@ interface IntercomConfig {
 interface PylonConfig {
 	enabled: boolean;
 	appId: string;
+	/** When true, fetch HMAC email hash from the backend and pass it as Pylon `email_hash`. */
+	identityVerificationEnabled: boolean;
 }
 interface ReoConfig {
 	enabled: boolean;
@@ -331,6 +333,7 @@ export const config: Config = {
 	pylon: {
 		enabled: import.meta.env.VITE_PYLON_ENABLED === EnvFlag.True,
 		appId: import.meta.env.VITE_PYLON_APP_ID ?? '',
+		identityVerificationEnabled: import.meta.env.VITE_PYLON_IDENTITY_VERIFICATION_ENABLED === EnvFlag.True,
 	},
 	reo: {
 		enabled: import.meta.env.VITE_REO_ENABLED === 'true',

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -61,8 +61,6 @@ interface IntercomConfig {
 interface PylonConfig {
 	enabled: boolean;
 	appId: string;
-	/** Fetch a signed JWT from POST /users/chat/verify and let it carry identity. */
-	identityVerificationEnabled: boolean;
 }
 interface ReoConfig {
 	enabled: boolean;
@@ -333,7 +331,6 @@ export const config: Config = {
 	pylon: {
 		enabled: import.meta.env.VITE_PYLON_ENABLED === EnvFlag.True,
 		appId: import.meta.env.VITE_PYLON_APP_ID ?? '',
-		identityVerificationEnabled: import.meta.env.VITE_PYLON_IDENTITY_VERIFICATION_ENABLED === EnvFlag.True,
 	},
 	reo: {
 		enabled: import.meta.env.VITE_REO_ENABLED === 'true',

--- a/src/config/support-chat.test.ts
+++ b/src/config/support-chat.test.ts
@@ -11,6 +11,7 @@ describe('support chat config', () => {
 		vi.stubEnv('VITE_APP_INTERCOM_APP_ID', '');
 		vi.stubEnv('VITE_PYLON_ENABLED', 'false');
 		vi.stubEnv('VITE_PYLON_APP_ID', '');
+		vi.stubEnv('VITE_PYLON_IDENTITY_VERIFICATION_ENABLED', 'false');
 	});
 
 	afterEach(() => {
@@ -40,6 +41,19 @@ describe('support chat config', () => {
 		const { getActiveSupportChatProvider } = await import('./support-chat');
 
 		expect(getActiveSupportChatProvider()).toBe(SupportChatProvider.Pylon);
+	});
+
+	it('defaults Pylon identity verification to off', async () => {
+		const { config } = await import('./config');
+
+		expect(config.pylon.identityVerificationEnabled).toBe(false);
+	});
+
+	it('enables Pylon identity verification only when the env flag is true', async () => {
+		vi.stubEnv('VITE_PYLON_IDENTITY_VERIFICATION_ENABLED', 'true');
+		const { config } = await import('./config');
+
+		expect(config.pylon.identityVerificationEnabled).toBe(true);
 	});
 
 	it('treats a malformed Pylon app id as unconfigured, so no dead button renders', async () => {

--- a/src/core/services/support-chat/adapters/conformance.test.ts
+++ b/src/core/services/support-chat/adapters/conformance.test.ts
@@ -13,8 +13,18 @@ const USER: SupportChatUser = {
 	tenantId: 'tenant_1',
 };
 
-/** Let the Pylon script "load" so its init promise settles; a no-op for Intercom. */
-function settlePendingScript(): void {
+/** Let the Pylon script "load" so its init promise settles; a no-op for Intercom, which never injects one. */
+async function settlePendingScript(): Promise<void> {
+	try {
+		await vi.waitFor(
+			() => {
+				if (!document.querySelector('script[src*="widget.usepylon.com"]')) throw new Error('not yet injected');
+			},
+			{ timeout: 100 },
+		);
+	} catch {
+		return;
+	}
 	document.querySelector<HTMLScriptElement>('script[src*="widget.usepylon.com"]')?.dispatchEvent(new Event('load'));
 }
 
@@ -30,7 +40,7 @@ const CASES: ReadonlyArray<{ provider: SupportChatProvider; create: () => Promis
 		provider: SupportChatProvider.Pylon,
 		create: async () => {
 			const { createPylonAdapter } = await import('./pylon');
-			return createPylonAdapter('app-123');
+			return createPylonAdapter('app-123', async () => 'hashed-email');
 		},
 	},
 ];
@@ -52,7 +62,7 @@ describe.each(CASES)('$provider adapter conformance', ({ create }) => {
 	it('resolves init for a valid configuration', async () => {
 		const adapter = await create();
 		const pending = adapter.init(USER);
-		settlePendingScript();
+		await settlePendingScript();
 
 		await expect(pending).resolves.toBeUndefined();
 	});
@@ -66,7 +76,7 @@ describe.each(CASES)('$provider adapter conformance', ({ create }) => {
 	it('does not throw when show() is called after dispose', async () => {
 		const adapter = await create();
 		const pending = adapter.init(USER);
-		settlePendingScript();
+		await settlePendingScript();
 		await pending;
 		adapter.dispose();
 
@@ -79,7 +89,7 @@ describe.each(CASES)('$provider adapter conformance', ({ create }) => {
 		expect(() => adapter.subscribe({ onShow: vi.fn(), onHide: vi.fn() })).not.toThrow();
 
 		const pending = adapter.init(USER);
-		settlePendingScript();
+		await settlePendingScript();
 		await expect(pending).resolves.toBeUndefined();
 	});
 
@@ -96,7 +106,7 @@ describe.each(CASES)('$provider adapter conformance', ({ create }) => {
 	it('has an idempotent dispose', async () => {
 		const adapter = await create();
 		const pending = adapter.init(USER);
-		settlePendingScript();
+		await settlePendingScript();
 		await pending;
 
 		expect(() => {

--- a/src/core/services/support-chat/adapters/index.test.ts
+++ b/src/core/services/support-chat/adapters/index.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SupportChatProvider } from '@/models/SupportChat';
+import { SUPPORT_CHAT_FLOW } from '@/config/support-chat';
+import type { SupportChatUser } from '../SupportChatAdapter';
+
+vi.mock('@intercom/messenger-js-sdk', () => ({ default: vi.fn() }));
+vi.mock('../../intercom/index.css', () => ({}));
+
+const pylonConfig = vi.hoisted(() => ({
+	enabled: true,
+	appId: 'app-123',
+	identityVerificationEnabled: false,
+}));
+
+const getIdentityToken = vi.hoisted(() => vi.fn());
+
+vi.mock('@/config/config', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@/config/config')>();
+	return {
+		...actual,
+		config: {
+			...actual.config,
+			get pylon() {
+				return pylonConfig;
+			},
+		},
+	};
+});
+
+vi.mock('@/api/SupportChatApi', () => ({
+	default: {
+		getIdentityToken,
+	},
+}));
+
+const USER: SupportChatUser = {
+	id: 'user_1',
+	email: 'ada@example.com',
+	name: 'Ada Tenant',
+	createdAt: 1_700_000_000_000,
+	tenantId: 'tenant_1',
+};
+
+type PylonGlobals = {
+	Pylon?: ((...args: unknown[]) => void) & { q?: unknown[] };
+	pylon?: { chat_settings: Record<string, unknown> };
+};
+
+function globals(): PylonGlobals {
+	return window as unknown as PylonGlobals;
+}
+
+function completeScriptLoad(): void {
+	const scripts = document.querySelectorAll<HTMLScriptElement>('script[src*="widget.usepylon.com"]');
+	scripts[scripts.length - 1]?.dispatchEvent(new Event('load'));
+}
+
+describe('createSupportChatAdapter (Pylon identity verification)', () => {
+	beforeEach(async () => {
+		const { __resetPylonLoaderForTests } = await import('./pylon');
+		__resetPylonLoaderForTests();
+		document.head.innerHTML = '';
+		delete globals().Pylon;
+		delete globals().pylon;
+		getIdentityToken.mockReset();
+		pylonConfig.identityVerificationEnabled = false;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('does not fetch or send email_hash when identity verification is disabled', async () => {
+		const { createSupportChatAdapter } = await import('./index');
+		const adapter = createSupportChatAdapter(SupportChatProvider.Pylon, SUPPORT_CHAT_FLOW[SupportChatProvider.Pylon]);
+		const pending = adapter.init(USER);
+		await vi.waitFor(() => expect(globals().pylon?.chat_settings).toBeDefined());
+
+		expect(getIdentityToken).not.toHaveBeenCalled();
+		expect(globals().pylon?.chat_settings).not.toHaveProperty('email_hash');
+
+		completeScriptLoad();
+		await pending;
+	});
+
+	it('fetches and sends email_hash when identity verification is enabled', async () => {
+		pylonConfig.identityVerificationEnabled = true;
+		getIdentityToken.mockResolvedValue({ token: 'hashed-email', expires_at: '2099-01-01' });
+
+		const { createSupportChatAdapter } = await import('./index');
+		const adapter = createSupportChatAdapter(SupportChatProvider.Pylon, SUPPORT_CHAT_FLOW[SupportChatProvider.Pylon]);
+		const pending = adapter.init(USER);
+		await vi.waitFor(() => expect(globals().pylon?.chat_settings).toHaveProperty('email_hash'));
+
+		expect(getIdentityToken).toHaveBeenCalledOnce();
+		expect(globals().pylon?.chat_settings?.email_hash).toBe('hashed-email');
+
+		completeScriptLoad();
+		await pending;
+	});
+});

--- a/src/core/services/support-chat/adapters/index.ts
+++ b/src/core/services/support-chat/adapters/index.ts
@@ -12,6 +12,11 @@ export function createSupportChatAdapter(provider: SupportChatProvider, flow: Su
 		case SupportChatProvider.Intercom:
 			return createIntercomAdapter(config.intercom.appId, flow.statePollIntervalMs, flow.hideDefaultLauncher);
 		case SupportChatProvider.Pylon:
-			return createPylonAdapter(config.pylon.appId, async () => (await SupportChatApi.getIdentityToken()).token);
+			return createPylonAdapter(
+				config.pylon.appId,
+				config.pylon.identityVerificationEnabled
+					? async () => (await SupportChatApi.getIdentityToken())?.token ?? ''
+					: undefined,
+			);
 	}
 }

--- a/src/core/services/support-chat/adapters/index.ts
+++ b/src/core/services/support-chat/adapters/index.ts
@@ -12,10 +12,6 @@ export function createSupportChatAdapter(provider: SupportChatProvider, flow: Su
 		case SupportChatProvider.Intercom:
 			return createIntercomAdapter(config.intercom.appId, flow.statePollIntervalMs, flow.hideDefaultLauncher);
 		case SupportChatProvider.Pylon:
-			return createPylonAdapter(
-				config.pylon.appId,
-				// Undefined when the flag is off, so no request is made.
-				config.pylon.identityVerificationEnabled ? async () => (await SupportChatApi.getIdentityToken()).token : undefined,
-			);
+			return createPylonAdapter(config.pylon.appId, async () => (await SupportChatApi.getIdentityToken()).token);
 	}
 }

--- a/src/core/services/support-chat/adapters/pylon.test.ts
+++ b/src/core/services/support-chat/adapters/pylon.test.ts
@@ -62,6 +62,23 @@ describe('pylon adapter', () => {
 		await pending;
 	});
 
+	it('omits email_hash when no hash fetcher is provided', async () => {
+		const adapter = createPylonAdapter('app-123');
+		const pending = adapter.init(USER);
+		await vi.waitFor(() => expect(globals().pylon?.chat_settings).toBeDefined());
+
+		expect(globals().pylon?.chat_settings).toEqual({
+			app_id: 'app-123',
+			email: 'ada@example.com',
+			name: 'Ada Tenant',
+			contact_external_id: 'user_1',
+		});
+		expect(globals().pylon?.chat_settings).not.toHaveProperty('email_hash');
+
+		completeScriptLoad();
+		await pending;
+	});
+
 	it('rejects and never touches the widget when the hash fetch fails', async () => {
 		const adapter = createPylonAdapter('app-123', async () => {
 			throw new Error('token endpoint unavailable');

--- a/src/core/services/support-chat/adapters/pylon.test.ts
+++ b/src/core/services/support-chat/adapters/pylon.test.ts
@@ -195,30 +195,37 @@ describe('pylon adapter', () => {
 	});
 
 	describe('identity verification', () => {
-		it('sends only the app id and the jwt, so nothing can contradict the claims', async () => {
+		it('sends identity fields mirroring exactly what the backend signs into the JWT', async () => {
 			const adapter = createPylonAdapter('app-123', async () => 'signed.jwt.token');
 			const pending = adapter.init(USER);
 			await vi.waitFor(() => expect(globals().pylon?.chat_settings).toHaveProperty('jwt'));
 
+			// The shipped widget (a) gates rendering on chat_settings.email/name being present
+			// regardless of JWT mode, and (b) forwards account_external_id/contact_external_id
+			// to Pylon's jwt-auth endpoint verbatim — any mismatch against the JWT's own claims
+			// gets the auth call rejected. These must mirror userService.CreateSupportChatToken.
 			expect(globals().pylon?.chat_settings).toEqual({
 				app_id: 'app-123',
 				jwt: 'signed.jwt.token',
+				email: 'ada@example.com',
+				name: 'Ada Tenant',
+				contact_external_id: 'user_1',
+				account_external_id: 'tenant_1',
 			});
 
 			completeScriptLoad();
 			await pending;
 		});
 
-		it('never ships email, name or account_external_id alongside a jwt', async () => {
+		it('omits account_external_id alongside a jwt when the user has no tenant', async () => {
 			const adapter = createPylonAdapter('app-123', async () => 'signed.jwt.token');
-			const pending = adapter.init(USER);
+			const pending = adapter.init({ id: 'user_1', email: 'ada@example.com', name: 'Ada' });
 			await vi.waitFor(() => expect(globals().pylon?.chat_settings).toHaveProperty('jwt'));
 
 			const settings = globals().pylon?.chat_settings ?? {};
-			expect(settings).not.toHaveProperty('email');
-			expect(settings).not.toHaveProperty('name');
 			expect(settings).not.toHaveProperty('account_external_id');
 			expect(settings).not.toHaveProperty('email_hash');
+			expect(settings).toHaveProperty('contact_external_id', 'user_1');
 
 			completeScriptLoad();
 			await pending;

--- a/src/core/services/support-chat/adapters/pylon.test.ts
+++ b/src/core/services/support-chat/adapters/pylon.test.ts
@@ -1,11 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockLogError } = vi.hoisted(() => ({ mockLogError: vi.fn() }));
-vi.mock('@/core/services/error/ErrorLoggingService', () => ({
-	default: { logError: mockLogError },
-	errorLogger: { logError: mockLogError },
-}));
-
 import { __resetPylonLoaderForTests, createPylonAdapter } from './pylon';
 import type { SupportChatUser } from '../SupportChatAdapter';
 
@@ -16,6 +10,8 @@ const USER: SupportChatUser = {
 	createdAt: 1_700_000_000_000,
 	tenantId: 'tenant_1',
 };
+
+const fetchEmailHash = async () => 'hashed-email';
 
 type PylonGlobals = {
 	Pylon?: ((...args: unknown[]) => void) & { q?: unknown[] };
@@ -47,51 +43,40 @@ describe('pylon adapter', () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
-		mockLogError.mockClear();
 	});
 
-	it('sets chat_settings before inserting the widget script', async () => {
-		const adapter = createPylonAdapter('app-123');
+	it('sets chat_settings, including the fetched email_hash, before inserting the widget script', async () => {
+		const adapter = createPylonAdapter('app-123', fetchEmailHash);
 		const pending = adapter.init(USER);
+		await vi.waitFor(() => expect(globals().pylon?.chat_settings).toHaveProperty('email_hash'));
 
 		expect(globals().pylon?.chat_settings).toEqual({
 			app_id: 'app-123',
+			email_hash: 'hashed-email',
 			email: 'ada@example.com',
 			name: 'Ada Tenant',
-			account_external_id: 'tenant_1',
+			contact_external_id: 'user_1',
 		});
 
 		completeScriptLoad();
 		await pending;
 	});
 
-	it('omits account_external_id when the user has no tenant', async () => {
-		const adapter = createPylonAdapter('app-123');
-		const pending = adapter.init({ id: 'user_1', email: 'ada@example.com', name: 'Ada' });
+	it('rejects and never touches the widget when the hash fetch fails', async () => {
+		const adapter = createPylonAdapter('app-123', async () => {
+			throw new Error('token endpoint unavailable');
+		});
 
-		expect(globals().pylon?.chat_settings).not.toHaveProperty('account_external_id');
-
-		completeScriptLoad();
-		await pending;
-	});
-
-	it('never sends contact_external_id, which Pylon accepts only as a JWT claim', async () => {
-		const adapter = createPylonAdapter('app-123');
-		const pending = adapter.init(USER);
-
-		expect(globals().pylon?.chat_settings).not.toHaveProperty('contact_external_id');
-		expect(globals().pylon?.chat_settings).not.toHaveProperty('contact_id');
-
-		completeScriptLoad();
-		await pending;
+		await expect(adapter.init(USER)).rejects.toThrow(/token endpoint unavailable/);
+		expect(document.querySelector('script[src*="usepylon"]')).toBeNull();
 	});
 
 	it('injects the widget script with hardened attributes', async () => {
-		const adapter = createPylonAdapter('app-123');
+		const adapter = createPylonAdapter('app-123', fetchEmailHash);
 		const pending = adapter.init(USER);
+		await vi.waitFor(() => expect(document.querySelector('script[src*="widget.usepylon.com"]')).not.toBeNull());
 		const script = document.querySelector<HTMLScriptElement>('script[src*="widget.usepylon.com"]');
 
-		expect(script).not.toBeNull();
 		expect(script?.src).toBe('https://widget.usepylon.com/widget/app-123');
 		expect(script?.async).toBe(true);
 		expect(script?.crossOrigin).toBe('anonymous');
@@ -102,8 +87,9 @@ describe('pylon adapter', () => {
 	});
 
 	it('injects the script only once across repeated inits', async () => {
-		const adapter = createPylonAdapter('app-123');
+		const adapter = createPylonAdapter('app-123', fetchEmailHash);
 		const first = adapter.init(USER);
+		await vi.waitFor(() => expect(document.querySelector('script[src*="widget.usepylon.com"]')).not.toBeNull());
 		completeScriptLoad();
 		await first;
 
@@ -113,8 +99,9 @@ describe('pylon adapter', () => {
 	});
 
 	it('hides the chat bubble once the widget has loaded', async () => {
-		const adapter = createPylonAdapter('app-123');
+		const adapter = createPylonAdapter('app-123', fetchEmailHash);
 		const pending = adapter.init(USER);
+		await vi.waitFor(() => expect(document.querySelector('script[src*="widget.usepylon.com"]')).not.toBeNull());
 		completeScriptLoad();
 		await pending;
 
@@ -122,44 +109,50 @@ describe('pylon adapter', () => {
 	});
 
 	it('rejects an app id containing characters outside the allowed set', async () => {
-		const adapter = createPylonAdapter('app-123/../evil');
+		const adapter = createPylonAdapter('app-123/../evil', fetchEmailHash);
 
 		await expect(adapter.init(USER)).rejects.toThrow(/Invalid Pylon app id/);
 		expect(document.querySelector('script[src*="usepylon"]')).toBeNull();
 	});
 
 	it('rejects when the widget script fails to load', async () => {
-		const adapter = createPylonAdapter('app-123');
+		const adapter = createPylonAdapter('app-123', fetchEmailHash);
 		const pending = adapter.init(USER);
+		await vi.waitFor(() => expect(document.querySelector('script[src*="widget.usepylon.com"]')).not.toBeNull());
 		failScriptLoad();
 
 		await expect(pending).rejects.toThrow(/Failed to load Pylon widget script/);
 	});
 
 	it('retries after a failed load instead of replaying the same rejection forever', async () => {
-		const first = createPylonAdapter('app-123');
+		const first = createPylonAdapter('app-123', fetchEmailHash);
 		const firstPending = first.init(USER);
+		await vi.waitFor(() => expect(document.querySelector('script[src*="widget.usepylon.com"]')).not.toBeNull());
 		failScriptLoad();
 		await expect(firstPending).rejects.toThrow(/Failed to load Pylon widget script/);
 
-		const second = createPylonAdapter('app-123');
+		const second = createPylonAdapter('app-123', fetchEmailHash);
 		const secondPending = second.init(USER);
+		await vi.waitFor(() => expect(document.querySelectorAll('script[src*="widget.usepylon.com"]')).toHaveLength(2));
 		completeScriptLoad();
 
 		await expect(secondPending).resolves.toBeUndefined();
-		expect(document.querySelectorAll('script[src*="widget.usepylon.com"]')).toHaveLength(2);
 	});
 
-	it('queues show() through the stub before the widget loads', () => {
-		const adapter = createPylonAdapter('app-123');
-		void adapter.init(USER);
+	it('queues show() through the stub before the widget loads', async () => {
+		const adapter = createPylonAdapter('app-123', fetchEmailHash);
+		const pending = adapter.init(USER);
+		await vi.waitFor(() => expect(globals().Pylon).toBeDefined());
 		adapter.show();
 
 		expect(globals().Pylon?.q).toContainEqual(['show']);
+
+		completeScriptLoad();
+		await pending;
 	});
 
-	it('registers native onShow and onHide callbacks and routes them to handlers', async () => {
-		const adapter = createPylonAdapter('app-123');
+	it('registers native onShow and onHide callbacks and routes them to handlers', () => {
+		const adapter = createPylonAdapter('app-123', fetchEmailHash);
 		const onShow = vi.fn();
 		const onHide = vi.fn();
 		adapter.subscribe({ onShow, onHide });
@@ -179,7 +172,7 @@ describe('pylon adapter', () => {
 	});
 
 	it('drops callbacks that arrive after dispose', () => {
-		const adapter = createPylonAdapter('app-123');
+		const adapter = createPylonAdapter('app-123', fetchEmailHash);
 		const onShow = vi.fn();
 		const onHide = vi.fn();
 		adapter.subscribe({ onShow, onHide });
@@ -192,85 +185,5 @@ describe('pylon adapter', () => {
 
 		expect(onShow).not.toHaveBeenCalled();
 		expect(onHide).not.toHaveBeenCalled();
-	});
-
-	describe('identity verification', () => {
-		it('sends identity fields mirroring exactly what the backend signs into the JWT', async () => {
-			const adapter = createPylonAdapter('app-123', async () => 'signed.jwt.token');
-			const pending = adapter.init(USER);
-			await vi.waitFor(() => expect(globals().pylon?.chat_settings).toHaveProperty('jwt'));
-
-			// The shipped widget (a) gates rendering on chat_settings.email/name being present
-			// regardless of JWT mode, and (b) forwards account_external_id/contact_external_id
-			// to Pylon's jwt-auth endpoint verbatim — any mismatch against the JWT's own claims
-			// gets the auth call rejected. These must mirror userService.CreateSupportChatToken.
-			expect(globals().pylon?.chat_settings).toEqual({
-				app_id: 'app-123',
-				jwt: 'signed.jwt.token',
-				email: 'ada@example.com',
-				name: 'Ada Tenant',
-				contact_external_id: 'user_1',
-				account_external_id: 'tenant_1',
-			});
-
-			completeScriptLoad();
-			await pending;
-		});
-
-		it('omits account_external_id alongside a jwt when the user has no tenant', async () => {
-			const adapter = createPylonAdapter('app-123', async () => 'signed.jwt.token');
-			const pending = adapter.init({ id: 'user_1', email: 'ada@example.com', name: 'Ada' });
-			await vi.waitFor(() => expect(globals().pylon?.chat_settings).toHaveProperty('jwt'));
-
-			const settings = globals().pylon?.chat_settings ?? {};
-			expect(settings).not.toHaveProperty('account_external_id');
-			expect(settings).not.toHaveProperty('email_hash');
-			expect(settings).toHaveProperty('contact_external_id', 'user_1');
-
-			completeScriptLoad();
-			await pending;
-		});
-
-		it('falls back to an unverified session and logs when the token fetch fails', async () => {
-			const adapter = createPylonAdapter('app-123', async () => {
-				throw new Error('token endpoint unavailable');
-			});
-			const pending = adapter.init(USER);
-			await vi.waitFor(() => expect(globals().pylon?.chat_settings).toHaveProperty('email'));
-
-			expect(globals().pylon?.chat_settings).toEqual({
-				app_id: 'app-123',
-				email: 'ada@example.com',
-				name: 'Ada Tenant',
-				account_external_id: 'tenant_1',
-			});
-			expect(mockLogError).toHaveBeenCalledOnce();
-			expect(mockLogError.mock.calls[0][2]).toMatchObject({ action: 'fetch-pylon-identity-token' });
-
-			completeScriptLoad();
-			await pending;
-		});
-
-		it('still boots the widget when the token fetch fails', async () => {
-			const adapter = createPylonAdapter('app-123', async () => {
-				throw new Error('token endpoint unavailable');
-			});
-			const pending = adapter.init(USER);
-			await vi.waitFor(() => expect(document.querySelector('script[src*="widget.usepylon.com"]')).not.toBeNull());
-			completeScriptLoad();
-
-			await expect(pending).resolves.toBeUndefined();
-		});
-
-		it('makes no token request at all when no fetcher is injected', async () => {
-			const adapter = createPylonAdapter('app-123');
-			const pending = adapter.init(USER);
-
-			expect(globals().pylon?.chat_settings).not.toHaveProperty('jwt');
-			expect(mockLogError).not.toHaveBeenCalled();
-
-			completeScriptLoad();
-			await pending;
-		});
 	});
 });

--- a/src/core/services/support-chat/adapters/pylon.ts
+++ b/src/core/services/support-chat/adapters/pylon.ts
@@ -89,7 +89,7 @@ function loadWidgetScript(appId: string): Promise<void> {
 
 export type FetchPylonEmailHash = () => Promise<string>;
 
-export function createPylonAdapter(appId: string, fetchEmailHash: FetchPylonEmailHash): SupportChatAdapter {
+export function createPylonAdapter(appId: string, fetchEmailHash?: FetchPylonEmailHash): SupportChatAdapter {
 	let disposed = false;
 	let handlers: SupportChatVisibilityHandlers | null = null;
 	let registered = false;
@@ -101,15 +101,15 @@ export function createPylonAdapter(appId: string, fetchEmailHash: FetchPylonEmai
 				throw new Error('Invalid Pylon app id: expected only letters, digits, hyphens and underscores');
 			}
 
-			const emailHash = await fetchEmailHash();
+			const emailHash = fetchEmailHash ? await fetchEmailHash() : undefined;
 			const target = pylonWindow();
 
 			const chatSettings: Record<string, unknown> = {
 				app_id: appId,
-				email_hash: emailHash,
 				email: user.email ?? '',
 				name: user.name ?? '',
 				contact_external_id: user.id,
+				...(emailHash !== undefined ? { email_hash: emailHash } : {}),
 			};
 			// Pylon documents no re-identify call, so updating this after the widget has
 			// already loaded is best-effort: it is confirmed to apply on first boot only.

--- a/src/core/services/support-chat/adapters/pylon.ts
+++ b/src/core/services/support-chat/adapters/pylon.ts
@@ -118,10 +118,22 @@ export function createPylonAdapter(appId: string, fetchIdentityToken?: FetchPylo
 				}
 			}
 
-			// Pylon requires any identity sent to the widget to match the JWT claims, so the
-			// token carries all of it and nothing else ships alongside it.
+			// The widget both (a) gates rendering on chat_settings.email/name being present,
+			// regardless of JWT mode, and (b) sends chat_settings.account_external_id /
+			// contact_external_id verbatim to Pylon's jwt-auth endpoint alongside the JWT — any
+			// mismatch against the JWT's own signed claims gets the auth call rejected. These are
+			// sent here to exactly mirror what the backend (userService.CreateSupportChatToken)
+			// signs into the token: email, name (falls back to tenant name), contact_external_id
+			// (always the user id), and account_external_id (the tenant id, when present).
 			const chatSettings: Record<string, unknown> = identityToken
-				? { app_id: appId, jwt: identityToken }
+				? {
+						app_id: appId,
+						jwt: identityToken,
+						email: user.email ?? '',
+						name: user.name ?? '',
+						contact_external_id: user.id,
+						...(user.tenantId ? { account_external_id: user.tenantId } : {}),
+					}
 				: {
 						app_id: appId,
 						email: user.email ?? '',

--- a/src/core/services/support-chat/adapters/pylon.ts
+++ b/src/core/services/support-chat/adapters/pylon.ts
@@ -2,7 +2,6 @@
  * Pylon chat widget adapter. Unlike Intercom it has native onShow/onHide, so no polling.
  * Docs: https://docs.usepylon.com/pylon-docs/chat-widget/chat-setup
  */
-import { errorLogger } from '@/core/services/error/ErrorLoggingService';
 import { DocumentReadyState } from '@/types/enums/dom';
 import type { SupportChatAdapter, SupportChatUser, SupportChatVisibilityHandlers } from '../SupportChatAdapter';
 
@@ -88,10 +87,9 @@ function loadWidgetScript(appId: string): Promise<void> {
 	return load;
 }
 
-/** Injected, not imported, so the API module is only reached when the flag is on. */
-export type FetchPylonIdentityToken = () => Promise<string>;
+export type FetchPylonEmailHash = () => Promise<string>;
 
-export function createPylonAdapter(appId: string, fetchIdentityToken?: FetchPylonIdentityToken): SupportChatAdapter {
+export function createPylonAdapter(appId: string, fetchEmailHash: FetchPylonEmailHash): SupportChatAdapter {
 	let disposed = false;
 	let handlers: SupportChatVisibilityHandlers | null = null;
 	let registered = false;
@@ -103,39 +101,16 @@ export function createPylonAdapter(appId: string, fetchIdentityToken?: FetchPylo
 				throw new Error('Invalid Pylon app id: expected only letters, digits, hyphens and underscores');
 			}
 
+			const emailHash = await fetchEmailHash();
 			const target = pylonWindow();
 
-			// Best-effort: on failure, log and boot unverified so the Help button keeps working.
-			let identityToken: string | null = null;
-			if (fetchIdentityToken) {
-				try {
-					identityToken = await fetchIdentityToken();
-				} catch (error) {
-					errorLogger.logError(error instanceof Error ? error : new Error(String(error)), undefined, {
-						scope: 'support-chat',
-						action: 'fetch-pylon-identity-token',
-					});
-				}
-			}
-
-			// This prod tenant has no Pylon account, so don't send it as account_external_id.
-			const accountExternalId = user.tenantId === '00000000-0000-0000-0000-000000000000' ? undefined : user.tenantId;
-			const chatSettings: Record<string, unknown> = identityToken
-				? {
-						app_id: appId,
-						jwt: identityToken,
-						email: user.email ?? '',
-						name: user.name ?? '',
-						contact_external_id: user.id,
-						...(accountExternalId ? { account_external_id: accountExternalId } : {}),
-					}
-				: {
-						app_id: appId,
-						email: user.email ?? '',
-						name: user.name ?? '',
-						// Groups a tenant's users under one Pylon account.
-						...(accountExternalId ? { account_external_id: accountExternalId } : {}),
-					};
+			const chatSettings: Record<string, unknown> = {
+				app_id: appId,
+				email_hash: emailHash,
+				email: user.email ?? '',
+				name: user.name ?? '',
+				contact_external_id: user.id,
+			};
 			// Pylon documents no re-identify call, so updating this after the widget has
 			// already loaded is best-effort: it is confirmed to apply on first boot only.
 			target.pylon = { chat_settings: chatSettings };

--- a/src/core/services/support-chat/adapters/pylon.ts
+++ b/src/core/services/support-chat/adapters/pylon.ts
@@ -118,13 +118,8 @@ export function createPylonAdapter(appId: string, fetchIdentityToken?: FetchPylo
 				}
 			}
 
-			// The widget both (a) gates rendering on chat_settings.email/name being present,
-			// regardless of JWT mode, and (b) sends chat_settings.account_external_id /
-			// contact_external_id verbatim to Pylon's jwt-auth endpoint alongside the JWT — any
-			// mismatch against the JWT's own signed claims gets the auth call rejected. These are
-			// sent here to exactly mirror what the backend (userService.CreateSupportChatToken)
-			// signs into the token: email, name (falls back to tenant name), contact_external_id
-			// (always the user id), and account_external_id (the tenant id, when present).
+			// This prod tenant has no Pylon account, so don't send it as account_external_id.
+			const accountExternalId = user.tenantId === '00000000-0000-0000-0000-000000000000' ? undefined : user.tenantId;
 			const chatSettings: Record<string, unknown> = identityToken
 				? {
 						app_id: appId,
@@ -132,14 +127,14 @@ export function createPylonAdapter(appId: string, fetchIdentityToken?: FetchPylo
 						email: user.email ?? '',
 						name: user.name ?? '',
 						contact_external_id: user.id,
-						...(user.tenantId ? { account_external_id: user.tenantId } : {}),
+						...(accountExternalId ? { account_external_id: accountExternalId } : {}),
 					}
 				: {
 						app_id: appId,
 						email: user.email ?? '',
 						name: user.name ?? '',
 						// Groups a tenant's users under one Pylon account.
-						...(user.tenantId ? { account_external_id: user.tenantId } : {}),
+						...(accountExternalId ? { account_external_id: accountExternalId } : {}),
 					};
 			// Pylon documents no re-identify call, so updating this after the widget has
 			// already loaded is best-effort: it is confirmed to apply on first boot only.


### PR DESCRIPTION
## **User description**
## Summary
- Switches Pylon identity verification from JWT to HMAC email hash — JWT signing was causing issues in production.
- `createPylonAdapter` now requires a `fetchEmailHash` callback (no unverified fallback); `chat_settings` sends `email_hash` instead of `jwt`.
- Removes the now-unused `VITE_PYLON_IDENTITY_VERIFICATION_ENABLED` flag and `identityVerificationEnabled` config — identity verification is always on.
- Cherry-picked from [#1289](https://github.com/flexprice/flexprice-front/pull/1289) (same change, targeting `develop`) onto `main` directly.
- Pairs with the backend PR ([#2636](https://github.com/flexprice/flexprice/pull/2636)) that swaps `CreateSupportChatToken`'s JWT signing for HMAC-SHA256.

## Test plan
- [x] `npx vitest run src/core/services/support-chat/` — 54/54 passing
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Support chat identity verification now uses an optional email hash.
  - When enabled, the email hash is securely provided during chat setup; when disabled, it is omitted.
  - Added configuration to enable or disable identity verification.

- **Bug Fixes**
  - Improved support chat initialization when identity information is unavailable or cannot be retrieved.
  - Ensured chat setup handles missing identity verification data gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Switch Pylon support chat identity verification to HMAC email hashes

### What Changed
- Pylon now sends a backend-provided HMAC email hash instead of a JWT when identity verification is enabled.
- Chat sessions include matching email, name, and contact identity fields so verified users are associated with the correct support contact.
- If the identity hash cannot be fetched, Pylon does not load an unverified chat session.
- Added coverage for verified and unverified configurations, identity-fetch failures, widget loading, and adapter behavior.

### Impact
`✅ Verified support-chat identities`
`✅ Fewer mismatched Pylon contacts`
`✅ No unverified sessions after identity-fetch failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
