### PR TITLE
chore(imports): log CSV Box lifecycle to triage upload stalls

### DIFF
--- a/src/components/molecules/ImportFileDrawer/ImportFileDrawer.test.tsx
+++ b/src/components/molecules/ImportFileDrawer/ImportFileDrawer.test.tsx
@@ -14,15 +14,16 @@ import TaskApi from '@/api/TaskApi';
 const csvBoxSpy = vi.fn();
 vi.mock('@csvbox/react', () => ({
 	CSVBoxButton: (props: {
-		user: string;
+		user: string | { user_id: string };
 		licenseKey: string;
 		onImport: (ok: boolean, meta: Record<string, unknown>) => void;
 		render: (launch: () => void, isLoading: boolean) => React.ReactNode;
 	}) => {
 		csvBoxSpy(props);
+		const userId = typeof props.user === 'string' ? props.user : props.user?.user_id;
 		return (
 			<div>
-				<div data-testid='csvbox-user'>{props.user}</div>
+				<div data-testid='csvbox-user'>{userId}</div>
 				{props.render(() => {
 					props.onImport(true, {
 						import_id: 987654,

--- a/src/components/molecules/ImportFileDrawer/ImportFileDrawer.tsx
+++ b/src/components/molecules/ImportFileDrawer/ImportFileDrawer.tsx
@@ -352,8 +352,29 @@ const ImportFileDrawer: FC<Props> = ({ isOpen, onOpenChange, taskId }) => {
 								<div className='space-y-4'>
 									<CSVBoxButton
 										key={csvBoxKey}
-										user={csvBoxCustomerId}
+										// CSV Box docs recommend the object form so custom attributes (e.g. env) can
+										// travel alongside user_id if we ever need them. String form still works, but
+										// object form is what their examples use and it's cheap to align.
+										user={{ user_id: csvBoxCustomerId }}
+										onReady={() => {
+											// Iframe finished loading; CSV Box is ready to accept a file.
+											 
+											console.debug('[csvbox] onReady', { customerId: csvBoxCustomerId });
+										}}
+										onSubmit={(meta: unknown) => {
+											// User clicked Submit inside the iframe — CSV Box will now push data to
+											// the sheet's configured destination. If we never see onImport after this,
+											// the CSV Box account's destination is what's stuck.
+											 
+											console.debug('[csvbox] onSubmit', meta);
+										}}
+										onClose={() => {
+											 
+											console.debug('[csvbox] onClose');
+										}}
 										onImport={(data: boolean, meta: ImportMeta) => {
+											 
+											console.debug('[csvbox] onImport', { success: data, meta });
 											setUploadedFile(meta);
 											if (data) {
 												handleImport(meta);


### PR DESCRIPTION
## Context
Following the CSV Box migration in #1324, the embed occasionally stalls at "Uploading Data (n/n)" inside CSV Box's iframe with nothing surfaced to our code. That progress bar is CSV Box's own push-to-destination stage — we have no hook into it once postMessage crosses the iframe boundary. If the CSV Box sheet's S3 destination isn't wired to Flexprice's bucket (with the `{upload_id}_{customer_id}.csv` template), CSV Box will always stall there in the embed even though the CSV Box **dashboard** test upload succeeds (dashboard uploads land in CSV Box's internal storage, not the sheet's destination).

## Summary
- Adds `console.debug('[csvbox] …', payload)` for the CSV Box lifecycle events we're already receiving: `onReady`, `onSubmit`, `onImport`, `onClose`. Grep DevTools for `[csvbox]` to see which stage the flow reaches.
- Switches `user` to CSV Box's documented object form (`{ user_id: … }`). Both string and object shapes propagate through their postMessage bridge, but the object form matches their README examples and leaves room for per-import attributes without another prop churn.

## How to use for triage
| Console shows | Likely root cause |
|---|---|
| `onReady` only | Iframe loaded but user never clicked Import inside CSV Box |
| `onSubmit` but **no** `onImport` | CSV Box's push to the sheet's destination is hanging — configure the destination on the CSV Box account or check the CSV-Box→S3 IAM path |
| `onImport(false, …)` | CSV Box push explicitly failed; check the 2nd arg |
| `onImport(true, …)` then hang | Failure is on **our** POST to `/v1/tasks`; check Network |

## Test plan
- [x] `npx vitest run src/components/molecules/ImportFileDrawer/ImportFileDrawer.test.tsx` — updated the mock to accept both shapes of `user`; both existing tests pass.
- [x] `npm run build` (via pre-commit).
- [ ] Manual: `/tools/bulk-imports` → Import File → Events → upload sample CSV. Check DevTools console for `[csvbox]` lifecycle to confirm which stage stalls.

## Not in this PR
- No behavioral change to the POST-to-`/v1/tasks` contract (still `file_provider: 'csvbox'` + `upload_id`).
- Not attempting to fix the stall itself — the destination config lives inside the CSV Box account and can't be set from the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)