### PR TITLE
feat(pricing): show bucket size in the three Charges tables

### DIFF
--- a/src/components/molecules/SubscriptionLineItemTable/SubscriptionLineItemTable.tsx
+++ b/src/components/molecules/SubscriptionLineItemTable/SubscriptionLineItemTable.tsx
@@ -16,7 +16,14 @@ import { ALERT_ENTITY_TYPE } from '@/models/AlertSetting';
 import { FC, useState, useCallback, useMemo } from 'react';
 import { Trash2, Pencil, Info, Eye, Tag, TicketX, Copy, Bell } from 'lucide-react';
 import { ENTITY_STATUS } from '@/models/base';
-import { copyToClipboard, formatBillingPeriodForDisplay, getCurrencySymbol, getPriceTypeLabel } from '@/utils/common/helper_functions';
+import {
+	copyToClipboard,
+	formatBillingPeriodForDisplay,
+	getBucketSizeLabel,
+	getCurrencySymbol,
+	getPriceTypeLabel,
+} from '@/utils/common/helper_functions';
+import { resolveBucketSize } from '@/utils/common/commitment_helpers';
 import { PRICE_ENTITY_TYPE, PRICE_STATUS, PRICE_TYPE } from '@/models/Price';
 import { formatDateTimeWithSecondsAndTimezone } from '@/utils/common/format_date';
 import LineItemWindowCommitmentViewDialog from '@/components/molecules/Subscription/LineItemWindowCommitmentViewDialog';
