### PR TITLE
feat(imports): switch CSV Box uploads to upload_id + tenant/env customer_id

### DIFF
--- a/src/components/molecules/ImportFileDrawer/ImportFileDrawer.test.tsx
+++ b/src/components/molecules/ImportFileDrawer/ImportFileDrawer.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import '@testing-library/jest-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { createInstance } from 'i18next';
+import type { i18n as I18nInstance } from 'i18next';
+import ImportFileDrawer from './ImportFileDrawer';
+import TaskApi from '@/api/TaskApi';
+
+// The CSVBoxButton renderer receives (launch, isLoading); reproduce the shape
+// so we can assert what our component passes it and simulate a completed upload.
+const csvBoxSpy = vi.fn();
+vi.mock('@csvbox/react', () => ({
+	CSVBoxButton: (props: {
+		user: string;
+		licenseKey: string;
+		onImport: (ok: boolean, meta: Record<string, unknown>) => void;
+		render: (launch: () => void, isLoading: boolean) => React.ReactNode;
+	}) => {
+		csvBoxSpy(props);
+		return (
+			<div>
+				<div data-testid='csvbox-user'>{props.user}</div>
+				{props.render(() => {
+					props.onImport(true, {
+						import_id: 987654,
+						original_filename: 'events.csv',
+						raw_file: 'https://example.com/events.csv',
+					});
+				}, false)}
+			</div>
+		);
+	},
+}));
+
+// Radix Select's portal + pointer-event dance doesn't play nicely with jsdom;
+// swap in a native <select> that exercises the same onChange contract. Also
+// stub Sheet so we don't rely on Radix Dialog focus traps.
+vi.mock('@/components/atoms', async () => {
+	const actual = await vi.importActual<Record<string, unknown>>('@/components/atoms');
+	return {
+		...actual,
+		Select: ({
+			options,
+			onChange,
+			label,
+		}: {
+			options: { value: string; label: string }[];
+			onChange?: (v: string) => void;
+			label?: string;
+		}) => (
+			<label>
+				{label}
+				<select data-testid='entity-type' onChange={(e) => onChange?.(e.target.value)}>
+					<option value=''>--</option>
+					{options.map((o) => (
+						<option key={o.value} value={o.value}>
+							{o.label}
+						</option>
+					))}
+				</select>
+			</label>
+		),
+		Sheet: ({ children, isOpen }: { children: React.ReactNode; isOpen: boolean }) => (isOpen ? <div>{children}</div> : null),
+	};
+});
+
+vi.mock('@/api/TaskApi', () => ({
+	default: {
+		addTask: vi.fn().mockResolvedValue({ id: 'task_1' }),
+		getTaskById: vi.fn().mockResolvedValue({ id: 'task_1', task_status: 'PENDING' }),
+	},
+}));
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('@/core/services/tanstack/ReactQueryProvider', () => ({ refetchQueries: vi.fn() }));
+vi.mock('@/hooks/useUser', () => ({ default: () => ({ user: { tenant: { id: 'tenant-42' } } }) }));
+vi.mock('@/hooks/useEnvironment', () => ({
+	useEnvironment: () => ({ activeEnvironment: { id: 'env-prod' } }),
+}));
+
+let testI18n: I18nInstance;
+beforeAll(async () => {
+	const instance = createInstance();
+	await instance.use(initReactI18next).init({
+		lng: 'en',
+		fallbackLng: 'en',
+		ns: ['settings', 'common'],
+		defaultNS: 'settings',
+		resources: {
+			en: {
+				settings: {
+					common: { labels: { importFile: 'Import File', importFileDescription: 'Import File Description' } },
+					import: {
+						entityTypes: { events: 'Events', customers: 'Customers', features: 'Features', prices: 'Prices' },
+						fileTypes: { csv: 'CSV', json: 'JSON' },
+						taskTypes: { import: 'Import', export: 'Export' },
+						taskStatus: { successful: 'Successful', failed: 'Failed', queued: 'Queued' },
+						validation: { uploadFile: 'upload file', selectEntityType: 'select entity type' },
+						toast: { uploadSuccess: '{{filename}} ok', uploadFailed: '{{filename}} fail' },
+						errors: {
+							notConfigured: 'not configured',
+							invalidUploadId: 'invalid upload',
+							missingTenantOrEnv: 'waiting for tenant/env',
+							downloadFailedHint: 'download failed hint',
+						},
+						importFileLabel: 'Import file',
+						chooseFile: 'Choose File to Upload',
+						maxFileSizeHint: 'max file size',
+						detailLabels: {},
+						rowStats: {},
+					},
+				},
+				common: {
+					labels: {
+						importFile: 'Import File',
+						importFileDescription: 'Description',
+						importType: 'Import Type',
+						selectImportType: 'Select',
+						importData: 'Import Data',
+						compareFileFormatting: 'Compare',
+						maxFileSizeSubtitle: 'Max size',
+						sampleCsv: 'Sample',
+						na: 'N/A',
+						importDetails: 'Details',
+						downloadCsv: 'Download CSV',
+						tryAgain: 'Try Again',
+					},
+					actions: { refresh: 'Refresh', done: 'Done' },
+					toast: { genericError: 'Something went wrong' },
+				},
+			},
+		},
+		interpolation: { escapeValue: false },
+	});
+	testI18n = instance;
+});
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+	<QueryClientProvider client={new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } })}>
+		<I18nextProvider i18n={testI18n}>{children}</I18nextProvider>
+	</QueryClientProvider>
+);
+
+beforeEach(() => {
+	csvBoxSpy.mockClear();
+	vi.mocked(TaskApi.addTask).mockClear();
+});
+
+describe('ImportFileDrawer csvbox flow', () => {
+	it('passes tenant__env as the CSV Box user identifier', async () => {
+		render(
+			<Wrapper>
+				<ImportFileDrawer isOpen={true} onOpenChange={() => {}} />
+			</Wrapper>,
+		);
+		await userEvent.selectOptions(screen.getByTestId('entity-type'), 'EVENTS');
+
+		await waitFor(() => {
+			expect(screen.getByTestId('csvbox-user')).toHaveTextContent('tenant-42__env-prod');
+		});
+	});
+
+	it('POSTs the task with file_provider=csvbox and upload_id (no file_url)', async () => {
+		render(
+			<Wrapper>
+				<ImportFileDrawer isOpen={true} onOpenChange={() => {}} />
+			</Wrapper>,
+		);
+		await userEvent.selectOptions(screen.getByTestId('entity-type'), 'EVENTS');
+		const chooseBtn = await screen.findByText('Choose File to Upload');
+		await userEvent.click(chooseBtn);
+
+		await waitFor(() => {
+			expect(TaskApi.addTask).toHaveBeenCalledTimes(1);
+		});
+		const payload = vi.mocked(TaskApi.addTask).mock.calls[0][0];
+		expect(payload).toMatchObject({
+			task_type: 'IMPORT',
+			entity_type: 'EVENTS',
+			file_type: 'CSV',
+			file_provider: 'csvbox',
+			upload_id: '987654',
+			file_name: 'events.csv',
+		});
+		expect((payload as { file_url?: string }).file_url).toBeUndefined();
+	});
+});

