### PR TITLE
chore: add dependabot config for weekly grouped version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Security alerts + security-updates are already enabled via repo settings.
+# This file adds scheduled weekly version bumps, grouped into one PR per ecosystem.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` enabling scheduled weekly version updates.

- Ecosystems: `npm` and `github-actions` (both directory `/`).
- Weekly schedule, `open-pull-requests-limit: 5` per ecosystem.
- Each ecosystem groups all patterns (`*`) into a single PR to avoid PR floods (one grouped PR per ecosystem).

Note: security alerts and security-updates are already enabled via repo settings; this only adds scheduled version bumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly dependency update checks for npm packages and GitHub Actions.
  * Groups updates by ecosystem and limits the number of open update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->