### PR TITLE
fix(imports): tidy Sample CSV link + add missing max-file-size hint

### DIFF
--- a/src/components/molecules/ImportFileDrawer/ImportFileDrawer.tsx
+++ b/src/components/molecules/ImportFileDrawer/ImportFileDrawer.tsx
@@ -388,7 +388,7 @@ const ImportFileDrawer: FC<Props> = ({ isOpen, onOpenChange, taskId }) => {
 											);
 										}}
 									/>
-									<div className='card !px-4 !py-3 border flex  items-start mb-2 gap-3'>
+									<div className='card !px-4 !py-3 border flex items-start mb-2 gap-3'>
 										<div className='py-1'>
 											<CircleAlert className='size-4' />
 										</div>
@@ -400,15 +400,16 @@ const ImportFileDrawer: FC<Props> = ({ isOpen, onOpenChange, taskId }) => {
 												titleClassName='mb-0'
 												subtitle={t('common:labels.maxFileSizeSubtitle')}
 											/>
-											<Button
-												className='flex gap-2 !p-0 m-0 underline'
-												variant={'link'}
-												onClick={() => {
-													window.open(getSampleFileUrl(entityType?.value || ''), '_blank');
-												}}>
+											{/* Rendered as an anchor because the Button atom's default size adds
+											    a border + fixed height that visually conflicts with a link. */}
+											<a
+												href={getSampleFileUrl(entityType?.value || '')}
+												target='_blank'
+												rel='noreferrer'
+												className='mt-1 inline-flex items-center gap-1 text-sm font-medium text-primary underline underline-offset-4 hover:opacity-80'>
 												{t('common:labels.sampleCsv')}
-												<Download className='size-4 underline' />
-											</Button>
+												<Download className='size-3.5' />
+											</a>
 										</div>
 									</div>
 								</div>

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -492,7 +492,8 @@
 			"downloadFailedHint": "We couldn't read the uploaded file. This usually happens if you clicked Import before the upload finished. Please try again."
 		},
 		"importFileLabel": "Import file",
-		"chooseFile": "Choose File to Upload"
+		"chooseFile": "Choose File to Upload",
+		"maxFileSizeHint": "Max 5 MB. Only .csv files are accepted."
 	},
 	"bulkImports": {
 		"writeDeniedTooltip": "You don't have permission to create import tasks. Ask a tenant admin for access.",


### PR DESCRIPTION
Follow-up to #1324. Two small polish fixes surfaced when actually opening the drawer:

## Summary
- **Sample CSV link:** the control was rendered via the `Button` atom's default size, which forces `h-8 border`, producing a boxed control that read as a form input rather than a link. Swapped to a plain `<a>` styled to match the surrounding "Compare your file formatting" card (underline, primary color, download glyph).
- **Missing i18n key:** the max-file-size hint under the upload button was rendering the raw key `import.maxFileSizeHint`. Added the string to `src/i18n/locales/en/settings.json`.

## Screenshots
Before: Sample CSV rendered as a bordered input-looking control; hint text showed the raw i18n path.
After: Sample CSV is a plain underlined link with an inline download glyph; hint reads "Max 5 MB. Only .csv files are accepted."

## Test plan
- [x] `npx vitest run src/components/molecules/ImportFileDrawer/ImportFileDrawer.test.tsx` — existing tests still pass (contract unchanged).
- [x] `npm run build` passes (pre-commit hook).
- [ ] Manual: open `/tools/bulk-imports` → **Import File** → pick "Events". Confirm Sample CSV renders as a link and clicking it downloads `/assets/csv/sample.csv`; confirm the hint reads full sentence not the i18n key.

## Not in this PR
- The CSV Box modal size and the "Uploading Data (2/2)" stall are inside CSV Box's own iframe — the frontend can't influence either. Both point to a CSV Box account / S3 destination config concern (verified independently on the CSV Box dashboard where uploads succeed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance in the import drawer showing the 5 MB file-size limit and supported CSV format.

* **Improvements**
  * Updated the sample CSV download control to use standard browser download behavior and open the file in a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->