### PR TITLE
fix(commitment): fetch the meter so window commitment survives unexpanded prices

### DIFF
--- a/src/components/molecules/CommitmentConfigDialog/CommitmentConfigDialog.tsx
+++ b/src/components/molecules/CommitmentConfigDialog/CommitmentConfigDialog.tsx
@@ -10,6 +10,7 @@ import {
 	resolveCommitmentTypeFromConfig,
 	validateCommitment,
 	supportsWindowCommitment,
+	resolveBucketSize,
 	supportsCommitmentTimeBuckets,
 	type CommitmentValidationTarget,
 } from '@/utils/common/commitment_helpers';
@@ -137,7 +138,7 @@ const CommitmentConfigDialog: FC<CommitmentConfigDialogProps> = ({
 		let normalizedTimeBuckets: CommitmentTimeBucket[] | undefined;
 		if (showTimeBucketEditor) {
 			if (timeBuckets.length > 0) {
-				const result = normalizeTimeBucketDraftsOrError(timeBuckets, commitmentType, price.bucket_size, {
+				const result = normalizeTimeBucketDraftsOrError(timeBuckets, commitmentType, resolveBucketSize(price), {
 					requireCommitmentFields: true,
 					requireBucketPrice: !!bucketPriceContext,
 					requireNonEmpty: false,
@@ -290,7 +291,9 @@ const CommitmentConfigDialog: FC<CommitmentConfigDialogProps> = ({
 					<div className='flex items-center justify-between p-4 bg-surface-subtle rounded-lg'>
 						<div className='flex-1'>
 							<label className='text-sm font-medium text-content-secondary block mb-1'>{t('commitmentConfig.windowCommitment')}</label>
-							<p className='text-xs text-content-muted'>{t('commitmentConfig.windowCommitmentHint', { bucketSize: price.bucket_size })}</p>
+							<p className='text-xs text-content-muted'>
+								{t('commitmentConfig.windowCommitmentHint', { bucketSize: resolveBucketSize(price) })}
+							</p>
 						</div>
 						<Switch
 							checked={isWindowCommitment}
@@ -309,7 +312,7 @@ const CommitmentConfigDialog: FC<CommitmentConfigDialogProps> = ({
 							setTimeBuckets(nextBuckets);
 							if (commitmentErrorTarget === 'banner') clearValidation();
 						}}
-						bucketSize={price.bucket_size}
+						bucketSize={resolveBucketSize(price)}
 						defaultCommitmentType={commitmentType}
 						currencySymbol={currencySymbol}
 						currency={price.currency}

--- a/src/components/molecules/PriceOverrideDialog/PriceOverrideDialog.tsx
+++ b/src/components/molecules/PriceOverrideDialog/PriceOverrideDialog.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/utils/subscription/subscription_line_item_commitment_helpers';
 import { resolveBucketSize } from '@/utils/common/commitment_helpers';
 import { useCommitmentTimeBucketPrices } from '@/hooks/useCommitmentTimeBucketPrices';
+import { useMeterForCommitment } from '@/hooks/useMeterForCommitment';
 import { convertPriceOverrideToLineItemUpdate } from '@/utils/subscription/priceOverrideToLineItemUpdate';
 
 interface Props {
@@ -54,7 +55,10 @@ const PriceOverrideDialog: FC<Props> = ({
 }) => {
 	const { t } = useTranslation('catalog');
 	const { t: tBilling } = useTranslation('billing');
-	const meterId = lineItem?.meter_id || lineItem?.price?.meter_id;
+	const meterId = lineItem?.meter_id || lineItem?.price?.meter_id || price.meter_id;
+	// The embedded price often carries only meter_id — fetch the meter so bucket-size
+	// resolution (and the window-commitment gate) can see meter-level bucketing.
+	const { meter: commitmentMeter } = useMeterForCommitment(meterId, price.meter ?? lineItem?.price?.meter ?? null);
 	const { bucketsWithPrices, isLoading: isLoadingBucketPrices } = useCommitmentTimeBucketPrices(
 		isOpen && lineItem ? lineItem.commitment_time_buckets : undefined,
 	);
@@ -96,14 +100,14 @@ const PriceOverrideDialog: FC<Props> = ({
 	);
 	// The API rejects a price defining its own bucket_size when the meter already carries one
 	// ("meter already defines a bucket size") - disable the override instead of surfacing that as a 400.
-	const meterBucketSize = price.meter?.aggregation?.bucket_size;
+	const meterBucketSize = price.meter?.aggregation?.bucket_size ?? commitmentMeter?.aggregation?.bucket_size;
 	// An empty selector on a price that HAD a bucket size is an explicit clear (submitted as
 	// BUCKET_SIZE_NONE). Commitment validation/normalization must then see "no bucket" — falling
 	// back to the price's old effective bucket would normalize time buckets for a removed size.
 	const bucketExplicitlyCleared = overrideBucketSize === '' && Boolean(price.bucket_size);
 	const effectiveBucketSizeForCommitment = bucketExplicitlyCleared
 		? undefined
-		: overrideBucketSize || resolveBucketSize(price) || undefined;
+		: overrideBucketSize || resolveBucketSize(price) || commitmentMeter?.aggregation?.bucket_size || undefined;
 
 	// Detect price unit type
 	const isCustomPriceUnit = price.price_unit_type === PRICE_UNIT_TYPE.CUSTOM;

--- a/src/components/molecules/Subscription/LineItemWindowCommitmentViewDialog.tsx
+++ b/src/components/molecules/Subscription/LineItemWindowCommitmentViewDialog.tsx
@@ -7,6 +7,8 @@ import {
 	lineItemWindowCommitmentStateFromBuckets,
 } from '@/utils/subscription/subscription_line_item_commitment_helpers';
 import { useCommitmentTimeBucketPrices } from '@/hooks/useCommitmentTimeBucketPrices';
+import { useMeterForCommitment } from '@/hooks/useMeterForCommitment';
+import { resolveBucketSize } from '@/utils/common/commitment_helpers';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
@@ -20,6 +22,9 @@ const LineItemWindowCommitmentViewDialog: FC<Props> = ({ isOpen, onOpenChange, l
 	const { t } = useTranslation('billing');
 	const { bucketsWithPrices, isLoading, isError } = useCommitmentTimeBucketPrices(lineItem.commitment_time_buckets);
 	const meterId = lineItem.meter_id || lineItem.price?.meter_id;
+	// Legacy charges carry the bucket on the meter, and search-sourced prices may embed only meter_id.
+	const { meter } = useMeterForCommitment(meterId, lineItem.price?.meter ?? null);
+	const sourceBucketSize = (lineItem.price ? resolveBucketSize(lineItem.price) : null) ?? meter?.aggregation?.bucket_size ?? null;
 
 	const commitmentState = useMemo(() => {
 		if (isLoading) return DEFAULT_SUBSCRIPTION_CHARGE_COMMITMENT_STATE;
@@ -50,6 +55,7 @@ const LineItemWindowCommitmentViewDialog: FC<Props> = ({ isOpen, onOpenChange, l
 					value={commitmentState}
 					onChange={() => {}}
 					disabled
+					sourceBucketSize={sourceBucketSize}
 				/>
 			)}
 		</Dialog>

--- a/src/components/molecules/Subscription/SubscriptionDetailChargesSection.tsx
+++ b/src/components/molecules/Subscription/SubscriptionDetailChargesSection.tsx
@@ -58,7 +58,7 @@ const SubscriptionDetailChargesSection: FC<Props> = ({ subscriptionId, customerI
 				active_filter: true,
 				limit,
 				offset,
-				expand: EXPAND.PRICES,
+				expand: `${EXPAND.PRICES}.${EXPAND.METERS}`,
 				filters: sanitizedFilters.length ? sanitizedFilters : undefined,
 				sort: sanitizedSorts.length ? sanitizedSorts : undefined,
 			}),

--- a/src/components/molecules/Subscription/SubscriptionEditChargesSection.tsx
+++ b/src/components/molecules/Subscription/SubscriptionEditChargesSection.tsx
@@ -87,7 +87,7 @@ const SubscriptionEditChargesSection: FC<SubscriptionEditChargesSectionProps> = 
 				active_filter: true,
 				limit,
 				offset,
-				expand: EXPAND.PRICES,
+				expand: `${EXPAND.PRICES}.${EXPAND.METERS}`,
 				filters: sanitizedFilters.length ? sanitizedFilters : undefined,
 				sort: sanitizedSorts.length ? sanitizedSorts : undefined,
 			}),

--- a/src/components/molecules/SubscriptionAddonsSection/ConfigureAddonDialog.tsx
+++ b/src/components/molecules/SubscriptionAddonsSection/ConfigureAddonDialog.tsx
@@ -73,7 +73,7 @@ const ConfigureAddonDialog: React.FC<Props> = ({
 				// Only active line items: ended charges must not reach the editors,
 				// especially via the single-charge direct-open path.
 				active_filter: true,
-				expand: EXPAND.PRICES,
+				expand: `${EXPAND.PRICES}.${EXPAND.METERS}`,
 				limit: 100,
 				offset: 0,
 			}),

--- a/src/components/molecules/UpdatePriceDialog/UpdatePriceDialog.tsx
+++ b/src/components/molecules/UpdatePriceDialog/UpdatePriceDialog.tsx
@@ -13,6 +13,7 @@ import { UpdatePriceRequest } from '@/types/dto';
 import { BUCKET_SIZE_NONE, priceBucketSizeOptions } from '@/constants/constants';
 import { formatDateTimeWithSecondsAndTimezone } from '@/utils/common/format_date';
 import { PremiumFeatureIcon } from '../PremiumFeature/PremiumFeature';
+import { useMeterForCommitment } from '@/hooks/useMeterForCommitment';
 import { useTranslation } from 'react-i18next';
 
 interface UpdatePriceDialogProps {
@@ -50,7 +51,9 @@ const UpdatePriceDialog: FC<UpdatePriceDialogProps> = ({ isOpen, onOpenChange, p
 	);
 	// The API rejects a price defining its own bucket_size when the meter already carries one
 	// ("meter already defines a bucket size") - disable the override instead of surfacing that as a 400.
-	const meterBucketSize = price.meter?.aggregation?.bucket_size;
+	// The price may embed only meter_id, so fetch the meter when aggregation data is missing.
+	const { meter: resolvedMeter } = useMeterForCommitment(price.meter_id, price.meter ?? null);
+	const meterBucketSize = price.meter?.aggregation?.bucket_size ?? resolvedMeter?.aggregation?.bucket_size;
 
 	// Detect price unit type
 	const isCustomPriceUnit = price.price_unit_type === PRICE_UNIT_TYPE.CUSTOM;

--- a/src/components/organisms/PlanForm/UsagePricingForm.tsx
+++ b/src/components/organisms/PlanForm/UsagePricingForm.tsx
@@ -21,6 +21,7 @@ import FeatureApi from '@/api/FeatureApi';
 import { ENTITY_STATUS } from '@/models/base';
 import { CurrencyPriceUnitSelector } from '@/components/molecules';
 import { CurrencyPriceUnitSelection, isPriceUnitOption } from '@/types/common';
+import { useMeterForCommitment } from '@/hooks/useMeterForCommitment';
 import { useTranslation } from 'react-i18next';
 
 /**
@@ -143,7 +144,9 @@ const UsagePricingForm: FC<Props> = ({
 	const [bucketSize, setBucketSize] = useState<PriceBucketSize | ''>((price.bucket_size as PriceBucketSize | undefined) ?? '');
 	// The API rejects a price-level bucket_size when the selected meter already defines one -
 	// disable the selector and drop any stale price-level choice instead of sending both.
-	const meterBucketSize = selectedFeature?.meter?.aggregation?.bucket_size;
+	// Features from SelectFeature often carry only meter_id, so fetch the meter when needed.
+	const { meter: resolvedMeter } = useMeterForCommitment(selectedFeature?.meter_id, selectedFeature?.meter ?? null);
+	const meterBucketSize = selectedFeature?.meter?.aggregation?.bucket_size ?? resolvedMeter?.aggregation?.bucket_size;
 	useEffect(() => {
 		if (meterBucketSize) setBucketSize('');
 	}, [meterBucketSize]);

--- a/src/components/organisms/PlanPriceTable/PlanPriceTable.tsx
+++ b/src/components/organisms/PlanPriceTable/PlanPriceTable.tsx
@@ -9,7 +9,7 @@ import {
 	UpdatePriceDetailsDrawer,
 	QueryBuilder,
 } from '@/components/molecules';
-import { Price, Plan, PRICE_STATUS, PRICE_ENTITY_TYPE, PRICE_TYPE, INVOICE_CADENCE } from '@/models';
+import { Price, Plan, PRICE_STATUS, PRICE_ENTITY_TYPE, PRICE_TYPE, INVOICE_CADENCE, EXPAND } from '@/models';
 import { PriceUnit } from '@/models/PriceUnit';
 import { Plus, Trash2, Pencil, FileText, Copy } from 'lucide-react';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -407,6 +407,8 @@ const PlanPriceTable: FC<PlanChargesTableProps> = ({ plan, onPriceUpdate }) => {
 				filters: searchFilters.length > 0 ? searchFilters : undefined,
 				sorts: searchSorts.length > 0 ? searchSorts : undefined,
 				allow_expired_prices: showExpiredPrices,
+				// Legacy prices carry the bucket on the meter; expand it so bucket-size display and edit guards resolve.
+				expand: EXPAND.METERS,
 				limit,
 				offset,
 			}),

--- a/src/components/organisms/Subscription/AddSubscriptionChargeDialog.tsx
+++ b/src/components/organisms/Subscription/AddSubscriptionChargeDialog.tsx
@@ -25,6 +25,7 @@ import {
 	sanitizeSubscriptionLineItemForApi,
 	subscriptionChargeCommitmentFromLineItem,
 } from '@/utils/subscription/subscription_line_item_commitment_helpers';
+import { useMeterForCommitment } from '@/hooks/useMeterForCommitment';
 import { useTranslation } from 'react-i18next';
 
 export type { AddedSubscriptionLineItem };
@@ -112,16 +113,16 @@ const AddSubscriptionChargeDialog: React.FC<AddSubscriptionChargeDialogProps> = 
 	const [price, setPrice] = useState<Partial<InternalPrice>>(() => getEmptyPrice(defaultCurrency, defaultBillingPeriod, defaultStartDate));
 	const [commitmentState, setCommitmentState] = useState<SubscriptionChargeCommitmentState>(DEFAULT_SUBSCRIPTION_CHARGE_COMMITMENT_STATE);
 	const [selectedMeterId, setSelectedMeterId] = useState<string | undefined>();
-	const [selectedMeterBucketSize, setSelectedMeterBucketSize] = useState<string | undefined>();
 
 	const meterId = selectedMeterId ?? price.meter_id;
-	// Price-then-meter: legacy usage prices may carry no bucket_size while their meter does.
-	const effectiveBucketSize = price.bucket_size ?? selectedMeterBucketSize;
+	// Features from SelectFeature often carry only meter_id — fetch the meter so
+	// price-then-meter bucket resolution works for legacy meter-bucketed prices.
+	const { meter } = useMeterForCommitment(meterId);
+	const effectiveBucketSize = price.bucket_size ?? meter?.aggregation?.bucket_size;
 
 	const resetForm = useCallback(() => {
 		setSelectedChargeType(null);
 		setSelectedMeterId(undefined);
-		setSelectedMeterBucketSize(undefined);
 		setCommitmentState(DEFAULT_SUBSCRIPTION_CHARGE_COMMITMENT_STATE);
 	}, []);
 
@@ -138,9 +139,6 @@ const AddSubscriptionChargeDialog: React.FC<AddSubscriptionChargeDialogProps> = 
 			);
 			setCommitmentState(subscriptionChargeCommitmentFromLineItem(initialItem));
 			setSelectedMeterId(initialItem.price?.meter_id);
-			// The line-item request shape carries no meter object; edit mode relies on
-			// the price-level bucket_size (present whenever the charge was bucketed).
-			setSelectedMeterBucketSize(undefined);
 		} else {
 			resetForm();
 			setPrice(getEmptyPrice(defaultCurrency, defaultBillingPeriod, defaultStartDate));
@@ -177,7 +175,7 @@ const AddSubscriptionChargeDialog: React.FC<AddSubscriptionChargeDialogProps> = 
 			if (isUsage) {
 				const commitmentError = applyWindowCommitmentToLineItem(finalRequest, commitmentState, {
 					...partial,
-					bucket_size: partial.bucket_size ?? selectedMeterBucketSize,
+					bucket_size: partial.bucket_size ?? meter?.aggregation?.bucket_size,
 				});
 				if (commitmentError) {
 					toast.error(formatWindowCommitmentError(commitmentError.error, t));
@@ -186,7 +184,7 @@ const AddSubscriptionChargeDialog: React.FC<AddSubscriptionChargeDialogProps> = 
 				finalRequest = sanitizeSubscriptionLineItemForApi(
 					finalRequest,
 					(partial.currency ?? defaultCurrency ?? 'usd').toLowerCase(),
-					partial.bucket_size ?? selectedMeterBucketSize,
+					partial.bucket_size ?? meter?.aggregation?.bucket_size,
 				);
 			}
 
@@ -197,7 +195,7 @@ const AddSubscriptionChargeDialog: React.FC<AddSubscriptionChargeDialogProps> = 
 				// Keep dialog open so the user can fix and retry.
 			}
 		},
-		[commitmentState, defaultCurrency, onOpenChange, onSave, selectedMeterBucketSize, t],
+		[commitmentState, defaultCurrency, meter, onOpenChange, onSave, t],
 	);
 
 	const handleAdd = useCallback((partial: Partial<InternalPrice>) => buildAndSave(partial, uniqueId('sub_')), [buildAndSave]);
@@ -256,10 +254,7 @@ const AddSubscriptionChargeDialog: React.FC<AddSubscriptionChargeDialogProps> = 
 					onDeleteClicked={() => onOpenChange(false)}
 					entityType={PRICE_ENTITY_TYPE.SUBSCRIPTION}
 					entityId={subscriptionId}
-					onMeterChange={(feature) => {
-						setSelectedMeterId(feature?.meter_id);
-						setSelectedMeterBucketSize(feature?.meter?.aggregation?.bucket_size ?? undefined);
-					}}
+					onMeterChange={(feature) => setSelectedMeterId(feature?.meter_id)}
 					isSaving={isSaving}
 					formFooter={
 						<SubscriptionChargeCommitmentSection

--- a/src/components/organisms/Subscription/AddSubscriptionChargeDialog.tsx
+++ b/src/components/organisms/Subscription/AddSubscriptionChargeDialog.tsx
@@ -186,6 +186,15 @@ const AddSubscriptionChargeDialog: React.FC<AddSubscriptionChargeDialogProps> = 
 					(partial.currency ?? defaultCurrency ?? 'usd').toLowerCase(),
 					partial.bucket_size ?? meter?.aggregation?.bucket_size,
 				);
+				// Carry the meter bucket on the pending item so the added-charges table can
+				// display it (the API payload strips `price.meter` before sending).
+				const meterBucketSize = meter?.aggregation?.bucket_size;
+				if (finalRequest.price && !finalRequest.price.bucket_size && meterBucketSize) {
+					finalRequest = {
+						...finalRequest,
+						price: { ...finalRequest.price, meter: { aggregation: { bucket_size: meterBucketSize } } } as typeof finalRequest.price,
+					};
+				}
 			}
 
 			try {

--- a/src/hooks/useMeterForCommitment.ts
+++ b/src/hooks/useMeterForCommitment.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { MeterApi } from '@/api';
+import { Meter } from '@/models/Meter';
+
+/**
+ * Resolves a meter with aggregation metadata for window-commitment UI.
+ * Features from SelectFeature often only include meter_id; this fetches the full meter when needed.
+ */
+export function useMeterForCommitment(meterId?: string, meter?: Meter | null) {
+	const hasBucketSize = meter?.aggregation?.bucket_size != null;
+
+	const { data: fetchedMeter, isLoading } = useQuery({
+		queryKey: ['meter-for-commitment', meterId],
+		queryFn: () => MeterApi.getMeterById(meterId!),
+		enabled: !!meterId && !hasBucketSize,
+		staleTime: 60_000,
+	});
+
+	const resolvedMeter = hasBucketSize ? meter : (fetchedMeter ?? meter ?? null);
+
+	return {
+		meter: resolvedMeter,
+		isLoading: !!meterId && !resolvedMeter && isLoading,
+	};
+}

--- a/src/pages/customer/customers/CreateCustomerSubscriptionPage.tsx
+++ b/src/pages/customer/customers/CreateCustomerSubscriptionPage.tsx
@@ -49,6 +49,7 @@ import { ExtendedPriceOverride, getLineItemOverrides } from '@/utils/common/pric
 import { extractLineItemCommitments } from '@/utils/common/commitment_helpers';
 import { sanitizeAddonLineItemCommitmentsForApi, filterAddonPricesForSubscription } from '@/utils/subscription/addon_commitment_helpers';
 import { extractSubscriptionBoundaries, extractFirstPhaseData } from '@/utils/subscription/phaseConversion';
+import { stripDisplayMeterFromLineItemRequest } from '@/utils/subscription/internalPriceToSubscriptionLineItemRequest';
 
 import { useBreadcrumbsStore } from '@/store/useBreadcrumbsStore';
 import { useEnvironment } from '@/hooks/useEnvironment';
@@ -789,7 +790,8 @@ const CreateCustomerSubscriptionPage: React.FC = () => {
 			line_items: (() => {
 				if (sanitized.sanitizedPhases) return undefined;
 				// Window commitment buckets are sanitized in AddSubscriptionChargeDialog (with meter context).
-				const addedItems = sanitized.addedSubscriptionLineItems?.map(({ tempId: _tempId, ...req }) => req) ?? [];
+				const addedItems =
+					sanitized.addedSubscriptionLineItems?.map(({ tempId: _tempId, ...req }) => stripDisplayMeterFromLineItemRequest(req)) ?? [];
 				return addedItems.length > 0 ? addedItems : undefined;
 			})(),
 			inheritance: Object.keys(inheritancePayload).length > 0 ? inheritancePayload : undefined,

--- a/src/pages/customer/customers/CustomerSubscriptionEditPage.tsx
+++ b/src/pages/customer/customers/CustomerSubscriptionEditPage.tsx
@@ -46,6 +46,7 @@ import { EXPAND } from '@/models';
 import { generateExpandQueryParams } from '@/utils/common/api_helper';
 import { ExtendedPriceOverride } from '@/utils/common/price_override_helpers';
 import { isInheritedSubscription } from '@/utils/subscription/isInheritedSubscription';
+import { stripDisplayMeterFromLineItemRequest } from '@/utils/subscription/internalPriceToSubscriptionLineItemRequest';
 import { getPriceTypeFromLineItem, lineItemToPrice } from '@/utils/subscription/lineItemToPrice';
 import { RouteNames } from '@/core/routes/Routes';
 import { refetchQueries } from '@/core/services/tanstack/ReactQueryProvider';
@@ -365,7 +366,7 @@ const CustomerSubscriptionEditPage: React.FC = () => {
 		async (item: AddedSubscriptionLineItem) => {
 			const { tempId, ...request } = item;
 			void tempId;
-			await createLineItem(request as CreateSubscriptionLineItemRequest);
+			await createLineItem(stripDisplayMeterFromLineItemRequest(request as CreateSubscriptionLineItemRequest));
 		},
 		[createLineItem],
 	);

--- a/src/utils/subscription/internalPriceToSubscriptionLineItemRequest.ts
+++ b/src/utils/subscription/internalPriceToSubscriptionLineItemRequest.ts
@@ -78,6 +78,16 @@ function applyFixedChargePricingFields(price: SubscriptionPriceCreateRequest, in
 /** Subscription line item in local form state (API request payload + client-side temp id). */
 export type AddedSubscriptionLineItem = CreateSubscriptionLineItemRequest & { tempId: string };
 
+/**
+ * Strip the display-only `price.meter` (stamped for pending-charge bucket display)
+ * before sending a line item request to the API.
+ */
+export function stripDisplayMeterFromLineItemRequest(request: CreateSubscriptionLineItemRequest): CreateSubscriptionLineItemRequest {
+	if (!request.price || !('meter' in request.price)) return request;
+	const { meter: _meter, ...price } = request.price as SubscriptionPriceCreateRequest & { meter?: unknown };
+	return { ...request, price };
+}
+
 export interface SubscriptionLineItemFormDefaults {
 	currency?: string;
 	billingPeriod?: string;

--- a/src/utils/subscription/subscription_line_item_commitment_helpers.ts
+++ b/src/utils/subscription/subscription_line_item_commitment_helpers.ts
@@ -559,17 +559,22 @@ export function sanitizeSubscriptionLineItemForApi(
 	const priceContext = bucketPriceContextFromLineItem(item, currency);
 	if (!priceContext) return item;
 
-	const buckets = normalizeCommitmentTimeBuckets(item.commitment_time_buckets, effectiveBucketSize ?? item.price?.bucket_size).map(
-		(bucket) => {
-			const draft = bucket as CommitmentTimeBucketDraft;
-			const hasInlinePrice = bucket.price && (bucket.price.amount || bucket.price.tiers?.length || bucket.price.billing_model);
+	// Price-then-meter fallback: legacy prices define the bucket only on their meter.
+	const itemPrice = item.price as
+		| (NonNullable<CreateSubscriptionLineItemRequest['price']> & {
+				meter?: { aggregation?: { bucket_size?: BUCKET_SIZE | string | null } };
+		  })
+		| undefined;
+	const fallbackBucketSize = itemPrice?.bucket_size ?? itemPrice?.meter?.aggregation?.bucket_size;
+	const buckets = normalizeCommitmentTimeBuckets(item.commitment_time_buckets, effectiveBucketSize ?? fallbackBucketSize).map((bucket) => {
+		const draft = bucket as CommitmentTimeBucketDraft;
+		const hasInlinePrice = bucket.price && (bucket.price.amount || bucket.price.tiers?.length || bucket.price.billing_model);
 
-			return {
-				...bucket,
-				price: hasInlinePrice ? bucket.price : buildBucketPriceFromDraft(draft, priceContext),
-			};
-		},
-	);
+		return {
+			...bucket,
+			price: hasInlinePrice ? bucket.price : buildBucketPriceFromDraft(draft, priceContext),
+		};
+	});
 
 	return {
 		...item,


### PR DESCRIPTION
## Root cause of the prod issue (and the #1313 revert)

The subscription line-items API embeds a price with `meter_id` but **no meter object** and (for meter-bucketed prices) **no price-level `bucket_size`**. Develop's window-commitment gate resolves the bucket only from that embedded price, so it saw `null` and rendered *“This charge does not support window commitment. Configure a bucket size on the price first.”* — even for line items that already carry `commitment_windowed: true` with time buckets (e.g. the Simplismart `nvidia-h100` charge).

Pre-release `main` handled this with a `useMeterForCommitment` hook that fetches the meter when embedded data lacks aggregation metadata. The 2026-08-27 release replaced that area with develop's embedded-only resolution, shipping the regression; #1313 reverted the release.

## Fix

Restores `useMeterForCommitment` (verbatim from pre-release main) and wires the fetched meter into every bucket-resolution site:

- **PriceOverrideDialog** — the support gate, `sourceBucketSize`, and commitment normalization resolve **price → embedded meter → fetched meter** (an explicit bucket clear still yields “no bucket”).
- **AddSubscriptionChargeDialog** — the fetched meter replaces the `onMeterChange` bucket plumbing for normalization/sanitization and the commitment section.
- **UsagePricingForm** — the meter-conflict guard (selector disabled when the meter defines a bucket) now sees fetched meters, since `SelectFeature` features often carry only `meter_id`.

With this merged into develop, the next release can re-land safely.

## Testing

TypeScript, ESLint (0 errors), production build, and the full Vitest suite (582 passing) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved commitment validation and normalization by consistently using the associated meter’s aggregation bucket size.
  * Added fallback handling when meter details are available only through a price or feature.
  * Improved subscription charge editing and usage pricing behavior when meter information loads asynchronously.
  * Added clearer loading behavior while meter details are being resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->