@@ -530,6 +537,13 @@ const SubscriptionLineItemTable: FC<Props> = ({
 			{
 				title: 'Billing Period',
 				render: (row) => formatBillingPeriodForDisplay(row.billing_period),
+			},
+			{
+				title: 'Bucket Size',
+				render: (row) => {
+					const label = getBucketSizeLabel(resolveBucketSize(row.price));
+					return label ? <Chip label={label} variant='default' /> : <span className='text-content-muted'>{t('labels.na')}</span>;
+				},
 			},
 			...(hasMultipleEntityTypes
 				? [

--- a/src/components/organisms/PlanPriceTable/PlanPriceTable.tsx
+++ b/src/components/organisms/PlanPriceTable/PlanPriceTable.tsx
@@ -22,6 +22,8 @@ import { ChargeValueCell } from '@/components/molecules';
 import { Dialog } from '@/components/ui';
 import { DeletePriceRequest } from '@/types/dto';
 import { formatDateTimeWithSecondsAndTimezone } from '@/utils/common/format_date';
+import { getBucketSizeLabel } from '@/utils/common/helper_functions';
+import { resolveBucketSize } from '@/utils/common/commitment_helpers';
 import useFilterSorting from '@/hooks/useFilterSorting';
 import { FilterField, FilterFieldType, FilterOperator, DataType, SortDirection, FilterCondition } from '@/types/common/QueryBuilder';
 import { sanitizeFilterConditions, sanitizeSortConditions } from '@/types/formatters/QueryBuilder';
@@ -482,6 +484,13 @@ const PlanPriceTable: FC<PlanChargesTableProps> = ({ plan, onPriceUpdate }) => {
 			{
 				title: 'Billing Period',
 				render: (row) => <span>{formatBillingPeriod(row.billing_period as string)}</span>,
+			},
+			{
+				title: 'Bucket Size',
+				render: (row) => {
+					const label = getBucketSizeLabel(resolveBucketSize(row));
+					return label ? <Chip label={label} variant='default' /> : <span className='text-content-muted'>{t('common:labels.na')}</span>;
+				},
 			},
 			{
 				title: 'Status',

--- a/src/components/organisms/Subscription/SubscriptionPriceTable.tsx
+++ b/src/components/organisms/Subscription/SubscriptionPriceTable.tsx
@@ -4,8 +4,9 @@ import { ColumnData, FlexpriceTable, LineItemCoupon } from '@/components/molecul
 import PriceOverrideDialog from '@/components/molecules/PriceOverrideDialog/PriceOverrideDialog';
 import CommitmentConfigDialog from '@/components/molecules/CommitmentConfigDialog';
 import { Price, PRICE_TYPE, PRICE_UNIT_TYPE } from '@/models';
+import type { PriceBucketSize } from '@/models/Meter';
 import { ChevronDownIcon, ChevronUpIcon, Copy, Pencil, RotateCcw, Tag, Target, Trash2 } from 'lucide-react';
-import { FormHeader, DecimalUsageInput, AddButton } from '@/components/atoms';
+import { FormHeader, DecimalUsageInput, AddButton, Chip } from '@/components/atoms';
 import { ChargeValueCell } from '@/components/molecules';
 import { capitalize } from 'es-toolkit';
 import { Coupon } from '@/models';
@@ -16,8 +17,9 @@ import { ExtendedPriceOverride } from '@/utils';
 import { LineItemCommitmentConfig } from '@/types/dto/LineItemCommitmentConfig';
 import type { CommitmentTimeBucket } from '@/types/dto/CommitmentTimeBucket';
 import type { AddedSubscriptionLineItem } from './AddSubscriptionChargeDialog';
-import { getCurrencySymbol, copyToClipboard } from '@/utils/common/helper_functions';
+import { getCurrencySymbol, copyToClipboard, getBucketSizeLabel } from '@/utils/common/helper_functions';
 import { formatBillingPeriodForPrice } from '@/utils/common/helper_functions';
+import { resolveBucketSize } from '@/utils/common/commitment_helpers';
 import { formatAmount } from '@/components/atoms/Input/Input';
 import { BILLING_PERIOD } from '@/constants/constants';
 import { isOneTimePlanPrice } from '@/utils/subscription/planPricesForSubscriptionUi';
@@ -41,7 +43,13 @@ type ChargeTableData = {
 	quantity: ReactNode;
 	price: ReactNode;
 	invoice_cadence: string;
+	bucketSize: ReactNode;
 	actions?: ReactNode;
+};
+
+const bucketSizeCell = (bucketSize: ReturnType<typeof resolveBucketSize> | PriceBucketSize | undefined, naLabel: string): ReactNode => {
+	const label = getBucketSizeLabel(bucketSize);
+	return label ? <Chip label={label} variant='default' /> : <span className='text-content-muted'>{naLabel}</span>;
 };
 
 interface PriceActionMenuProps {
@@ -274,6 +282,7 @@ const SubscriptionPriceTable: FC<Props> = ({
 			},
 			{ fieldName: 'quantity', title: t('organisms.subscriptionPriceTable.colQuantity') },
 			{ fieldName: 'price', title: t('organisms.subscriptionPriceTable.colPrice') },
+			{ fieldName: 'bucketSize', title: t('organisms.subscriptionPriceTable.colBucketSize') },
 			{
 				fieldName: 'actions',
 				title: '',
@@ -347,6 +356,7 @@ const SubscriptionPriceTable: FC<Props> = ({
 				),
 				price: <ChargeValueCell data={price} appliedCoupon={appliedCoupon} priceOverride={isOverridden ? override : undefined} />,
 				invoice_cadence: price.invoice_cadence,
+				bucketSize: bucketSizeCell(resolveBucketSize(price), t('common:labels.na')),
 				actions: (
 					<PriceActionMenu
 						price={price}
@@ -383,6 +393,7 @@ const SubscriptionPriceTable: FC<Props> = ({
 			quantity: <span>{item.quantity ?? 1}</span>,
 			price: <span>{formatAddedLineItemPrice(item, currency)}</span>,
 			invoice_cadence: item.price?.invoice_cadence ?? '--',
+			bucketSize: bucketSizeCell(item.price?.bucket_size, t('common:labels.na')),
 			actions:
 				onRemoveAddedCharge || onEditAddedCharge ? (
 					<OptionsDropdownMenu

--- a/src/i18n/locales/ar/customers.json
+++ b/src/i18n/locales/ar/customers.json
@@ -533,6 +533,7 @@
 			"colBillingPeriod": "فترة الفوترة",
 			"colQuantity": "الكمية",
 			"colPrice": "السعر",
+			"colBucketSize": "حجم الدفعة",
 			"editAdded": "تعديل",
 			"deleteAdded": "حذف"
 		},

--- a/src/i18n/locales/en/customers.json
+++ b/src/i18n/locales/en/customers.json
@@ -511,6 +511,7 @@
 			"colBillingPeriod": "Billing Period",
 			"colQuantity": "Quantity",
 			"colPrice": "Price",
+			"colBucketSize": "Bucket Size",
 			"editAdded": "Edit",
 			"deleteAdded": "Delete"
 		},

--- a/src/utils/common/helper_functions.ts
+++ b/src/utils/common/helper_functions.ts
@@ -1,5 +1,6 @@
-import { BILLING_PERIOD } from '@/constants/constants';
+import { BILLING_PERIOD, priceBucketSizeOptions } from '@/constants/constants';
 import { BILLING_MODEL, Price, PRICE_TYPE } from '@/models/Price';
+import { BUCKET_SIZE } from '@/models/Meter';
 import { getAllISOCodes } from 'iso-country-currency';
 import { v4 as uuidv4 } from 'uuid';
 import toast from 'react-hot-toast';
@@ -99,6 +100,12 @@ export const getPriceTypeLabel = (type: string | PRICE_TYPE | undefined): string
 		default:
 			return '--';
 	}
+};
+
+/** Human label for a price/meter bucket_size (e.g. "HOUR" -> "Hour"), or null when unbucketed. */
+export const getBucketSizeLabel = (bucketSize?: BUCKET_SIZE | string | null): string | null => {
+	if (!bucketSize) return null;
+	return priceBucketSizeOptions.find((option) => option.value === bucketSize)?.label ?? String(bucketSize);
 };
 
 export const toSentenceCase = (str: string): string => {


### PR DESCRIPTION
## Summary
- None of the subscription line item table, subscription price-selection table, or plan Charges table surfaced a price's `bucket_size`, even though the data (`Price.bucket_size`, with a meter fallback for legacy configs via `resolveBucketSize`) is already present on every row.
- Added a "Bucket Size" column to all three tables, reusing the existing `priceBucketSizeOptions` labels and the `Chip` component for visual consistency with the other status/type pills already in these tables.

## Context
Follow-up to #1291. While investigating why a `PUT /subscriptions/lineitems/:id` with `bucket_size` in the body wasn't reflected anywhere in the UI, confirmed the value is on `Price.bucket_size` in every one of these tables' row data already — the gap was purely a missing column. A companion backend fix (persisting `bucket_size` through the line-item override path) is being tracked separately.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on touched files — clean
- [x] `npm run build`
- [ ] Manual: open a subscription with a bucketed usage price and confirm "Bucket Size" renders on all three tables (subscription detail charges, add-charge price picker, plan overview charges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Bucket Size** column to subscription, plan pricing, and line-item tables.
  * Bucket sizes are displayed with readable labels, with **N/A** shown when unavailable.
  * Added English and Arabic translations for the new column heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->