### PR TITLE
fix(meter): trim whitespace from aggregation field input

### DIFF
--- a/src/pages/product-catalog/features/AddFeature.tsx
+++ b/src/pages/product-catalog/features/AddFeature.tsx
@@ -760,7 +760,7 @@ const AggregationSection = ({
 					aggregation: {
 						...meter?.aggregation,
 						type: meter?.aggregation?.type || METER_AGGREGATION_TYPE.SUM,
-						field,
+						field: field.trim(),
 					},
 				},
 			});
@@ -1075,7 +1075,7 @@ const AddFeaturePage = () => {
 								// so at most one of these is populated at submit time.
 								...(featureData.meter.aggregation?.expression?.trim()
 									? { expression: featureData.meter.aggregation.expression.trim() }
-									: { field: featureData.meter.aggregation?.field || '' }),
+									: { field: featureData.meter.aggregation?.field?.trim() || '' }),
 								multiplier: featureData.meter.aggregation?.multiplier,
 								bucket_size: aggregationSupportsBucketSize(featureData.meter.aggregation?.type)
 									? featureData.meter.aggregation?.bucket_size


### PR DESCRIPTION
## **User description**
## Summary
- The "Aggregation Field" input on the Create/Edit Feature form saved leading/trailing whitespace verbatim (e.g. `" gpu_mins"`), which then got sent to the backend as-is and mismatched actual event property keys.
- `handleAggregationFieldChange` now trims on change, and the create-feature payload builder trims `field` at submit time too, mirroring the existing `expression.trim()` handling right next to it.

## Test plan
- [x] `npx tsc --noEmit` passes with no new errors
- [ ] In the Create Feature form, type `" gpu_mins"` (leading space) into the Aggregation Field input and confirm the saved/submitted value is `"gpu_mins"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Prevent invalid aggregation field names caused by leading or trailing spaces

### What Changed
- Leading and trailing spaces are removed while entering an aggregation field
- Aggregation field names are trimmed again before feature creation, preventing whitespace from reaching the backend

### Impact
`✅ Matching event property keys`
`✅ Fewer invalid metered features`
`✅ Consistent aggregation field values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary whitespace from aggregation fields when creating or updating features.
  * Ensured fallback aggregation values are also cleaned up when no custom expression is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->