### PR TITLE
fix(customer-portal): open checkout and add-card in a new tab, keep the link on screen

### DIFF
--- a/src/components/customer-portal/widgets/PaymentMethodsWidget.test.tsx
+++ b/src/components/customer-portal/widgets/PaymentMethodsWidget.test.tsx
@@ -69,13 +69,18 @@ const renderWidget = () => {
 describe('PaymentMethodsWidget', () => {
 	const originalLocation = window.location;
 
+	let openSpy: ReturnType<typeof vi.fn>;
+
 	beforeEach(() => {
+		openSpy = vi.fn().mockReturnValue({} as Window);
+		vi.stubGlobal('open', openSpy);
 		vi.mocked(CustomerPortalApi.getIntegrations).mockResolvedValue(FULL_CAPABILITIES as never);
 		Object.defineProperty(window, 'location', { configurable: true, value: { href: 'https://portal.test/methods' } });
 	});
 
 	afterEach(() => {
 		Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+		vi.unstubAllGlobals();
 		vi.clearAllMocks();
 	});
 
@@ -166,8 +171,9 @@ describe('PaymentMethodsWidget', () => {
 		);
 	});
 
-	// Adding returns an action, not a method — follow it only when it is a redirect.
-	it('follows a redirect action when adding a card', async () => {
+	// A new tab, so abandoning the provider's page still leaves the portal behind;
+	// the link is shown too, since the open can be blocked.
+	it('opens a redirect action in a new tab and keeps the link on the page', async () => {
 		vi.mocked(CustomerPortalApi.getPaymentMethods).mockResolvedValue({ providers: [] } as never);
 		vi.mocked(CustomerPortalApi.addPaymentMethod).mockResolvedValue({
 			provider: 'chargebee',
@@ -177,7 +183,10 @@ describe('PaymentMethodsWidget', () => {
 		renderWidget();
 		await userEvent.click(await screen.findByRole('button', { name: /add card/i }));
 
-		await waitFor(() => expect(window.location.href).toBe('https://vault.test/setup'));
+		await waitFor(() => expect(openSpy).toHaveBeenCalledWith('https://vault.test/setup', '_blank', expect.any(String)));
+		expect(await screen.findByText('https://vault.test/setup')).toBeInTheDocument();
+		// The portal must still be mounted — that is the point of not navigating.
+		expect(window.location.href).toBe('https://portal.test/methods');
 	});
 
 	// type 'none' means the provider vaulted server-to-server; there is nothing to

--- a/src/components/customer-portal/widgets/PaymentMethodsWidget.tsx
+++ b/src/components/customer-portal/widgets/PaymentMethodsWidget.tsx
@@ -11,7 +11,8 @@ import { refetchPortalQueries } from '../refetchPortalQueries';
 import type { PaymentGatewayType, ProviderSavedPaymentMethods, SavedPaymentMethod } from '@/types/dto/CustomerPortalBilling';
 import { portalPaymentMethodsQueryKey } from '../queryKeys';
 import usePortalIntegrations from '../usePortalIntegrations';
-import { navigateToPaymentUrl } from '@/utils/common/openPaymentUrl';
+import { openPaymentUrl } from '@/utils/common/openPaymentUrl';
+import CheckoutLinkDialog from './CheckoutLinkDialog';
 import EmptyState from '../EmptyState';
 
 interface PaymentMethodsWidgetProps {
@@ -148,6 +149,7 @@ const PaymentMethodsWidget = ({ label }: PaymentMethodsWidgetProps) => {
 		isError: integrationsError,
 	} = usePortalIntegrations();
 	const [pendingDelete, setPendingDelete] = useState<SavedPaymentMethod | null>(null);
+	const [setupUrl, setSetupUrl] = useState<string | null>(null);
 	const queryClient = useQueryClient();
 
 	const canManage = supports('payment_method_management');
@@ -172,11 +174,13 @@ const PaymentMethodsWidget = ({ label }: PaymentMethodsWidgetProps) => {
 			// A provider that vaults server-to-server returns type 'none' — there is
 			// nothing to redirect to, so refresh instead of waiting for a return trip.
 			if (response.action.type === 'redirect' && response.action.url) {
-				// Refused rather than followed when the scheme is not http(s): the URL is
-				// an unconstrained API string and a javascript: URL would execute.
-				if (!navigateToPaymentUrl(response.action.url)) {
-					toast.error(t('errors.addPaymentMethod'));
-				}
+				// A new tab, not this one: navigating away would unmount the portal, so a
+				// customer who abandons the provider's page has nothing to come back to.
+				// The link is shown as well, because the open runs in an async callback
+				// rather than the click and a popup blocker can stop it. Both paths refuse
+				// a non-http(s) scheme — the URL is an unconstrained API string.
+				setSetupUrl(response.action.url);
+				openPaymentUrl(response.action.url);
 				return;
 			}
 			toast.success(t('paymentMethods.added'));
@@ -235,6 +239,7 @@ const PaymentMethodsWidget = ({ label }: PaymentMethodsWidgetProps) => {
 
 	return (
 		<Card className='rounded-xl p-5' style={cardStyle}>
+			<CheckoutLinkDialog url={setupUrl} onOpenChange={(open) => !open && setSetupUrl(null)} />
 			<Dialog
 				isOpen={pendingDelete !== null}
 				onOpenChange={(open) => !open && setPendingDelete(null)}

--- a/src/components/customer-portal/widgets/TopUpForm.tsx
+++ b/src/components/customer-portal/widgets/TopUpForm.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import CustomerPortalApi from '@/api/CustomerPortalApi';
 import { portalReturnUrl } from '../portalReturnUrl';
+import { openPaymentUrl } from '@/utils/common/openPaymentUrl';
 import { Button, Input, Select, Toggle } from '@/components/atoms';
 import { refetchPortalQueries } from '../refetchPortalQueries';
 import { getCurrencySymbol } from '@/utils/common/helper_functions';
@@ -116,7 +117,12 @@ const TopUpForm = ({ wallet, onDone, onActionUrl }: TopUpFormProps) => {
 			// server-to-server — so an absent action means done, not broken.
 			if (action?.url) {
 				if (response.checkout_session?.id) rememberPendingCheckout(response.checkout_session.id);
+				// Surface the link first, then open it. Both, not either: the open runs in
+				// an async callback rather than the click, so a popup blocker can stop it,
+				// and the dialog stays on the page carrying the link either way — for a
+				// blocked open, and for coming back to it after the tab is closed.
 				onActionUrl?.(action.url);
+				openPaymentUrl(action.url);
 				return;
 			}
 

--- a/src/components/customer-portal/widgets/TopUpWidget.test.tsx
+++ b/src/components/customer-portal/widgets/TopUpWidget.test.tsx
@@ -53,7 +53,11 @@ const enterCredits = async (value: string) => {
 describe('TopUpWidget', () => {
 	const originalLocation = window.location;
 
+	let openSpy: ReturnType<typeof vi.fn>;
+
 	beforeEach(() => {
+		openSpy = vi.fn().mockReturnValue({} as Window);
+		vi.stubGlobal('open', openSpy);
 		vi.mocked(CustomerPortalApi.getWallets).mockResolvedValue([WALLET] as never);
 		vi.mocked(CustomerPortalApi.getIntegrations).mockResolvedValue({
 			payment_integrations: [{ provider: 'chargebee', capabilities: [{ type: 'checkout', is_default: true }] }],
@@ -65,6 +69,7 @@ describe('TopUpWidget', () => {
 
 	afterEach(() => {
 		Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+		vi.unstubAllGlobals();
 		vi.clearAllMocks();
 	});
 
@@ -85,7 +90,9 @@ describe('TopUpWidget', () => {
 
 	// Pay now is the checkout path: the customer is charged before credits land,
 	// so the widget must hand off to the returned session.
-	it('Pay now requests checkout and surfaces the returned action URL', async () => {
+	// Both, not either: the open can be blocked, and the dialog is what the customer
+	// falls back to — so the link must be on the page even when the tab opens.
+	it('Pay now opens the checkout and keeps the link on the page', async () => {
 		vi.mocked(CustomerPortalApi.topUpWallet).mockResolvedValue({
 			checkout_session: { id: 'cs_1', payment_action: { type: 'checkout_url', url: 'https://checkout.test/session' } },
 		} as never);
@@ -94,9 +101,8 @@ describe('TopUpWidget', () => {
 		await enterCredits('50');
 		await userEvent.click(screen.getByRole('button', { name: /pay now/i }));
 
-		await waitFor(() => expect(CustomerPortalApi.topUpWallet).toHaveBeenCalled());
-		const [, payload] = vi.mocked(CustomerPortalApi.topUpWallet).mock.calls[0];
-		expect(payload.checkout).toBeDefined();
+		await waitFor(() => expect(openSpy).toHaveBeenCalledWith('https://checkout.test/session', '_blank', expect.any(String)));
+		expect(await screen.findByText('https://checkout.test/session')).toBeInTheDocument();
 	});
 
 	// transaction_reason is pinned server-side; the client must not send one.

--- a/src/components/customer-portal/widgets/TopUpWidget.tsx
+++ b/src/components/customer-portal/widgets/TopUpWidget.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card } from '@/components/atoms';
 import usePortalWallet from '../usePortalWallet';
 import EmptyState from '../EmptyState';
 import TopUpForm from './TopUpForm';
+import CheckoutLinkDialog from './CheckoutLinkDialog';
 
 interface TopUpWidgetProps {
 	label?: string;
@@ -11,6 +13,7 @@ interface TopUpWidgetProps {
 /** Standalone top-up card. The Credits page surfaces `TopUpButton` in the wallet header instead. */
 const TopUpWidget = ({ label }: TopUpWidgetProps) => {
 	const { t } = useTranslation('customer-portal');
+	const [checkoutUrl, setCheckoutUrl] = useState<string | null>(null);
 	const { wallet, isLoading } = usePortalWallet();
 
 	if (isLoading) {
@@ -46,7 +49,10 @@ const TopUpWidget = ({ label }: TopUpWidgetProps) => {
 			<p className='text-sm mb-4' style={{ color: 'var(--portal-text-secondary, #71717a)' }}>
 				{t('topUp.description')}
 			</p>
-			<TopUpForm wallet={wallet} />
+			{/* Same fallback as the dialog variant: the open can be blocked, so the link
+			    has to remain reachable on the page. */}
+			<TopUpForm wallet={wallet} onActionUrl={setCheckoutUrl} />
+			<CheckoutLinkDialog url={checkoutUrl} onOpenChange={(open) => !open && setCheckoutUrl(null)} />
 		</Card>
 	);
 };


### PR DESCRIPTION
Follows #1336, which merged without the last two commits on that branch. This carries only those, cherry-picked onto current develop — no already-merged history.

## What

All three provider hand-offs — top-up checkout, invoice payment and add card — now open a **new tab** and leave the link on the page.

| | Before | After |
|---|---|---|
| Top-up Pay now | showed the link, never opened it | opens the tab **and** shows the link |
| Add card | navigated the current tab | opens a new tab, link shown |
| Invoice pay | already did both | unchanged |

## Why both, not either

The open runs in an async callback *after* the API responds, not in the user's click — which is exactly what popup blockers stop. So the tab is best-effort and the link on the page is the reliable path. Showing only the link meant a second click to go anywhere; opening only the tab meant a blocked popup was a dead end.

## Why a new tab rather than navigating

Navigating unmounted the portal. A customer who abandoned the provider's page had nothing to return to, and on Add card the saved-card list they were mid-way through managing was gone.

## Two gaps this closed

- The standalone top-up **card** rendered `TopUpForm` with no `onActionUrl`, so that variant would have opened a tab and shown **no link at all** if the popup were blocked. Only the dialog variant had the fallback.
- Add card had no link fallback either.

The `javascript:`/`data:`/`file:` scheme guard is preserved on both paths — these URLs are unconstrained API strings.

## Verification

108 test files, 720 tests, `npm run build` clean, `eslint --quiet` reports no errors. Tests assert the tab is opened, the link is rendered, and that the portal is still mounted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)