### PR TITLE
fix(imports): unstall CSV Box upload by passing user as object form

### DIFF
--- a/src/components/molecules/ImportFileDrawer/ImportFileDrawer.test.tsx
+++ b/src/components/molecules/ImportFileDrawer/ImportFileDrawer.test.tsx
@@ -14,15 +14,16 @@ import TaskApi from '@/api/TaskApi';
 const csvBoxSpy = vi.fn();
 vi.mock('@csvbox/react', () => ({
 	CSVBoxButton: (props: {
-		user: string;
+		user: string | { user_id: string };
 		licenseKey: string;
 		onImport: (ok: boolean, meta: Record<string, unknown>) => void;
 		render: (launch: () => void, isLoading: boolean) => React.ReactNode;
 	}) => {
 		csvBoxSpy(props);
+		const userId = typeof props.user === 'string' ? props.user : props.user?.user_id;
 		return (
 			<div>
-				<div data-testid='csvbox-user'>{props.user}</div>
+				<div data-testid='csvbox-user'>{userId}</div>
 				{props.render(() => {
 					props.onImport(true, {
 						import_id: 987654,

--- a/src/components/molecules/ImportFileDrawer/ImportFileDrawer.tsx
+++ b/src/components/molecules/ImportFileDrawer/ImportFileDrawer.tsx
@@ -352,7 +352,10 @@ const ImportFileDrawer: FC<Props> = ({ isOpen, onOpenChange, taskId }) => {
 								<div className='space-y-4'>
 									<CSVBoxButton
 										key={csvBoxKey}
-										user={csvBoxCustomerId}
+										// Object form matches CSV Box's docs. The bare-string form is accepted by
+										// their postMessage bridge but stalls the destination-push stage on staging
+										// (the "Uploading Data (n/n)" screen never advances). Object form works.
+										user={{ user_id: csvBoxCustomerId }}
 										onImport={(data: boolean, meta: ImportMeta) => {
 											setUploadedFile(meta);
 											if (data) {


### PR DESCRIPTION
## Symptom
On staging (admin-dev), the CSV Box embed reliably stalls at "Uploading Data (n/n) — Do not close the browser window" after the user hits Submit inside the iframe. `onImport` never fires, so the frontend never sees success or failure. On localhost the same file uploads fine.

## Root cause
Diffing the local branch (where uploads work) against `develop` (staging), the **only** functional difference was the shape of the `user` prop handed to `<CSVBoxButton>`:
- staging: `user={csvBoxCustomerId}` — bare string
- local:   `user={{ user_id: csvBoxCustomerId }}` — object form

CSV Box's postMessage bridge accepts both, but the destination-push stage inside their iframe behaves differently for the two shapes. The object form is what their own docs use, and it advances the push consistently across environments.

Verified locally by flipping the shape back to a string and reproducing the stall; flipping back to object unstalls it.

## Change
One prop shape flip in `ImportFileDrawer.tsx` and a matching type/render tweak in the co-located test's `@csvbox/react` mock to accept either shape.

## Test plan
- [x] `npx vitest run src/components/molecules/ImportFileDrawer/ImportFileDrawer.test.tsx` — 2/2 pass.
- [x] `npm run build` (pre-commit hook).
- [x] Manual on localhost: `/tools/bulk-imports` → Import File → Events → upload sample CSV → "sample.csv uploaded successfully" toast, task row appears.
- [ ] Manual on admin-dev after deploy: same flow reaches `onImport` and creates the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSV imports stalling during the destination-push stage in staging.
  * Updated the CSV import integration to provide user identification in the format required by CSV Box.
* **Tests**
  * Updated import drawer tests to support and verify the corrected user identification format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->