### PR TITLE
fix(subscription): stop charges table pagination from resetting to page 1 mid-fetch

### DIFF
--- a/src/components/molecules/Subscription/SubscriptionDetailChargesSection.tsx
+++ b/src/components/molecules/Subscription/SubscriptionDetailChargesSection.tsx
@@ -1,6 +1,6 @@
 import { FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import SubscriptionApi from '@/api/SubscriptionApi';
 import { Card, CardHeader, ShortPagination, Spacer } from '@/components/atoms';
 import { QueryBuilder } from '@/components/molecules/QueryBuilder';
@@ -63,6 +63,11 @@ const SubscriptionDetailChargesSection: FC<Props> = ({ subscriptionId, customerI
 				sort: sanitizedSorts.length ? sanitizedSorts : undefined,
 			}),
 		enabled: !!subscriptionId && !!customerId && !!currentPeriodStart,
+		// Keep the previous page's data (and total) visible while the next page is in flight.
+		// Without this, `data` briefly goes undefined on every page change (queryKey changes,
+		// nothing cached yet), totalLineItems collapses to 0, and ShortPagination's self-clamp
+		// effect immediately snaps the page back to 1 before the new page's response arrives.
+		placeholderData: keepPreviousData,
 	});
 
 	const lineItems = useMemo(() => (lineItemsResponse?.items ?? []).map(subscriptionLineItemListItemToLineItem), [lineItemsResponse?.items]);

--- a/src/components/molecules/Subscription/SubscriptionEditChargesSection.pagination.test.tsx
+++ b/src/components/molecules/Subscription/SubscriptionEditChargesSection.pagination.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+import { I18nextProvider } from 'react-i18next';
+import { createInstance } from 'i18next';
+import type { i18n as I18nInstance } from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import commonEn from '@/i18n/locales/en/common.json';
+
+const mockSearchSubscriptionLineItems = vi.hoisted(() => vi.fn());
+
+vi.mock('@/api/SubscriptionApi', () => ({
+	default: {
+		searchSubscriptionLineItems: (...args: unknown[]) => mockSearchSubscriptionLineItems(...args),
+	},
+}));
+
+vi.mock('@/components/molecules/SubscriptionLineItemTable/SubscriptionLineItemTable', () => ({
+	default: () => null,
+}));
+
+vi.mock('@/components/molecules/QueryBuilder', () => ({
+	QueryBuilder: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import SubscriptionEditChargesSection from './SubscriptionEditChargesSection';
+
+let testI18n: I18nInstance;
+
+beforeAll(async () => {
+	const instance = createInstance();
+	await instance.use(initReactI18next).init({
+		lng: 'en',
+		fallbackLng: 'en',
+		ns: ['common'],
+		defaultNS: 'common',
+		resources: { en: { common: commonEn } },
+		interpolation: { escapeValue: false },
+	});
+	testI18n = instance;
+});
+
+// 25 total line items, 10 per page — enough to exercise page 1 -> page 2.
+const pageOfItems = (offset: number, limit: number, total = 25) =>
+	Array.from({ length: Math.max(0, Math.min(limit, total - offset)) }, (_, i) => ({
+		id: `li_${offset + i}`,
+		price: { id: `price_${offset + i}`, amount: '10', currency: 'usd' },
+	}));
+
+const renderSection = () => {
+	// Mirrors the real app's QueryClient defaults: staleTime 0, gcTime 0, no placeholderData
+	// override at the client level — the fix under test sets placeholderData on the query itself.
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { staleTime: 0, gcTime: 0, retry: false } },
+	});
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<I18nextProvider i18n={testI18n}>
+				<MemoryRouter initialEntries={['/subscriptions/sub_1/edit']}>
+					<SubscriptionEditChargesSection
+						subscriptionId='sub_1'
+						customerId='cust_1'
+						currentPeriodStart='2026-01-01T00:00:00Z'
+						onEditLineItem={vi.fn()}
+						onTerminateLineItem={vi.fn()}
+					/>
+				</MemoryRouter>
+			</I18nextProvider>
+		</QueryClientProvider>,
+	);
+};
+
+describe('SubscriptionEditChargesSection pagination', () => {
+	beforeEach(() => {
+		mockSearchSubscriptionLineItems.mockReset();
+		mockSearchSubscriptionLineItems.mockImplementation(async ({ limit, offset }: { limit: number; offset: number }) => {
+			await new Promise((r) => setTimeout(r, 100));
+			return { items: pageOfItems(offset, limit), pagination: { total: 25 } };
+		});
+	});
+
+	it('does not snap back to page 1 while the next page is still loading', async () => {
+		renderSection();
+
+		// Wait for the initial (page 1) fetch to resolve and the pagination row to render.
+		await waitFor(() => expect(screen.getByText(/Showing 1 to 10 of 25 charges/i)).toBeInTheDocument());
+		expect(mockSearchSubscriptionLineItems).toHaveBeenCalledTimes(1);
+		expect(mockSearchSubscriptionLineItems).toHaveBeenNthCalledWith(1, expect.objectContaining({ offset: 0, limit: 10 }));
+
+		fireEvent.click(screen.getByLabelText(/next/i));
+
+		// While the page-2 fetch is in flight, the range text must not regress to "1 to 10" —
+		// that would mean the self-clamp effect reset the page back to 1 before the response landed.
+		await waitFor(() => expect(mockSearchSubscriptionLineItems).toHaveBeenCalledTimes(2));
+		expect(mockSearchSubscriptionLineItems).toHaveBeenNthCalledWith(2, expect.objectContaining({ offset: 10, limit: 10 }));
+
+		await waitFor(() => expect(screen.getByText(/Showing 11 to 20 of 25 charges/i)).toBeInTheDocument());
+
+		// The bug re-fetched page 1 a third time after bouncing back — assert that never happened.
+		expect(mockSearchSubscriptionLineItems).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/components/molecules/Subscription/SubscriptionEditChargesSection.tsx
+++ b/src/components/molecules/Subscription/SubscriptionEditChargesSection.tsx
@@ -5,7 +5,7 @@ import SubscriptionLineItemTable from '@/components/molecules/SubscriptionLineIt
 import { QueryBuilder } from '@/components/molecules/QueryBuilder';
 import type { LineItem, SubscriptionCommitmentInfo, SubscriptionPhase } from '@/models/Subscription';
 import formatDate from '@/utils/common/format_date';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import SubscriptionApi from '@/api/SubscriptionApi';
 import { EXPAND } from '@/models';
 import usePagination, { PAGINATION_PREFIX } from '@/hooks/usePagination';
@@ -92,6 +92,11 @@ const SubscriptionEditChargesSection: FC<SubscriptionEditChargesSectionProps> = 
 				sort: sanitizedSorts.length ? sanitizedSorts : undefined,
 			}),
 		enabled: !!subscriptionId && !!customerId && !!currentPeriodStart,
+		// Keep the previous page's data (and total) visible while the next page is in flight.
+		// Without this, `data` briefly goes undefined on every page change (queryKey changes,
+		// nothing cached yet), totalLineItems collapses to 0, and ShortPagination's self-clamp
+		// effect immediately snaps the page back to 1 before the new page's response arrives.
+		placeholderData: keepPreviousData,
 	});
 
 	const lineItems = useMemo(() => (lineItemsResponse?.items ?? []).map(subscriptionLineItemListItemToLineItem), [lineItemsResponse?.items]);


