### PR TITLE
chore: add CODEOWNERS with default reviewer teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS — default reviewers for all changes.
+# Team slugs must exist in the flexprice org. Branch protection must have
+# "Require review from Code Owners" enabled for this to gate merges.
+
+*       @flexprice/frontend @flexprice/flexprice-oss-maintainers


### PR DESCRIPTION
Adds `.github/CODEOWNERS` making `@flexprice/frontend` and `@flexprice/flexprice-oss-maintainers` default code owners for the whole repo (`*`).

Note: for this to actually gate merges, branch protection must have **"Require review from Code Owners"** enabled. Both team slugs must exist in the `flexprice` org.