### PR TITLE
feat(auth): show SSO login button for single-tenant deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,12 @@ VITE_REO_CLIENT_ID=your-reo-client-id-here
 VITE_DASHBOARD_URL_INDIA=
 VITE_DASHBOARD_URL_US=
 
+# SAML SSO
+# Single-tenant deployments: set this to the tenant id so the SSO button always
+# shows on login without a ?sso= link. A ?sso= URL param overrides it. Leave empty
+# for multi-tenant deployments (button then requires the param).
+VITE_SSO_TENANT_ID=
+
 # Integrations
 VITE_GOOGLE_SHEETS_WEB_APP_URL=
 # AWS account ID that owns Flexprice's marketplace-metering role. Rendered into the

--- a/src/pages/auth/LoginForm.tsx
+++ b/src/pages/auth/LoginForm.tsx
@@ -10,7 +10,7 @@ import AuthApi from '@/api/AuthApi';
 import { config, APP_ENV } from '@/config/config';
 import { RouteNames } from '@/core/routes/Routes';
 import GoogleSignin from './GoogleSignin';
-import SamlSignin, { SSO_TENANT_PARAM } from './SamlSignin';
+import SamlSignin, { SSO_TENANT_PARAM, resolveSsoTenantId } from './SamlSignin';
 import { AuthTab } from './authTabs';
 import { useTranslation } from 'react-i18next';
 
@@ -30,7 +30,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ switchTab }) => {
 	// Read straight from the URL rather than held in state: the prefill effect
 	// below rewrites the query string, and a stale copy would make the SSO button
 	// disappear mid-visit.
-	const ssoTenantId = searchParams.get(SSO_TENANT_PARAM)?.trim();
+	const ssoTenantId = resolveSsoTenantId(searchParams.get(SSO_TENANT_PARAM), import.meta.env.VITE_SSO_TENANT_ID as string | undefined);
 
 	// Prefill from query params (e.g. shared login link); then strip params from URL
 	useEffect(() => {

--- a/src/pages/auth/SamlSignin.test.ts
+++ b/src/pages/auth/SamlSignin.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSsoTenantId } from './SamlSignin';
+
+describe('resolveSsoTenantId', () => {
+	it('prefers the URL param over the env tenant', () => {
+		expect(resolveSsoTenantId('tenant_url', 'tenant_env')).toBe('tenant_url');
+	});
+
+	it('falls back to the env tenant when no param (single-tenant deployment)', () => {
+		expect(resolveSsoTenantId(null, 'tenant_env')).toBe('tenant_env');
+		expect(resolveSsoTenantId('', 'tenant_env')).toBe('tenant_env');
+		expect(resolveSsoTenantId('   ', 'tenant_env')).toBe('tenant_env');
+	});
+
+	it('returns undefined when neither is set (button hidden)', () => {
+		expect(resolveSsoTenantId(null, undefined)).toBeUndefined();
+		expect(resolveSsoTenantId('  ', '  ')).toBeUndefined();
+		expect(resolveSsoTenantId(undefined, '')).toBeUndefined();
+	});
+
+	it('trims surrounding whitespace on the resolved value', () => {
+		expect(resolveSsoTenantId('  tenant_url  ', undefined)).toBe('tenant_url');
+		expect(resolveSsoTenantId(null, '  tenant_env  ')).toBe('tenant_env');
+	});
+});

--- a/src/pages/auth/SamlSignin.tsx
+++ b/src/pages/auth/SamlSignin.tsx
@@ -17,6 +17,16 @@ import { config } from '@/config/config';
 export const SSO_TENANT_PARAM = 'sso';
 
 /**
+ * Resolves which tenant the login-page SSO button should target. The URL param wins
+ * (per-tenant links on a multi-tenant deployment); otherwise a build-time tenant lets
+ * a single-tenant deployment show the button without a ?sso= URL param. Empty/whitespace
+ * on both → undefined (no button).
+ */
+export function resolveSsoTenantId(paramValue: string | null | undefined, envTenantId: string | undefined): string | undefined {
+	return paramValue?.trim() || envTenantId?.trim() || undefined;
+}
+
+/**
  * sessionStorage key marking that this browser tab started an SSO login.
  *
  * The callback stores whatever token it is handed, and it is a public route: without this, anyone


### PR DESCRIPTION
## **User description**
## What
The login-page SSO button only rendered when the URL carried `?sso=<tenant>` (`LoginForm.tsx`). Single-tenant / BYOC deployments have no such link, so SSO was effectively hidden on login.

Add a build-time `VITE_SSO_TENANT_ID` fallback:
- `?sso=` URL param still wins (multi-tenant links unchanged).
- Otherwise the env tenant is used → button always shows on a single-tenant build.
- Neither set → button hidden (existing behavior; multi-tenant default).

## How
Extracted the resolution to a pure `resolveSsoTenantId(param, env)` helper in `SamlSignin.tsx` and unit-tested it. Documented `VITE_SSO_TENANT_ID` in `.env.example`.

## Test
`vitest run src/pages/auth/SamlSignin.test.ts` → 4/4 pass (param-wins, env-fallback, hidden-when-neither, trimming).

## Notes
- UI-only. Button visibility ≠ working SSO: the tenant still needs `saml_config` set + `active=true` in DB, and the backend needs a correct `FLEXPRICE_AUTH_SAML_BASE_URL`.
- For the BYOC client, build with `VITE_SSO_TENANT_ID=<tenant-id>`.


___

## **CodeAnt-AI Description**
Show SSO login for configured single-tenant deployments

### What Changed
- The login page shows the SSO button for single-tenant deployments configured with `VITE_SSO_TENANT_ID`, even when the URL has no `?sso=` parameter.
- A `?sso=` tenant value still takes priority for multi-tenant login links.
- Empty or whitespace-only tenant values hide the button, preserving the existing behavior when no tenant is configured.
- Added coverage for tenant selection, fallback behavior, and whitespace handling.
- Documented the new environment setting in the example configuration.

### Impact
`✅ SSO available without special login links`
`✅ Multi-tenant SSO links remain targeted to their requested tenant`
`✅ SSO button stays hidden when no tenant is configured`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a default SAML SSO tenant.
  * SSO sign-in now selects the tenant from the URL when provided, otherwise using the configured default.
  * Whitespace-only tenant values are ignored for more reliable sign-in behavior.

* **Documentation**
  * Updated environment configuration guidance for single-tenant and multi-tenant SSO deployments.

* **Tests**
  * Added coverage for tenant selection, fallback behavior, and empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->