### PR TITLE
fix(e2e): resolve auth setup timeout caused by wrong login mode in CI build

### DIFF
--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -110,6 +110,11 @@ jobs:
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
           VITE_API_URL: ${{ secrets.E2E_API_URL }}
+          # E2E_USER_EMAIL/PASSWORD are native FlexPrice accounts on E2E_API_URL, not a
+          # Supabase project - without this, LoginForm takes the Supabase branch, whose
+          # client is a mock (no VITE_SUPABASE_URL/ANON_KEY here), so signInWithPassword
+          # throws and auth.setup.ts hangs until page.waitForURL times out.
+          VITE_APP_ENV: self-hosted
         run: npm run build
 
       - name: Decide which projects can run

--- a/src/core/services/supbase/config.ts
+++ b/src/core/services/supbase/config.ts
@@ -6,7 +6,13 @@ const isSelfHosted = config.app.env === APP_ENV.SelfHosted;
 const createMockClient = () => {
 	return {
 		auth: {
-			signIn: async () => ({ user: null, error: null }),
+			// Matches supabase-js's real signInWithPassword shape ({ data, error }) so
+			// LoginForm's destructuring works instead of throwing "not a function" when
+			// this client is used (self-hosted, or Supabase env vars simply unset).
+			signInWithPassword: async () => ({
+				data: { user: null, session: null },
+				error: new Error('Authentication is not configured for this deployment.'),
+			}),
 			signOut: async () => ({ error: null }),
 			onAuthStateChange: () => ({ data: null, error: null }),
 			getSession: async () => ({ data: null, error: null }),

--- a/src/pages/auth/LoginForm.tsx
+++ b/src/pages/auth/LoginForm.tsx
@@ -70,6 +70,9 @@ const LoginForm: React.FC<LoginFormProps> = ({ switchTab }) => {
 		onError: (error: Error) => {
 			toast.error(error.message || 'Something went wrong. Please try again.');
 		},
+		// Runs after either outcome — a failed self-hosted login otherwise left the button
+		// disabled forever, since neither onSuccess nor onError reset `loading`.
+		onSettled: () => setLoading(false),
 	});
 
 	const handleLogin = async () => {
@@ -81,21 +84,27 @@ const LoginForm: React.FC<LoginFormProps> = ({ switchTab }) => {
 		setLoading(true);
 
 		if (config.app.env !== APP_ENV.SelfHosted) {
-			const { error } = await supabase.auth.signInWithPassword({
-				email,
-				password,
-			});
+			try {
+				const { error } = await supabase.auth.signInWithPassword({
+					email,
+					password,
+				});
 
-			setLoading(false);
+				if (error) {
+					toast.error(error.message);
+					return;
+				}
 
-			if (error) {
-				toast.error(error.message);
-				return;
+				userContext.setUser(data);
+				navigate('/');
+				toast.success('Login successful');
+			} catch (error) {
+				// Belt-and-suspenders: a thrown error here (e.g. a misconfigured auth client)
+				// must still surface and release the button, not just leave it disabled.
+				toast.error(error instanceof Error ? error.message : 'Something went wrong. Please try again.');
+			} finally {
+				setLoading(false);
 			}
-
-			userContext.setUser(data);
-			navigate('/');
-			toast.success('Login successful');
 		} else {
 			localLogin();
 		}


### PR DESCRIPTION
## Summary
Resolves the Playwright E2E failure on #1359 (`E2E (PR)` / Playwright job): `authenticate` setup times out on `page.waitForURL` after 45s, twice in a row, every time E2E secrets are actually available for the run (consistently reproducible on the `develop`-headed release PR).

## Root cause
`e2e-pr.yml`'s Build step never sets `VITE_APP_ENV`, so `config.app.env` defaults to `'local'` rather than `'self-hosted'`. `LoginForm` therefore takes the Supabase branch — but the build also never receives `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY`, so `supabase/config.ts` falls back to its mock client. That mock only implemented `signIn` (unused anywhere in the app), not `signInWithPassword` (what `LoginForm` actually calls), so the call threw a `TypeError` *before* `setLoading(false)` — leaving the login button permanently disabled and the page stuck on `/login`, exactly matching the failing run's page snapshot (`button [disabled]`, fields filled, no visible error).

The E2E test credentials (`demo-user-v2@flexprice.io` against `E2E_API_URL`) are a native FlexPrice account for `AuthApi`'s own `/auth/login` endpoint, not a Supabase project — self-hosted mode is what this build was actually meant to run in.

## Fix
- **`e2e-pr.yml`**: set `VITE_APP_ENV=self-hosted` on the Build step, so `LoginForm` calls `AuthApi.Login` (the real backend) instead of Supabase.
- **`LoginForm.tsx`**: wrap the Supabase branch in `try/catch/finally`, and add `onSettled` to the self-hosted mutation, so a failed login of either kind always resets `loading` and surfaces an error toast — this class of bug (a thrown/rejected auth call never clearing the loading state) shouldn't be able to hang a real user's login either, not just this test.
- **`supbase/config.ts`**: mock client now implements `signInWithPassword` (matching the real SDK's `{ data, error }` shape) instead of the unused `signIn`, so any deployment that reaches this path degrades to a clear "not configured" error instead of a raw `TypeError`.

## Test plan
- [x] `npx tsc --noEmit -p .` clean
- [x] `npx eslint` on touched files — 0 errors (2 pre-existing warnings, unchanged)
- [x] `npx vitest run` — all 803 tests pass
- [x] `npm run build` succeeds
- [ ] Playwright `authenticate` setup passes in CI (can't verify locally without the E2E secrets — this is the actual test of the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)