### PR TITLE
fix(customer-portal): stop the provider picker closing the top-up dialog

### DIFF
--- a/src/components/customer-portal/widgets/TopUpForm.tsx
+++ b/src/components/customer-portal/widgets/TopUpForm.tsx
@@ -5,7 +5,7 @@ import toast from 'react-hot-toast';
 import CustomerPortalApi from '@/api/CustomerPortalApi';
 import { portalReturnUrl } from '../portalReturnUrl';
 import { openPaymentUrl } from '@/utils/common/openPaymentUrl';
-import { Button, Input, Select, Toggle } from '@/components/atoms';
+import { Button, Input, Toggle } from '@/components/atoms';
 import { refetchPortalQueries } from '../refetchPortalQueries';
 import { getCurrencySymbol } from '@/utils/common/helper_functions';
 import { formatMoney } from '@/utils/common/formatBalance';
@@ -187,14 +187,41 @@ const TopUpForm = ({ wallet, onDone, onActionUrl }: TopUpFormProps) => {
 			/>
 
 			{canCheckout && checkoutProviders.length > 1 && (
-				<Select
-					label={t('topUp.providerLabel')}
-					description={t('topUp.providerHint')}
-					value={effectiveProvider ?? ''}
-					onChange={(value) => setSelectedProvider(value as PaymentGatewayType)}
-					options={checkoutProviders.map((p: PaymentGatewayType) => ({ value: p, label: t(`paymentProviders.${p}`) }))}
-					disabled={isPending}
-				/>
+				<div>
+					<p className='text-sm font-medium mb-1' style={{ color: 'var(--portal-text-primary, #09090b)' }}>
+						{t('topUp.providerLabel')}
+					</p>
+					{/* Inline rather than a Select: a Radix Select portals its list outside
+					    the dialog, and this dialog is modal={false}, so choosing an option
+					    reads as an outside click to the dismissable layer and closed the
+					    whole dialog mid-choice. With a handful of providers there is no
+					    reason to introduce a second dismissable layer at all. */}
+					<div role='radiogroup' aria-label={t('topUp.providerLabel')} className='flex flex-wrap gap-2'>
+						{checkoutProviders.map((provider: PaymentGatewayType) => {
+							const isSelected = effectiveProvider === provider;
+							return (
+								<button
+									key={provider}
+									type='button'
+									role='radio'
+									aria-checked={isSelected}
+									onClick={() => setSelectedProvider(provider)}
+									disabled={isPending}
+									className='px-3.5 py-2 text-sm rounded-lg border transition-colors disabled:opacity-50'
+									style={{
+										borderColor: isSelected ? 'var(--portal-primary, #2563eb)' : 'var(--portal-border, #E9E9E9)',
+										color: isSelected ? 'var(--portal-primary, #2563eb)' : 'var(--portal-text-primary, #09090b)',
+										backgroundColor: isSelected ? 'var(--portal-bg, #eff6ff)' : 'transparent',
+									}}>
+									{t(`paymentProviders.${provider}`)}
+								</button>
+							);
+						})}
+					</div>
+					<p className='text-xs mt-1.5' style={{ color: 'var(--portal-text-secondary, #71717a)' }}>
+						{t('topUp.providerHint')}
+					</p>
+				</div>
 			)}
 
 			{canCheckout && (

--- a/src/components/customer-portal/widgets/TopUpWidget.test.tsx
+++ b/src/components/customer-portal/widgets/TopUpWidget.test.tsx
@@ -237,6 +237,8 @@ describe('TopUpWidget', () => {
 		expect(screen.queryByText('Payment provider')).not.toBeInTheDocument();
 	});
 
+	// Inline options, not a Select: a portaled listbox inside this modal={false}
+	// dialog reads as an outside click and closed the dialog mid-choice.
 	it('asks which gateway to use when more than one can host checkout', async () => {
 		vi.mocked(CustomerPortalApi.getIntegrations).mockResolvedValue({
 			payment_integrations: [
@@ -247,6 +249,34 @@ describe('TopUpWidget', () => {
 
 		renderWidget();
 		expect(await screen.findByText('Payment provider')).toBeInTheDocument();
+
+		// Selectable in place, with no portaled layer to dismiss.
+		const options = screen.getAllByRole('radio');
+		expect(options.map((o) => o.textContent)).toEqual(['Chargebee', 'Razorpay']);
+		expect(options[0]).toHaveAttribute('aria-checked', 'true');
+
+		await userEvent.click(options[1]);
+		expect(options[1]).toHaveAttribute('aria-checked', 'true');
+	});
+
+	it('sends the provider the customer picked', async () => {
+		vi.mocked(CustomerPortalApi.getIntegrations).mockResolvedValue({
+			payment_integrations: [
+				{ provider: 'chargebee', capabilities: [{ type: 'checkout', is_default: true }] },
+				{ provider: 'razorpay', capabilities: [{ type: 'checkout', is_default: false }] },
+			],
+		} as never);
+		vi.mocked(CustomerPortalApi.topUpWallet).mockResolvedValue({} as never);
+
+		renderWidget();
+		await screen.findByText('Payment provider');
+		await userEvent.click(screen.getByRole('radio', { name: 'Razorpay' }));
+		await enterCredits('10');
+		await userEvent.click(screen.getByRole('button', { name: /pay now/i }));
+
+		await waitFor(() => expect(CustomerPortalApi.topUpWallet).toHaveBeenCalled());
+		const [, payload] = vi.mocked(CustomerPortalApi.topUpWallet).mock.calls[0];
+		expect(payload.checkout?.payment_provider).toBe('razorpay');
 	});
 
 	// Portal checkouts always vault, so no save flag may be sent from here.


### PR DESCRIPTION
Choosing a payment provider closed the whole **Add credits** dialog.

## Cause

The picker was a Radix `Select`, which portals its listbox outside the dialog's DOM. That dialog is `modal={false}`, so Radix's dismissable layer reads a click on the portaled list as an *outside* click and dismisses the dialog out from under the customer, mid-choice.

## Why not fix the guard

There is a guard for exactly this — `useSheetOutsideDismissGuards` — and it is wired correctly: `Dialog` computes it and the shadcn `DialogContent` forwards it to `DialogPrimitive.Content`. I verified both.

It works by beating Radix's own document-level capture listener to the `pointerdown`. Both register on mount, so which wins is registration order. Hardening that would have been guesswork, and it would stay fragile.

## Fix

With a handful of providers there is no reason to open a second dismissable layer at all. The options are now inline radio buttons — the same treatment as the preset amounts — so there is no portal and nothing to dismiss. That removes the failure rather than racing it.

Kept as `role="radiogroup"` with `aria-checked`, so it is still announced as one choice rather than a row of unrelated buttons.

## Note for reviewers

The same latent bug applies to any other portaled control inside these `modal={false}` dialogs — the auto top-up cooloff-unit `Select` is one. It has not been reported, and the same substitution is the fix if it is.

## Verification

108 test files, 724 tests, `npm run build` clean, `eslint --quiet` reports no errors. Two new tests: the options render and toggle in place, and the provider the customer picks is the one actually sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)