### PR TITLE
fix(subscription): restore one-time price handling dropped by the cadence-compatibility merge

### DIFF
--- a/src/components/organisms/Subscription/SubscriptionPriceTable.test.tsx
+++ b/src/components/organisms/Subscription/SubscriptionPriceTable.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { resolveQuantityFromInput } from './SubscriptionPriceTable';
+import { resolveQuantityFromInput, isPriceCompatibleWithBillingPeriod } from './SubscriptionPriceTable';
+import { BILLING_PERIOD } from '@/constants/constants';
 
 describe('resolveQuantityFromInput', () => {
 	it('returns 0 when the input is "0" instead of falling back to minQuantity', () => {
@@ -16,5 +17,28 @@ describe('resolveQuantityFromInput', () => {
 
 	it('truncates decimal input the same way parseInt does', () => {
 		expect(resolveQuantityFromInput('4.9', 1)).toBe(4);
+	});
+});
+
+describe('isPriceCompatibleWithBillingPeriod', () => {
+	it('keeps a one-time price regardless of the selected billing period', () => {
+		const oneTimePrice = { billing_period: BILLING_PERIOD.ONETIME, billing_period_count: 1 };
+		expect(isPriceCompatibleWithBillingPeriod(oneTimePrice, BILLING_PERIOD.MONTHLY, 1)).toBe(true);
+		expect(isPriceCompatibleWithBillingPeriod(oneTimePrice, BILLING_PERIOD.ANNUAL, 1)).toBe(true);
+	});
+
+	it('keeps a recurring price whose cadence matches the subscription cadence', () => {
+		const monthlyPrice = { billing_period: BILLING_PERIOD.MONTHLY, billing_period_count: 1 };
+		expect(isPriceCompatibleWithBillingPeriod(monthlyPrice, BILLING_PERIOD.MONTHLY, 1)).toBe(true);
+	});
+
+	it('drops a recurring price whose cadence does not divide the subscription cadence', () => {
+		const quarterlyPrice = { billing_period: BILLING_PERIOD.QUARTERLY, billing_period_count: 1 };
+		expect(isPriceCompatibleWithBillingPeriod(quarterlyPrice, BILLING_PERIOD.MONTHLY, 1)).toBe(false);
+	});
+
+	it('keeps a recurring price whose cadence evenly divides a multi-count subscription cadence', () => {
+		const monthlyPrice = { billing_period: BILLING_PERIOD.MONTHLY, billing_period_count: 1 };
+		expect(isPriceCompatibleWithBillingPeriod(monthlyPrice, BILLING_PERIOD.QUARTERLY, 1)).toBe(true);
 	});
 });

--- a/src/components/organisms/Subscription/SubscriptionPriceTable.tsx
+++ b/src/components/organisms/Subscription/SubscriptionPriceTable.tsx
@@ -38,6 +38,20 @@ export function resolveQuantityFromInput(value: string, minQuantity: number): nu
 	return Number.isNaN(parsed) ? minQuantity : parsed;
 }
 
+/**
+ * Whether a price belongs in the table for the selected subscription billing period.
+ * isCadenceCompatible always returns false for ONETIME (it only reasons about the
+ * recurring scale), so one-time prices must be kept explicitly, or they silently drop
+ * out of the table whenever a billing period filter is active.
+ */
+export function isPriceCompatibleWithBillingPeriod(
+	price: Pick<Price, 'billing_period' | 'billing_period_count'>,
+	billingPeriod: string,
+	billingPeriodCount?: number,
+): boolean {
+	return isOneTimePlanPrice(price) || isCadenceCompatible(billingPeriod, billingPeriodCount, price.billing_period, price.billing_period_count);
+}
+
 type ChargeTableData = {
 	priceId: string;
 	charge: ReactNode;
@@ -320,7 +334,7 @@ const SubscriptionPriceTable: FC<Props> = ({
 			filtered = filtered.filter((p) => p.currency.toLowerCase() === currency.toLowerCase());
 		}
 		if (billingPeriod) {
-			filtered = filtered.filter((p) => isCadenceCompatible(billingPeriod, billingPeriodCount, p.billing_period, p.billing_period_count));
+			filtered = filtered.filter((p) => isPriceCompatibleWithBillingPeriod(p, billingPeriod, billingPeriodCount));
 		}
 		return filtered;
 	}, [data, billingPeriod, billingPeriodCount, currency]);


### PR DESCRIPTION
## Summary
`develop` currently fails to build with:
```
src/components/organisms/Subscription/SubscriptionPriceTable.tsx(26,1): error TS6133: 'isOneTimePlanPrice' is declared but its value is never read.
```

## Root cause
A `main` → `develop` merge brought `main`'s `isOneTimePlanPrice` import in alongside `develop`'s newer `isCadenceCompatible` refactor, but only the import-line conflict got resolved — the actual filter usage below it was left calling `isCadenceCompatible` alone, leaving the import unused.

Deleting the import (the obvious fix for the compiler error) would silence TS6133 but reintroduce a real bug: `isCadenceCompatible`'s own doc comment states it always returns `false` for `ONETIME` prices (it only reasons about the recurring billing scale) and expects the caller to handle "ONETIME is always valid" separately. Without that, one-time-priced items silently vanish from the Charges/Prices table whenever a billing period filter is active - confirmed by diffing against the pre-fork version of this file, which still had `main`'s `isOneTimePlanPrice(p) || p.billing_period === periodKey` check intact.

## Fix
- Combined both checks into a new `isPriceCompatibleWithBillingPeriod` helper (keeps develop's period+count-aware cadence matching, restores the one-time-price short-circuit), used in `filteredPrices`.
- Extracted it as a standalone exported function (mirroring this file's existing `resolveQuantityFromInput` pattern) so it's unit-testable without mounting the table.
- Added 4 test cases: one-time price always kept, matching-cadence price kept, non-dividing cadence dropped, multi-count cadence that divides evenly kept.

## Test plan
- [x] `npx tsc --noEmit -p .` clean (TS6133 resolved)
- [x] `npx eslint` on touched files - 0 errors (warning count unchanged vs. baseline)
- [x] `npx vitest run` - all 637 tests pass, including 8/8 in the touched test file
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)