### PR TITLE
fix(ci): add explicit least-privilege permissions to e2e-pr workflow

### DIFF
--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -37,6 +37,9 @@ on:
       - '.github/workflows/e2e-pr.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A newer push supersedes the run in progress; nobody needs the results of a commit
 # that has already been replaced.
 concurrency:


### PR DESCRIPTION
## Summary
Resolves the two CodeQL review comments on #1317 (`.github/workflows/e2e-pr.yml`, lines 71 and 149 — one per job):

> CodeQL / Workflow does not contain permissions
> Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: `{contents: read}`

## Fix
Neither the `checks` nor the `e2e` job calls the GitHub API for anything beyond reading repo contents (checkout, setup-node, npm ci/lint/typecheck, Playwright cache, build, upload-artifact) — none of them need write access. Added the exact minimal `permissions: contents: read` block CodeQL suggests, at the workflow level (applies to both jobs), matching the existing convention already used in `lint.yml` and `test.yml`.

Targeting `develop` directly (rather than the `main`-bound release PR #1317) since that's where this workflow file lives and where CI config changes belong.

## Test plan
- [x] YAML structure verified (indentation matches `lint.yml`/`test.yml`'s `permissions:` block placement)
- [x] No `src/` or app code touched — CI workflow file only, nothing to typecheck/lint/test/build

🤖 Generated with [Claude Code](https://claude.com/claude-code)