### PR TITLE
fix(subscription): show cadence-compatible addon charges on sub create

### DIFF
--- a/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonModal.tsx
+++ b/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonModal.tsx
@@ -36,6 +36,8 @@ interface Props {
 	onCancel: () => void;
 	getEmptyAddon: () => Partial<AddAddonToSubscriptionRequest>;
 	billingPeriod?: BILLING_PERIOD;
+	/** Subscription's billing_period_count paired with billingPeriod for the cadence-compat filter. Defaults to 1. */
+	billingPeriodCount?: number;
 	currency?: string;
 }
 
@@ -76,6 +78,7 @@ const SubscriptionAddonModal: React.FC<Props> = ({
 	onCancel,
 	getEmptyAddon,
 	billingPeriod,
+	billingPeriodCount = 1,
 	currency,
 }) => {
 	const { t } = useTranslation(['common', 'customers']);
@@ -140,8 +143,8 @@ const SubscriptionAddonModal: React.FC<Props> = ({
 	}, [formData, t]);
 
 	const selectedAddonPrices = useMemo(
-		() => filterAddonPricesForSubscription((selectedAddonDetails?.prices as Price[]) || [], billingPeriod, currency),
-		[selectedAddonDetails, billingPeriod, currency],
+		() => filterAddonPricesForSubscription((selectedAddonDetails?.prices as Price[]) || [], billingPeriod, currency, billingPeriodCount),
+		[selectedAddonDetails, billingPeriod, currency, billingPeriodCount],
 	);
 
 	const handleSave = useCallback(() => {

--- a/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonTable.tsx
+++ b/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonTable.tsx
@@ -22,6 +22,8 @@ interface Props {
 	priceOverrides?: Record<string, ExtendedPriceOverride>;
 	coupons?: Coupon[];
 	billingPeriod?: BILLING_PERIOD;
+	/** Subscription's billing_period_count paired with billingPeriod for the cadence-compat filter. Defaults to 1. */
+	billingPeriodCount?: number;
 	currency?: string;
 }
 const formatAddonCharges = (
@@ -63,6 +65,7 @@ const SubscriptionAddonTable: React.FC<Props> = ({
 	priceOverrides = {},
 	coupons = [],
 	billingPeriod,
+	billingPeriodCount = 1,
 	currency,
 }) => {
 	const { t } = useTranslation('common');
@@ -147,7 +150,7 @@ const SubscriptionAddonTable: React.FC<Props> = ({
 				title: t('subscriptionAddon.columnCharges'),
 				render: (row) => {
 					const addonDetails = getAddonDetails(row.addon_id);
-					const prices = filterAddonPricesForSubscription(addonDetails?.prices || [], billingPeriod, currency);
+					const prices = filterAddonPricesForSubscription(addonDetails?.prices || [], billingPeriod, currency, billingPeriodCount);
 					return <span>{formatAddonCharges(prices, priceOverrides, coupons, t)}</span>;
 				},
 			},
@@ -184,7 +187,7 @@ const SubscriptionAddonTable: React.FC<Props> = ({
 				},
 			},
 		],
-		[disabled, getAddonDetails, handleDelete, handleEdit, priceOverrides, coupons, billingPeriod, currency, t],
+		[disabled, getAddonDetails, handleDelete, handleEdit, priceOverrides, coupons, billingPeriod, billingPeriodCount, currency, t],
 	);
 
 	return (
@@ -200,6 +203,7 @@ const SubscriptionAddonTable: React.FC<Props> = ({
 					setSelectedAddon(null);
 				}}
 				billingPeriod={billingPeriod}
+				billingPeriodCount={billingPeriodCount}
 				currency={currency}
 			/>
 			<div className='space-y-4'>

--- a/src/components/molecules/SubscriptionAddonsSection/AddAddonDialog.tsx
+++ b/src/components/molecules/SubscriptionAddonsSection/AddAddonDialog.tsx
@@ -36,6 +36,12 @@ interface Props {
 	onOpenChange: (open: boolean) => void;
 	subscriptionId: string;
 	billingPeriod?: BILLING_PERIOD;
+	/**
+	 * Subscription's billing_period_count paired with billingPeriod for the cadence-compat filter.
+	 * Defaults to 1 when the caller has not resolved the subscription context yet; a follow-up
+	 * fetch below can supply the real value.
+	 */
+	billingPeriodCount?: number;
 	currency?: string;
 	/** When provided, skips GET subscription for defaults (subscription edit passes from core fetch). */
 	currentPeriodEndIso?: string;
@@ -45,7 +51,15 @@ interface FormErrors {
 	addon_id?: string;
 }
 
-const AddAddonDialog: React.FC<Props> = ({ isOpen, onOpenChange, subscriptionId, billingPeriod, currency, currentPeriodEndIso }) => {
+const AddAddonDialog: React.FC<Props> = ({
+	isOpen,
+	onOpenChange,
+	subscriptionId,
+	billingPeriod,
+	billingPeriodCount,
+	currency,
+	currentPeriodEndIso,
+}) => {
 	const { t } = useTranslation(['billing', 'common', 'customers']);
 	const [formData, setFormData] = useState<Partial<AddAddonRequest>>({});
 	const [errors, setErrors] = useState<FormErrors>({});
@@ -71,6 +85,10 @@ const AddAddonDialog: React.FC<Props> = ({ isOpen, onOpenChange, subscriptionId,
 	});
 
 	const resolvedPeriodEndRaw = currentPeriodEndIso ?? (subscriptionDetails as SubscriptionResponse | undefined)?.current_period_end;
+	// Prefer the count from props (caller-supplied); fall back to the fetched subscription;
+	// default to 1 when neither is available (matches backend EffectiveMonths behavior).
+	const resolvedBillingPeriodCount =
+		billingPeriodCount ?? (subscriptionDetails as SubscriptionResponse | undefined)?.billing_period_count ?? 1;
 
 	// Fetch available addons
 	const { data: addonsResponse } = useQuery({
@@ -82,8 +100,8 @@ const AddAddonDialog: React.FC<Props> = ({ isOpen, onOpenChange, subscriptionId,
 
 	// Reset form when modal opens/closes
 	const selectedAddonPrices = useMemo(
-		() => filterAddonPricesForSubscription((selectedAddonDetails?.prices as Price[]) || [], billingPeriod, currency),
-		[selectedAddonDetails, billingPeriod, currency],
+		() => filterAddonPricesForSubscription((selectedAddonDetails?.prices as Price[]) || [], billingPeriod, currency, resolvedBillingPeriodCount),
+		[selectedAddonDetails, billingPeriod, currency, resolvedBillingPeriodCount],
 	);
 
 	const { overriddenPrices, overridePrice, resetOverride, resetAllOverrides } = usePriceOverrides(selectedAddonPrices);

--- a/src/components/molecules/SubscriptionAddonsSection/SubscriptionAddonsSection.tsx
+++ b/src/components/molecules/SubscriptionAddonsSection/SubscriptionAddonsSection.tsx
@@ -9,7 +9,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { BsThreeDots } from 'react-icons/bs';
 import SubscriptionApi from '@/api/SubscriptionApi';
 import { ADDON_ASSOCIATION_STATUS } from '@/models/AddonAssociation';
-import { AddonAssociationResponse } from '@/types/dto/Subscription';
+import { AddonAssociationResponse, SubscriptionResponse } from '@/types/dto/Subscription';
 import { ADDON_PRORATION_BEHAVIOR } from '@/types/dto/Addon';
 import { BILLING_PERIOD } from '@/constants/constants';
 import { toSentenceCase, copyToClipboard } from '@/utils/common/helper_functions';
@@ -33,6 +33,8 @@ interface SubscriptionAddonsSectionProps {
 	 * avoids an extra GET /subscriptions/:id fetch.
 	 */
 	subscriptionBillingPeriod?: BILLING_PERIOD;
+	/** Paired with subscriptionBillingPeriod for the cadence-compat filter. Defaults to 1. */
+	subscriptionBillingPeriodCount?: number;
 	subscriptionCurrency?: string;
 	subscriptionCurrentPeriodStart?: string;
 	subscriptionCurrentPeriodEnd?: string;
@@ -149,6 +151,7 @@ const SubscriptionAddonsSection: FC<SubscriptionAddonsSectionProps> = ({
 	subscriptionId,
 	readOnly = false,
 	subscriptionBillingPeriod,
+	subscriptionBillingPeriodCount,
 	subscriptionCurrency,
 	subscriptionCurrentPeriodStart,
 	subscriptionCurrentPeriodEnd,
@@ -423,6 +426,10 @@ const SubscriptionAddonsSection: FC<SubscriptionAddonsSectionProps> = ({
 					onOpenChange={setIsAddDialogOpen}
 					subscriptionId={subscriptionId}
 					billingPeriod={subscriptionDetails?.billing_period}
+					billingPeriodCount={
+						subscriptionBillingPeriodCount ??
+						(subscriptionContextResolved ? undefined : (subscriptionDetailsFetched as SubscriptionResponse | undefined)?.billing_period_count)
+					}
 					currency={subscriptionDetails?.currency}
 					currentPeriodEndIso={subscriptionDetails?.current_period_end}
 				/>

--- a/src/components/organisms/Subscription/SubscriptionForm.tsx
+++ b/src/components/organisms/Subscription/SubscriptionForm.tsx
@@ -1081,6 +1081,7 @@ const SubscriptionForm = ({
 						}}
 						disabled={isDisabled}
 						billingPeriod={state.billingPeriod}
+						billingPeriodCount={1}
 						currency={state.currency}
 					/>
 				</div>

--- a/src/i18n/locales/ar/common.json
+++ b/src/i18n/locales/ar/common.json
@@ -607,7 +607,7 @@
 		"labelAddon": "الإضافة",
 		"placeholderSelectAddon": "اختر إضافة",
 		"addonChargesHeading": "رسوم الإضافة",
-		"filteredByPeriodAndCurrency": "مُصفّى حسب {{period}} و {{currency}}",
+		"filteredByPeriodAndCurrency": "متوافق مع {{period}} و {{currency}}",
 		"billingPeriodFallback": "فترة الفوترة",
 		"currencyFallback": "العملة",
 		"noChargesForPeriod": "لا توجد رسوم لهذه الفترة/العملة.",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -612,7 +612,7 @@
 		"labelAddon": "Addon",
 		"placeholderSelectAddon": "Select addon",
 		"addonChargesHeading": "Addon Charges",
-		"filteredByPeriodAndCurrency": "Filtered by {{period}} and {{currency}}",
+		"filteredByPeriodAndCurrency": "Compatible with {{period}} and {{currency}}",
 		"billingPeriodFallback": "billing period",
 		"currencyFallback": "currency",
 		"noChargesForPeriod": "No charges for this billing period/currency.",

--- a/src/pages/customer/customers/CreateCustomerSubscriptionPage.tsx
+++ b/src/pages/customer/customers/CreateCustomerSubscriptionPage.tsx
@@ -672,7 +672,10 @@ const CreateCustomerSubscriptionPage: React.FC = () => {
 			subscriptionState.addons && subscriptionState.addons.length > 0
 				? subscriptionState.addons.map((addon: AddAddonToSubscriptionRequest) => {
 						const addonDetails = addonsById.get(addon.addon_id);
-						const prices = filterAddonPricesForSubscription(addonDetails?.prices as Price[] | undefined, billingPeriod, currency);
+						// Create flow hardcodes billing_period_count to 1 at submit (see the payload
+						// below). Pass it here explicitly so the addon-price filter agrees with what
+						// will actually be sent.
+						const prices = filterAddonPricesForSubscription(addonDetails?.prices as Price[] | undefined, billingPeriod, currency, 1);
 						const line_item_commitments = sanitizeAddonLineItemCommitmentsForApi(addon.line_item_commitments, prices);
 						return {
 							...addon,

--- a/src/pages/customer/customers/CustomerSubscriptionDetailsPage.tsx
+++ b/src/pages/customer/customers/CustomerSubscriptionDetailsPage.tsx
@@ -593,6 +593,7 @@ const CustomerSubscriptionDetailsPage: FC = () => {
 						subscriptionId={subscription_id}
 						readOnly
 						subscriptionBillingPeriod={subscriptionDetails.billing_period}
+						subscriptionBillingPeriodCount={subscriptionDetails.billing_period_count}
 						subscriptionCurrency={subscriptionDetails.currency}
 						subscriptionCurrentPeriodStart={subscriptionDetails.current_period_start}
 						subscriptionCurrentPeriodEnd={subscriptionDetails.current_period_end}

--- a/src/pages/customer/customers/CustomerSubscriptionEditPage.tsx
+++ b/src/pages/customer/customers/CustomerSubscriptionEditPage.tsx
@@ -472,6 +472,7 @@ const CustomerSubscriptionEditPage: React.FC = () => {
 							subscriptionId={subscriptionId}
 							readOnly={subscriptionReadOnly}
 							subscriptionBillingPeriod={subscriptionDetails.billing_period}
+							subscriptionBillingPeriodCount={subscriptionDetails.billing_period_count}
 							subscriptionCurrency={subscriptionDetails.currency}
 							subscriptionCurrentPeriodStart={subscriptionDetails.current_period_start}
 							subscriptionCurrentPeriodEnd={subscriptionDetails.current_period_end}

--- a/src/utils/subscription/addon_commitment_helpers.ts
+++ b/src/utils/subscription/addon_commitment_helpers.ts
@@ -3,17 +3,28 @@ import { Price } from '@/models/Price';
 import type { CommitmentTimeBucket } from '@/types/dto/CommitmentTimeBucket';
 import { LineItemCommitmentConfig, LineItemCommitmentsMap } from '@/types/dto/LineItemCommitmentConfig';
 import { enrichCommitmentTimeBucketsForApi } from '@/utils/common/commitment_helpers';
+import { isCadenceCompatible } from '@/utils/subscription/cadenceCompatibility';
 import { isOneTimePlanPrice } from '@/utils/subscription/planPricesForSubscriptionUi';
 
-/** Filter addon prices to match subscription billing period and currency. */
-export function filterAddonPricesForSubscription(prices: Price[] = [], billingPeriod?: BILLING_PERIOD, currency?: string): Price[] {
+/**
+ * Filter addon prices to those the subscription can attach: same currency, plus a cadence
+ * that equals or evenly divides the subscription cadence (ONETIME always attaches, per the
+ * backend's ONETIME-passes rule). Mirrors backend `filterValidPricesForSubscription`, which
+ * runs the same `IsCadenceCompatible` check for both PLAN and ADDON entity types — so a
+ * monthly addon shows up (and attaches) on a quarterly sub, fanning out per month at billing.
+ */
+export function filterAddonPricesForSubscription(
+	prices: Price[] = [],
+	billingPeriod?: BILLING_PERIOD,
+	currency?: string,
+	billingPeriodCount: number = 1,
+): Price[] {
 	let filtered = prices;
 	if (currency) {
 		filtered = filtered.filter((p) => p.currency?.toLowerCase() === currency.toLowerCase());
 	}
 	if (billingPeriod) {
-		const periodKey = billingPeriod.toUpperCase();
-		filtered = filtered.filter((p) => isOneTimePlanPrice(p) || p.billing_period?.toUpperCase() === periodKey);
+		filtered = filtered.filter((p) => isOneTimePlanPrice(p) || isCadenceCompatible(billingPeriod, billingPeriodCount, p.billing_period, p.billing_period_count));
 	}
 	return filtered;
 }


### PR DESCRIPTION
## Summary

Same-shape fix as the plan-price cadence filter shipped in #1327/#1328 — `filterAddonPricesForSubscription` was using an exact billing-period match, so adding a monthly addon to a quarterly subscription rendered *"No charges for this billing period/currency"* in the "Add Addon" dialog even though the backend attaches the addon's monthly charges.

## Backend sync

The backend already handles this correctly. \`subscription.go:4978\` calls \`ValidateAndFilterPricesForSubscription(req.AddonID, PRICE_ENTITY_TYPE_ADDON, sub, nil)\` which routes through the same \`filterValidPricesForSubscription\` used for PLAN prices — the \`IsCadenceCompatible\` gate applies to both entity types. So a monthly addon on a quarterly sub attaches (and fans out per month at billing time). User confirmed by observation.

## Changes

- \`filterAddonPricesForSubscription\` (\`src/utils/subscription/addon_commitment_helpers.ts\`): swap the exact-cadence filter to \`isCadenceCompatible\`. Adds an optional \`billingPeriodCount\` param defaulting to \`1\`, matching the sub cadence tuple used elsewhere. ONETIME addon prices still auto-attach (via existing \`isOneTimePlanPrice\` short-circuit + backend's ONETIME-passes rule).
- Label update: \`common.subscriptionAddon.filteredByPeriodAndCurrency\` shifts from *"Filtered by X and Y"* → *"Compatible with X and Y"* (en + ar). "Filtered" implied strict exclusion; "Compatible" reflects the inclusive gate.

## Test plan

- [x] \`npx vitest run\` — 56 tests pass (addon commitment tests + subscription utils)
- [x] \`npx tsc --noEmit\` clean on touched files
- [ ] Manual QA: create a quarterly sub, add a monthly addon → charges list now shows the monthly rows with the "Compatible with Quarterly and USD" subtitle; submit succeeds and the resulting invoice fans monthlies out into 3 line items per invoice window

## Not changed

- Fan-out hint per addon row — same-shape decision as the plan-price section; the dialog is already scoped to one addon so a per-row hint would be repetitive. Happy to add if you want it.
- Addon commitment editing on cross-cadence prices — backend already allows this (no cadence gate in \`validateLineItemCommitment\`); the existing "usage-based only" restriction on the addon dialog remains correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Add-on pricing now supports subscription billing periods that match or evenly divide the subscription cadence.
  * One-time add-ons continue to be available across billing periods.

* **Bug Fixes**
  * Improved filtering of add-on prices by billing cadence and currency.

* **Translations**
  * Updated English and Arabic wording to clarify that add-ons are “compatible with” the selected period and currency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->