### PR TITLE
fix(commitment): pass null on explicit bucket clear so update payload skips stale resolution

### DIFF
--- a/src/components/molecules/PriceOverrideDialog/PriceOverrideDialog.tsx
+++ b/src/components/molecules/PriceOverrideDialog/PriceOverrideDialog.tsx
@@ -105,8 +105,10 @@ const PriceOverrideDialog: FC<Props> = ({
 	// BUCKET_SIZE_NONE). Commitment validation/normalization must then see "no bucket" — falling
 	// back to the price's old effective bucket would normalize time buckets for a removed size.
 	const bucketExplicitlyCleared = overrideBucketSize === '' && Boolean(price.bucket_size);
+	// null (not undefined): buildLineItemCommitmentUpdatePayload treats undefined as
+	// "resolve from the line item's price", which would validate against the removed bucket.
 	const effectiveBucketSizeForCommitment = bucketExplicitlyCleared
-		? undefined
+		? null
 		: overrideBucketSize || resolveBucketSize(price) || commitmentMeter?.aggregation?.bucket_size || undefined;
 
 	// Detect price unit type


### PR DESCRIPTION
Re-lands commit 89629a32 from #1315, which was pushed after that PR's squash-merge and so never reached develop.

An explicit bucket-size clear in PriceOverrideDialog passed `undefined` to `buildLineItemCommitmentUpdatePayload`, which treats `undefined` as "resolve from the line item's old price" — so a clear combined with a window-commitment edit validated commitment ranges against the removed bucket while the update sent `BUCKET_SIZE_NONE`. Passing `null` (the helper's explicit no-bucket signal) fixes it.

Addresses the one open CodeRabbit Major on release PR #1316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)