### PR DESCRIPTION
## Summary
On the subscription edit page's Charges table (and its read-only sibling on the subscription details page), clicking Next on the pagination control appeared completely broken - the page snapped back to 1 immediately instead of advancing.

## Root cause
The shared `QueryClient` (`ReactQueryProvider.tsx`) uses `staleTime: 0` / `gcTime: 0` with no `placeholderData` configured. When the page/limit-derived query key changed, `data` briefly went `undefined` while the new page's request was in flight (nothing cached for that key yet), so `totalLineItems` collapsed to `0`.

`ShortPaginationControls`'s self-correcting effect - which exists to recover from a stale page number after e.g. a delete or filter shrinks the total - saw `totalPages <= 1` under that momentarily-zero total and immediately clamped the page back to `1`, before the in-flight fetch for the requested page had even resolved.

## Fix
Added `placeholderData: keepPreviousData` to the line-item queries in:
- `SubscriptionEditChargesSection.tsx` (the reported page)
- `SubscriptionDetailChargesSection.tsx` (read-only sibling sharing the identical query/pagination pattern and `PAGINATION_PREFIX.SUBSCRIPTION_LINE_ITEMS`)

The previous page's data (and total) now stay visible while the next page loads, so the total never spuriously drops to 0 and the self-clamp effect no longer misfires. As a side benefit this also removes a loading-skeleton flash on every page change, and stops `SubscriptionDetailChargesSection`'s entire card from unmounting on every paginated fetch (its `isLoading` check was gating a `return null`, previously true on every page change, not just the first load).

## Test plan
- [x] Added a regression test (`SubscriptionEditChargesSection.pagination.test.tsx`) that mounts the real component against a delayed mock API response and asserts the page doesn't bounce back to 1 while page 2 is loading; confirmed it **fails** against the pre-fix code and **passes** with the fix
- [x] `npx tsc --noEmit -p .` clean
- [x] `npx eslint` on all touched files - no new warnings/errors
- [x] `npx vitest run` - all 588 tests pass
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription charge pagination so the current page remains visible while the next page loads.
  * Prevented pagination from unexpectedly returning to page 1 during page changes.
  * Preserved item totals and range information while loading new results.

* **Tests**
  * Added coverage to verify stable pagination behavior during delayed page requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->