### PR TITLE
fix(security): resolve open CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,6 +29,9 @@ on:
       - private
       - private-staging
 
+permissions:
+  contents: read
+
 # One deploy run per branch at a time; a newer push cancels any in-progress run.
 concurrency:
   group: deploy-${{ github.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/src/components/molecules/Tenant/UpdateTenantDrawer.tsx
+++ b/src/components/molecules/Tenant/UpdateTenantDrawer.tsx
@@ -117,10 +117,15 @@ const useUpdateTenantForm = (tenantSchema: z.ZodTypeAny, initialData?: User) => 
 		}
 	}, [initialData]);
 
+	const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 	const handleChange = (path: string, value: string) => {
 		setFormData((prev) => {
 			const newData = { ...prev };
 			const keys = path.split('.');
+			if (keys.some((key) => UNSAFE_KEYS.has(key))) {
+				return newData;
+			}
 			let current: any = newData;
 			for (let i = 0; i < keys.length - 1; i++) {
 				if (!current[keys[i]]) {

--- a/src/components/molecules/ZohoBooksConnectionDrawer/ZohoBooksConnectionDrawer.tsx
+++ b/src/components/molecules/ZohoBooksConnectionDrawer/ZohoBooksConnectionDrawer.tsx
@@ -124,6 +124,10 @@ const ZohoBooksConnectionDrawer: FC<ZohoBooksConnectionDrawerProps> = ({ isOpen,
 		onSuccess: (response) => {
 			sessionStorage.setItem(ZOHO_SESSION_KEY, response.session_id);
 			sessionStorage.setItem(OAUTH_PROVIDER_KEY, 'zoho_books');
+			// codeql[js/clear-text-storage-of-sensitive-data] organization_id is a non-secret account
+			// identifier (not the client_secret/webhook_secret credentials, which are never persisted
+			// client-side) - it must survive the full-page redirect to Zoho and back for the OAuth
+			// callback to resume the connection.
 			sessionStorage.setItem('zoho_books_organization_id', formData.organization_id.trim());
 			onOpenChange(false);
 			window.location.href = response.oauth_url;


### PR DESCRIPTION
## Summary
Resolves all 5 currently open code-scanning alerts (https://github.com/flexprice/flexprice-front/security/code-scanning):

- **#36 Prototype-polluting function** (`UpdateTenantDrawer.tsx`) — the dot-path setter now rejects `__proto__`/`constructor`/`prototype` keys before assigning. Not exploitable today (every call site passes a literal path), but the recursive-assignment pattern was a real footgun for any future dynamic caller.
- **#35 Clear-text storage of sensitive data** (`ZohoBooksConnectionDrawer.tsx`) — suppressed with a justifying inline comment. The flagged value is `organization_id`, a non-secret account identifier (not `client_secret`/`webhook_secret`, which are never persisted client-side); it's stashed in `sessionStorage` only to survive the full-page OAuth redirect to Zoho and back, the same pattern already used for the session ID right above it.
- **#34/#33/#32 Workflow missing permissions** (`deploy.yaml`, `test.yml`, `lint.yml`) — added an explicit `permissions: contents: read` block to each. None of the three write to the repo, comment on PRs, or need any broader `GITHUB_TOKEN` scope.

## Test plan
- [x] `npx tsc --noEmit -p .` clean
- [x] `npx eslint` on both touched TS/TSX files — no new warnings/errors
- [x] `npx vitest run` — 582/583 passing (the one failure, `EnvironmentApi.test.ts`, is an untouched, pre-existing timing-flaky test that passes cleanly in isolation)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)