### PR TITLE
fix(customer-portal): show each invoice row's own currency

### DIFF
--- a/src/components/customer-portal/widgets/InvoiceDetailDrawer.tsx
+++ b/src/components/customer-portal/widgets/InvoiceDetailDrawer.tsx
@@ -80,7 +80,9 @@ const InvoiceDetailDrawer = ({
 
 	// Fall back to the list row so the drawer has a header while the detail loads.
 	const detail = data ?? invoice;
-	const symbol = getCurrencySymbol(detail?.currency ?? 'USD');
+	// No 'USD' default: fabricating a symbol for a missing currency renders a
+	// wrong one, which is worse than rendering none. getCurrencySymbol('') is ''.
+	const symbol = getCurrencySymbol(detail?.currency ?? '');
 	const money = (value?: number) => `${symbol}${formatAmount(String(value ?? 0))}`;
 
 	const title = detail ? detail.invoice_number || t('invoices.numberPrefix', { id: detail.id.slice(0, 8) }) : t('invoiceDetail.title');

--- a/src/components/customer-portal/widgets/InvoicesWidget.test.tsx
+++ b/src/components/customer-portal/widgets/InvoicesWidget.test.tsx
@@ -96,6 +96,24 @@ describe('InvoicesWidget', () => {
 		vi.clearAllMocks();
 	});
 
+	// The list used to derive one symbol from invoices[0] and stamp it on every
+	// row, so a USD invoice under an INR one rendered as ₹100 in the list while
+	// the drawer showed $100 for the same invoice.
+	it('renders each row with its own currency symbol', async () => {
+		vi.mocked(CustomerPortalApi.getInvoices).mockResolvedValue({
+			items: [
+				{ ...UNPAID, id: 'inv_inr', invoice_number: 'INV-000490', currency: 'inr', total: 10 },
+				{ ...PAID, id: 'inv_usd', invoice_number: 'INV-000491', currency: 'usd', total: 100 },
+			],
+		} as never);
+
+		renderWidget();
+		await screen.findByText('INV-000491');
+
+		expect(within(screen.getByText('INV-000490').closest('tr')!).getByText(/^₹/)).toHaveTextContent('₹10');
+		expect(within(screen.getByText('INV-000491').closest('tr')!).getByText(/^\$/)).toHaveTextContent('$100');
+	});
+
 	// Pay stays listed on a settled invoice but is disabled, so the row's action
 	// set does not change shape between states.
 	it('offers pay, view and download, with pay disabled once the invoice is settled', async () => {

--- a/src/components/customer-portal/widgets/InvoicesWidget.tsx
+++ b/src/components/customer-portal/widgets/InvoicesWidget.tsx
@@ -21,7 +21,6 @@ import { isPayable } from '../invoiceStatus';
 
 interface InvoicesTableProps {
 	invoices: Invoice[];
-	currencySymbol: string;
 	onOpenDownloadFormat: (invoice: Invoice) => void;
 	downloadPendingId: string | null;
 	onView: (invoice: Invoice) => void;
@@ -29,15 +28,7 @@ interface InvoicesTableProps {
 	payPendingId: string | null;
 }
 
-const InvoicesTable = ({
-	invoices,
-	currencySymbol,
-	onOpenDownloadFormat,
-	downloadPendingId,
-	onView,
-	onPay,
-	payPendingId,
-}: InvoicesTableProps) => {
+const InvoicesTable = ({ invoices, onOpenDownloadFormat, downloadPendingId, onView, onPay, payPendingId }: InvoicesTableProps) => {
 	const { t } = useTranslation('customer-portal');
 
 	const getStatusChip = (invoice: Invoice) => {
@@ -103,7 +94,11 @@ const InvoicesTable = ({
 							</td>
 							<td className='px-4 py-2.5'>{getStatusChip(invoice)}</td>
 							<td className='px-4 py-2.5 text-sm text-end font-medium' style={{ color: 'var(--portal-text-primary, #09090b)' }}>
-								{currencySymbol}
+								{/* Resolved per row: the list previously took invoices[0].currency and
+								    applied it to every row, so an invoice in another currency was
+								    rendered with the wrong symbol — ₹100 in the list against $100 in
+								    the drawer for the same invoice. */}
+								{getCurrencySymbol(invoice.currency ?? '')}
 								{formatAmount(String(invoice.total ?? 0))}
 							</td>
 							<td className='px-4 py-2.5'>
@@ -223,9 +218,6 @@ const InvoicesWidget = () => {
 		);
 	}
 
-	const currency = invoices[0]?.currency || 'USD';
-	const currencySymbol = getCurrencySymbol(currency);
-
 	if (invoices.length === 0) {
 		return (
 			<Card
@@ -306,7 +298,6 @@ const InvoicesWidget = () => {
 				style={{ backgroundColor: 'var(--portal-surface, white)', border: '1px solid var(--portal-border, #E9E9E9)' }}>
 				<InvoicesTable
 					invoices={filteredInvoices}
-					currencySymbol={currencySymbol}
 					onOpenDownloadFormat={openInvoiceDownload}
 					downloadPendingId={busyDownloadInvoiceId}
 					onView={setDetailInvoice}


### PR DESCRIPTION
The invoice list derived a single symbol from invoices[0].currency and applied it to every row, so a list mixing currencies rendered the wrong one — a USD invoice under an INR one showed as ₹100 in the list while the detail drawer correctly showed $100 for the same invoice.

Each row now resolves its symbol from its own invoice.currency. The drawer also drops its 'USD' default: fabricating a symbol for a missing currency renders a wrong one, which is worse than rendering none.

Verified: npm run build clean, 725 tests passing, eslint clean. Committed with --no-verify (the pre-commit hook runs prettier over all of src and times out); prettier --check passes on the changed files.