### PR TITLE
fix(billing): stop long charge amounts from hiding the row action menu

### DIFF
--- a/src/components/molecules/ChargeValueCell/ChargeValueCell.tsx
+++ b/src/components/molecules/ChargeValueCell/ChargeValueCell.tsx
@@ -344,8 +344,10 @@ const ChargeValueCell: FC<Props> = ({ data, appliedCoupon, priceOverride }) => {
 
 	const couponLabel = appliedCoupon ? formatCouponName(appliedCoupon) : t('catalog:chargeValue.noCouponApplied');
 
+	const priceDisplay = formatPriceDisplay(displayData);
+
 	return (
-		<div className='flex items-center gap-2'>
+		<div className='flex min-w-0 items-center gap-2'>
 			{discountInfo ? (
 				<DiscountedPriceDisplay
 					originalAmount={discountInfo.originalAmount}
@@ -354,7 +356,9 @@ const ChargeValueCell: FC<Props> = ({ data, appliedCoupon, priceOverride }) => {
 					couponName={couponLabel}
 				/>
 			) : (
-				<div>{formatPriceDisplay(displayData)}</div>
+				<div className='min-w-0 truncate' title={priceDisplay}>
+					{priceDisplay}
+				</div>
 			)}
 
 			{hasOverrides && !isTiered && overriddenNormalized && (

--- a/src/components/molecules/SubscriptionLineItemTable/SubscriptionLineItemTable.tsx
+++ b/src/components/molecules/SubscriptionLineItemTable/SubscriptionLineItemTable.tsx
@@ -582,7 +582,7 @@ const SubscriptionLineItemTable: FC<Props> = ({
 					const isSubscriptionOverride =
 						row.price.entity_type === PRICE_ENTITY_TYPE.SUBSCRIPTION && row.entity_type === SUBSCRIPTION_LINE_ITEM_ENTITY_TYPE.PLAN;
 					return (
-						<div className='flex items-center gap-2'>
+						<div className='flex min-w-0 items-center gap-2'>
 							<ChargeValueCell data={row.price} />
 							{isSubscriptionOverride && <PriceTooltip data={row.price} isSubscriptionOverride={true} />}
 						</div>

--- a/src/utils/common/price_helpers.test.ts
+++ b/src/utils/common/price_helpers.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { formatPriceDisplay, NormalizedPriceDisplay } from './price_helpers';
+import { BILLING_MODEL, TIER_MODE, PRICE_UNIT_TYPE } from '@/models/Price';
+
+const base: NormalizedPriceDisplay = {
+	amount: '0',
+	symbol: '$',
+	tiers: null,
+	billingModel: BILLING_MODEL.FLAT_FEE,
+	tierMode: TIER_MODE.VOLUME,
+	transformQuantity: null,
+	priceUnitType: PRICE_UNIT_TYPE.FIAT,
+};
+
+describe('formatPriceDisplay', () => {
+	it('caps a long floating-point decimal tail to 6 places instead of rendering it in full', () => {
+		expect(formatPriceDisplay({ ...base, amount: '0.066666666666667' })).toBe('$0.066667');
+	});
+
+	it('leaves short, common decimal amounts unchanged', () => {
+		expect(formatPriceDisplay({ ...base, amount: '5.00' })).toBe('$5.00');
+		expect(formatPriceDisplay({ ...base, amount: '19.99' })).toBe('$19.99');
+	});
+
+	it('leaves whole-number amounts unchanged', () => {
+		expect(formatPriceDisplay({ ...base, amount: '100' })).toBe('$100');
+	});
+
+	it('caps the divideBy-derived unit amount for PACKAGE billing', () => {
+		expect(
+			formatPriceDisplay({
+				...base,
+				billingModel: BILLING_MODEL.PACKAGE,
+				amount: '0.066666666666667',
+				transformQuantity: { divide_by: 15 },
+			}),
+		).toBe('$0.066667 / 15 units');
+	});
+
+	it('caps the first tier unit amount for TIERED billing', () => {
+		expect(
+			formatPriceDisplay({
+				...base,
+				billingModel: BILLING_MODEL.TIERED,
+				tiers: [{ up_to: 100, unit_amount: '0.066666666666667', flat_amount: '0' }],
+			}),
+		).toBe('starts at $0.066667 per unit');
+	});
+});

--- a/src/utils/common/price_helpers.ts
+++ b/src/utils/common/price_helpers.ts
@@ -134,26 +134,39 @@ export const normalizePriceDisplay = (
  * @param normalized - The normalized price display data
  * @returns Formatted price string for display
  */
+// Backend amounts can carry full floating-point precision (e.g. a per-unit rate computed as
+// amount/quantity yielding "0.066666666666667"). Display doesn't need more than this many decimal
+// places - values with fewer decimals are returned untouched, so the common 2-decimal case is
+// unaffected.
+const MAX_DISPLAY_DECIMALS = 6;
+
+const capDisplayDecimals = (amount: string, maxDecimals: number = MAX_DISPLAY_DECIMALS): string => {
+	const [, decimalPart] = amount.split('.');
+	if (!decimalPart || decimalPart.length <= maxDecimals) return amount;
+	const parsed = Number(amount);
+	return Number.isFinite(parsed) ? parsed.toFixed(maxDecimals) : amount;
+};
+
 export const formatPriceDisplay = (normalized: NormalizedPriceDisplay): string => {
 	const { amount, symbol, billingModel, transformQuantity, tiers } = normalized;
 
 	switch (billingModel) {
 		case BILLING_MODEL.FLAT_FEE:
-			return `${symbol}${formatAmount(amount)}`;
+			return `${symbol}${formatAmount(capDisplayDecimals(amount))}`;
 
 		case BILLING_MODEL.PACKAGE: {
 			const divideBy = transformQuantity?.divide_by || 1;
-			return `${symbol}${formatAmount(amount)} / ${divideBy} units`;
+			return `${symbol}${formatAmount(capDisplayDecimals(amount))} / ${divideBy} units`;
 		}
 
 		case BILLING_MODEL.TIERED:
 		case 'SLAB_TIERED': {
 			const firstTier = tiers?.[0];
-			return `starts at ${symbol}${formatAmount(firstTier?.unit_amount || '0')} per unit`;
+			return `starts at ${symbol}${formatAmount(capDisplayDecimals(firstTier?.unit_amount || '0'))} per unit`;
 		}
 
 		default:
-			return `${symbol}${formatAmount(amount)}`;
+			return `${symbol}${formatAmount(capDisplayDecimals(amount))}`;
 	}
 };
 


### PR DESCRIPTION
## Summary
On the subscription edit page's Charges table, a per-unit usage price rendered as a raw, unrounded floating-point value (e.g. `0.066666666666667`) overflows its column in the `table-fixed` layout and visually covers the trailing "..." action menu - which becomes completely inaccessible since `table-fixed` doesn't grow the table's scrollable width for visually-overflowing content, so there's nothing to scroll to either.

## Fix
- `price_helpers.ts` - cap displayed decimal precision to 6 places in `formatPriceDisplay`. Amounts with 6 or fewer decimals (the common case) pass through unchanged; fixes the reported value at its source.
- `ChargeValueCell.tsx` - defensive truncation (`min-w-0` + `truncate` + a `title` attribute with the full value) on the price text, since billing models like PACKAGE/TIERED still produce longer descriptive strings that decimal-capping alone doesn't bound. `ChargeValueCell` is shared by every price table in the app (Plan, Subscription, Addon, CostSheet, ...), so this closes the same class of bug everywhere it's used, not just on this page. Mirrors the truncate+tooltip pattern already used for this table's Display Name column.
- `SubscriptionLineItemTable.tsx` - `min-w-0` on the Charge column's flex wrapper, completing the flex-shrink chain down to the truncating div.

## Test plan
- [x] Added `price_helpers.test.ts` covering the exact reported value plus FLAT_FEE/PACKAGE/TIERED billing models, and confirming short/common decimal amounts (`5.00`, `19.99`, whole numbers) are unaffected
- [x] `npx tsc --noEmit -p .` clean
- [x] `npx eslint` on all touched files - no new warnings/errors
- [x] `npx vitest run` - all 587 tests pass
- [x] `npm run build` succeeds
- [x] Visually verified with a throwaway local harness rendering `ChargeValueCell` at the production column width: the reported value now renders as `$0.066667` with the action menu fully visible, and an intentionally more extreme value (huge integer part) correctly truncates with an ellipsis + tooltip instead of reproducing the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved charge value display in subscription tables by truncating long amounts cleanly within narrow layouts.
  - Added tooltips so users can view the full charge when the displayed value is truncated.
  - Standardized pricing calculations to round lengthy decimal values to six places while preserving valid special values.
  - Corrected formatting consistency for flat-fee, package, tiered, and slab-tiered pricing.
- **Tests**
  - Added coverage for decimal rounding and pricing display across supported billing models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->