--- a/src/components/molecules/ImportFileDrawer/ImportFileDrawer.tsx
+++ b/src/components/molecules/ImportFileDrawer/ImportFileDrawer.tsx
@@ -11,6 +11,8 @@ import { ImportTask } from '@/models/ImportTask';
 import { toSentenceCase } from '@/utils/common/helper_functions';
 import toast from 'react-hot-toast';
 import { refetchQueries } from '@/core/services/tanstack/ReactQueryProvider';
+import useUser from '@/hooks/useUser';
+import { useEnvironment } from '@/hooks/useEnvironment';
 
 interface Props {
 	isOpen: boolean;
@@ -79,6 +81,17 @@ const getSampleFileUrl = (tab: string): string => {
 	}
 };
 
+// Map backend 400 messages from the csvbox import endpoint to friendly copy.
+// The backend surfaces two specific strings we want to distinguish; anything
+// else falls through to the caller's generic error.
+const getCsvImportErrorKey = (message: string | undefined): string | null => {
+	if (!message) return null;
+	const m = message.toLowerCase();
+	if (m.includes('csv imports are not configured')) return 'import.errors.notConfigured';
+	if (m.includes('invalid upload_id')) return 'import.errors.invalidUploadId';
+	return null;
+};
+
 const getTaskStatusChips = (status: string, t: (k: string) => string) => {
 	const mapStatusChips = (s: string) => {
 		if (s === 'COMPLETED') return t('import.taskStatus.successful');
@@ -130,9 +143,18 @@ const ImportFileDrawer: FC<Props> = ({ isOpen, onOpenChange, taskId }) => {
 	const [entityType, setEntityType] = useState<SelectOption>();
 	const [uploadedTaskDetails, setuploadedTaskDetails] = useState<ImportTask>();
 
+	const { user } = useUser();
+	const { activeEnvironment } = useEnvironment();
+	const tenantId = user?.tenant?.id;
+	const environmentId = activeEnvironment?.id;
+	// Backend derives the S3 key from `{upload_id}_{customer_id}.csv`, where
+	// customer_id must be `<tenant>__<env>` (double underscore). Anything else
+	// makes the upload undownloadable on the backend.
+	const csvBoxCustomerId = tenantId && environmentId ? `${tenantId}__${environmentId}` : '';
+
 	const csvBoxKey = useMemo(
-		() => `${entityType?.value ? getLicenseKey(entityType.value) : ''}-${JSON.stringify(entityType?.label)}`,
-		[entityType],
+		() => `${entityType?.value ? getLicenseKey(entityType.value) : ''}-${JSON.stringify(entityType?.label)}-${csvBoxCustomerId}`,
+		[entityType, csvBoxCustomerId],
 	);
 
 	const [errors, seterrors] = useState({
@@ -149,12 +171,15 @@ const ImportFileDrawer: FC<Props> = ({ isOpen, onOpenChange, taskId }) => {
 		// error,
 	} = useMutation({
 		mutationFn: async (data?: Partial<ImportMeta>) => {
+			const meta = data ?? uploadedFile;
+			const importId = meta?.import_id;
 			return await TaskApi.addTask({
 				entity_type: entityType?.value || '',
 				file_type: fileTypeOptions[0].value,
-				file_url: (data?.raw_file ?? uploadedFile?.raw_file) || '',
 				task_type: taskTypeOptions[0].value,
-				file_name: (data?.original_filename ?? uploadedFile?.original_filename) || '',
+				file_provider: 'csvbox',
+				upload_id: importId != null ? String(importId) : '',
+				file_name: meta?.original_filename || '',
 			});
 		},
 		onSuccess: async () => {
@@ -163,7 +188,8 @@ const ImportFileDrawer: FC<Props> = ({ isOpen, onOpenChange, taskId }) => {
 			await refetchQueries('importTasks');
 		},
 		onError: (error: Error) => {
-			toast.error(error.message || t('common:toast.genericError'));
+			const mappedKey = getCsvImportErrorKey(error.message);
+			toast.error(mappedKey ? t(mappedKey) : error.message || t('common:toast.genericError'));
 		},
 	});
 
@@ -326,7 +352,7 @@ const ImportFileDrawer: FC<Props> = ({ isOpen, onOpenChange, taskId }) => {
 								<div className='space-y-4'>
 									<CSVBoxButton
 										key={csvBoxKey}
-										user='user_id'
+										user={csvBoxCustomerId}
 										onImport={(data: boolean, meta: ImportMeta) => {
 											setUploadedFile(meta);
 											if (data) {
@@ -337,21 +363,30 @@ const ImportFileDrawer: FC<Props> = ({ isOpen, onOpenChange, taskId }) => {
 											}
 										}}
 										licenseKey={getLicenseKey(entityType?.value || '')}
-										render={(launch, isLoading) => (
-											<div onClick={launch} className='cursor-pointer'>
-												<div className='space-y-1 w-full flex flex-col'>
-													{/* Label */}
-													<label className={cn(' block text-sm font-medium', 'text-content-zinc')}>{t('import.importFileLabel')}</label>
-													<div aria-disabled={isLoading} className={cn(isLoading && 'text-content-zinc-muted')}>
-														<button className={'p-2 border border-line-zinc rounded-lg py-2 px-4 w-full'}>
-															<p className='font-medium text-sm flex gap-2 items-center justify-start'>{t('import.chooseFile')}</p>
-														</button>
+										render={(launch, isLoading) => {
+											const disabled = isLoading || !csvBoxCustomerId;
+											return (
+												<div
+													onClick={() => {
+														if (!csvBoxCustomerId) return;
+														launch();
+													}}
+													className={cn(!csvBoxCustomerId ? 'cursor-not-allowed' : 'cursor-pointer')}>
+													<div className='space-y-1 w-full flex flex-col'>
+														{/* Label */}
+														<label className={cn(' block text-sm font-medium', 'text-content-zinc')}>{t('import.importFileLabel')}</label>
+														<div aria-disabled={disabled} className={cn(disabled && 'text-content-zinc-muted')}>
+															<button disabled={disabled} className={'p-2 border border-line-zinc rounded-lg py-2 px-4 w-full'}>
+																<p className='font-medium text-sm flex gap-2 items-center justify-start'>{t('import.chooseFile')}</p>
+															</button>
+														</div>
+														<p className={cn('text-sm', 'text-muted-foreground')}>{t('import.maxFileSizeHint')}</p>
+														{!csvBoxCustomerId && <p className='text-sm text-destructive'>{t('import.errors.missingTenantOrEnv')}</p>}
+														{errors.file && <p className='text-sm text-destructive'>{errors.file}</p>}
 													</div>
-													<p className={cn('text-sm', 'text-muted-foreground')}>{t('import.maxFileSizeHint')}</p>
-													{errors.file && <p className='text-sm text-destructive'>{errors.file}</p>}
 												</div>
-											</div>
-										)}
+											);
+										}}
 									/>
 									<div className='card !px-4 !py-3 border flex  items-start mb-2 gap-3'>
 										<div className='py-1'>
@@ -437,29 +472,38 @@ const ImportFileDrawer: FC<Props> = ({ isOpen, onOpenChange, taskId }) => {
 						)}
 
 						{uploadedTaskDetails && uploadedTaskDetails.task_status === 'FAILED' && (
-							<div className='flex gap-2 items-center'>
-								<Button
-									onClick={() => {
-										window.open(uploadedTaskDetails.file_url || uploadedFile?.raw_file, '_blank');
-									}}
-									variant={'outline'}
-									className='flex gap-2 items-center'>
-									{t('common:labels.downloadCsv')}
-								</Button>
-								<Button
-									onClick={() => {
-										if (taskId && uploadedTaskDetails) {
+							<div className='flex flex-col gap-2'>
+								{uploadedTaskDetails.error_summary && (
+									<p className='text-sm text-destructive'>
+										{/download/i.test(uploadedTaskDetails.error_summary)
+											? t('import.errors.downloadFailedHint')
+											: uploadedTaskDetails.error_summary}
+									</p>
+								)}
+								<div className='flex gap-2 items-center'>
+									{uploadedTaskDetails.file_url && (
+										<Button
+											onClick={() => {
+												window.open(uploadedTaskDetails.file_url || uploadedFile?.raw_file, '_blank');
+											}}
+											variant={'outline'}
+											className='flex gap-2 items-center'>
+											{t('common:labels.downloadCsv')}
+										</Button>
+									)}
+									<Button
+										onClick={() => {
+											// Reset local state so the CSV Box widget re-opens for a fresh upload.
+											// The backend derives the S3 key from upload_id, so we can't blindly
+											// resubmit a failed task's file_url like the legacy flow did.
+											setuploadedTaskDetails(undefined);
+											setUploadedFile(undefined);
 											setEntityType(importTypeOptions.find((option) => option.value === uploadedTaskDetails.entity_type));
-											setUploadedFile({
-												original_filename: uploadedTaskDetails.file_name,
-												raw_file: uploadedTaskDetails.file_url,
-											});
-											addTask(uploadedFile);
-										}
-									}}
-									className='flex gap-2 items-center'>
-									{t('common:labels.tryAgain')}
-								</Button>
+										}}
+										className='flex gap-2 items-center'>
+										{t('common:labels.tryAgain')}
+									</Button>
+								</div>
 							</div>
 						)}
 						{/* <div className='border rounded-md border-destructive text-destructive p-4 mt-4 flex gap-3 items-start fonts-sans text-sm'>

--- a/src/components/molecules/ImportFileDrawer/ImportFileDrawer.tsx
+++ b/src/components/molecules/ImportFileDrawer/ImportFileDrawer.tsx
@@ -368,7 +368,7 @@ const ImportFileDrawer: FC<Props> = ({ isOpen, onOpenChange, taskId }) => {
 											return (
 												<div
 													onClick={() => {
-														if (!csvBoxCustomerId) return;
+														if (disabled) return;
 														launch();
 													}}
 													className={cn(!csvBoxCustomerId ? 'cursor-not-allowed' : 'cursor-pointer')}>

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -485,6 +485,12 @@
 			"uploadSuccess": "{{filename}} uploaded successfully",
 			"uploadFailed": "{{filename}} upload failed"
 		},
+		"errors": {
+			"notConfigured": "Import is not enabled for this environment. Please contact support.",
+			"invalidUploadId": "Something went wrong wiring up the uploader. Please refresh and try again.",
+			"missingTenantOrEnv": "Waiting for your tenant and environment to load…",
+			"downloadFailedHint": "We couldn't read the uploaded file. This usually happens if you clicked Import before the upload finished. Please try again."
+		},
 		"importFileLabel": "Import file",
 		"chooseFile": "Choose File to Upload"
 	},

--- a/src/types/dto/Task.ts
+++ b/src/types/dto/Task.ts
@@ -11,10 +11,15 @@ import {
 export interface AddTaskPayload {
 	entity_type: string;
 	file_type: string;
-	file_url: string;
 	task_type: string;
 	file_name?: string;
 	metadata?: Metadata;
+	// Legacy: pre-signed/hosted URL flow. Kept for non-csvbox providers.
+	file_url?: string;
+	// Backend derives the S3 key from `upload_id` + the authenticated tenant/env,
+	// so nothing else about the object is sent from the client.
+	file_provider?: 'csvbox';
+	upload_id?: string;
 }
 
 export interface GetTasksPayload {


### PR DESCRIPTION
## Summary
- Aligns the CSV Box upload flow with backend PR flexprice/flexprice#2707: the widget now scopes uploads by `<tenant_id>__<environment_id>` (customer_id), and `POST /v1/tasks` sends `file_provider: "csvbox"` + `upload_id` instead of the legacy `file_url` (backend derives the S3 key from `upload_id` + the authenticated tenant/env).
- Maps the two backend 400s (`"csv imports are not configured"`, `"invalid upload_id"`) to specific user-facing copy so support tickets self-triage.
- Reworks the FAILED-task retry: since there's no `file_url` to resubmit, "Try Again" now resets state and reopens CSV Box; if `error_summary` mentions "download", surfaces the "you probably clicked Import before the upload finished" hint.

## Test plan
- [x] `npx vitest run src/components/molecules/ImportFileDrawer/ImportFileDrawer.test.tsx` — new tests assert (1) CSV Box `user` prop = `${tenant}__${env}`, (2) task POST body has `file_provider: 'csvbox'` + `upload_id` and no `file_url`.
- [x] `npm run build` passes (via pre-commit hook).
- [ ] Manual smoke: import an EVENTS CSV in dev; confirm S3 object lands under `csv-box-uplods/{upload_id}_{tenant}__{env}.csv` and the task advances PENDING → PROCESSING → COMPLETED.
- [ ] Manual smoke: import while `FLEXPRICE_S3_IMPORTS_*` is unset on backend; confirm the "Import is not enabled for this environment" copy shows.
- [ ] Manual smoke: force a FAILED task with a "download" error; confirm the retry hint renders and "Try Again" reopens CSV Box (no attempt to reuse a file_url).

## Frontend contract notes for reviewers
- CSV Box widget config (one-time, in CSV Box account settings): S3 prefix `csv-box-uplods`, filename template `{upload_id}_{customer_id}.csv`.
- Nothing changes for non-CSV Box providers; `file_url` remains optional on `AddTaskPayload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSVBox-based file importing with tenant and environment validation.
  * Import tasks now support upload IDs and display clearer, localized error messages.
  * Failed imports show backend error details, with retry controls that reset the import state.

* **Bug Fixes**
  * Prevented uploads when required account or environment information is unavailable.
  * Improved handling of incomplete uploads and invalid import requests.

* **Tests**
  * Added coverage for CSVBox identifiers and import task creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->