### PR TITLE
fix: address CodeRabbit review findings on release PR #1359

### DIFF
--- a/src/components/customer-portal/PortalHeader.tsx
+++ b/src/components/customer-portal/PortalHeader.tsx
@@ -2,6 +2,7 @@ import { Customer } from '@/models';
 import { Building2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { usePortalConfig } from '@/context/PortalConfigContext';
+import { isColorDark } from '@/components/customer-portal/portalTheme';
 import { cn } from '@/lib/utils';
 
 interface PortalHeaderProps {
@@ -13,6 +14,9 @@ const PortalHeader = ({ customer, tenantName }: PortalHeaderProps) => {
 	const { t } = useTranslation('customer-portal');
 	const { config } = usePortalConfig();
 	const theme = config.theme;
+	// The avatar's own background is the tenant color, not a themed surface token, so it needs
+	// its own light/dark check — a light primary_color (e.g. #ffffff) must not get white text.
+	const avatarTextIsLight = theme?.primary_color ? isColorDark(theme.primary_color) : false;
 
 	const initials =
 		customer.name
@@ -33,7 +37,13 @@ const PortalHeader = ({ customer, tenantName }: PortalHeaderProps) => {
 						<div
 							className='flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-surface-subtle'
 							style={theme?.primary_color ? { backgroundColor: theme.primary_color } : undefined}>
-							<span className={cn('text-lg font-medium', theme?.primary_color ? 'text-white' : 'text-content-secondary')}>{initials}</span>
+							<span
+							className={cn(
+								'text-lg font-medium',
+								theme?.primary_color ? (avatarTextIsLight ? 'text-white' : 'text-content') : 'text-content-secondary',
+							)}>
+							{initials}
+						</span>
 						</div>
 
 						<div>

--- a/src/components/customer-portal/widgets/InvoicesWidget.tsx
+++ b/src/components/customer-portal/widgets/InvoicesWidget.tsx
@@ -10,7 +10,7 @@ import { InvoiceDownloadFormatDialog } from '@/components/molecules';
 import { Invoice, INVOICE_STATUS } from '@/models/Invoice';
 import { PAYMENT_STATUS } from '@/constants/payment';
 import { formatDateShort, getCurrencySymbol } from '@/utils/common/helper_functions';
-import { formatAmount } from '@/components/atoms/Input/Input';
+import { formatMoney } from '@/utils/common/formatBalance';
 import { CreditCard, Download, Eye, MoreHorizontal, Receipt, Search, SearchX } from 'lucide-react';
 import EmptyState from '../EmptyState';
 import PortalSection from '../PortalSection';
@@ -79,7 +79,7 @@ const InvoicesTable = ({ invoices, onOpenDownloadFormat, downloadPendingId, onVi
 								    rendered with the wrong symbol — ₹100 in the list against $100 in
 								    the drawer for the same invoice. */}
 							{getCurrencySymbol(invoice.currency ?? '')}
-							{formatAmount(String(invoice.total ?? 0))}
+							{formatMoney(invoice.total ?? 0)}
 						</PortalTableCell>
 						<PortalTableCell align='end'>
 							<div className='flex items-center justify-end'>

--- a/src/components/molecules/InvoiceTable/InvoiceTableMenu.tsx
+++ b/src/components/molecules/InvoiceTable/InvoiceTableMenu.tsx
@@ -20,9 +20,12 @@ import { useCurrentUserPermissions } from '@/hooks/useCurrentUserPermissions';
 
 interface Props {
 	data: InvoiceListItem;
+	/** Overrides the default `/invoices/:id/edit` navigation — lets a caller keep
+	 *  this menu decoupled from RouteNames when it needs a different edit route. */
+	onEdit?: (invoiceId: string) => void;
 }
 
-const InvoiceTableMenu: FC<Props> = ({ data }) => {
+const InvoiceTableMenu: FC<Props> = ({ data, onEdit }) => {
 	const navigate = useNavigate();
 	const { t } = useTranslation('billing');
 	const { t: tc } = useTranslation('common');
@@ -106,7 +109,8 @@ const InvoiceTableMenu: FC<Props> = ({ data }) => {
 			label: t('invoices.edit.menuLabel'),
 			group: 'Actions',
 			onSelect: () => {
-				navigate(`${RouteNames.invoices}/${data.id}/edit`);
+				if (onEdit) onEdit(data.id);
+				else navigate(`${RouteNames.invoices}/${data.id}/edit`);
 			},
 			disabled: !canWrite || !isEditableStatus,
 			disabledReason: writeDeniedReason ?? (!isEditableStatus ? t('invoices.edit.menuDisabledStatus') : undefined),

--- a/src/i18n/locales/ar/customer-portal.json
+++ b/src/i18n/locales/ar/customer-portal.json
@@ -89,7 +89,11 @@
 		"unknownPlan": "خطة غير معروفة",
 		"nextBilling": "الفوترة التالية {{date}}",
 		"trialEnds": "تنتهي التجربة {{date}}",
+		"count_zero": "لا توجد اشتراكات",
 		"count_one": "اشتراك واحد",
+		"count_two": "اشتراكان",
+		"count_few": "{{count}} اشتراكات",
+		"count_many": "{{count}} اشتراكًا",
 		"count_other": "{{count}} اشتراكات"
 	},
 	"usage": {

--- a/src/pages/customer/invoices/EditInvoicePage.test.tsx
+++ b/src/pages/customer/invoices/EditInvoicePage.test.tsx
@@ -432,6 +432,54 @@ describe('EditInvoicePage', () => {
 		expect(mockNavigate).not.toHaveBeenCalled();
 	});
 
+	it('resumes onto the recreated draft on retry instead of replaying the completed step', async () => {
+		mockGetInvoiceById.mockResolvedValue(
+			makeInvoice({
+				invoice_status: 'FINALIZED',
+				line_items: [{ id: 'li_1', display_name: 'Consulting', quantity: '2', amount: 300 }],
+			}),
+		);
+		mockModifyInvoice
+			// The update step succeeds and voids-and-recreates the invoice.
+			.mockResolvedValueOnce({ invoice: makeInvoice({ id: 'inv_draft_2', invoice_status: 'DRAFT' }) })
+			// The add step fails on the first attempt.
+			.mockRejectedValueOnce(new Error('add failed'))
+			// The retried add step succeeds.
+			.mockResolvedValueOnce({ invoice: makeInvoice({ id: 'inv_draft_2', invoice_status: 'DRAFT' }) });
+		const user = userEvent.setup();
+		renderPage();
+
+		const nameInput = await screen.findByDisplayValue('Consulting');
+		await user.clear(nameInput);
+		await user.type(nameInput, 'Consulting hours');
+		await user.click(screen.getByRole('button', { name: 'Add Line Item' }));
+		const nameInputs = screen.getAllByPlaceholderText('Enter item name');
+		await user.type(nameInputs[nameInputs.length - 1], 'Setup fee');
+		const amountInputs = screen.getAllByPlaceholderText('0.00');
+		await user.clear(amountInputs[amountInputs.length - 1]);
+		await user.type(amountInputs[amountInputs.length - 1], '50');
+
+		// First attempt: update succeeds (recreates the draft), add fails.
+		await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+		await user.click(await screen.findByRole('button', { name: 'Void & create draft' }));
+		await waitFor(() => expect(mockModifyInvoice).toHaveBeenCalledTimes(2));
+		expect(mockNavigate).not.toHaveBeenCalled();
+
+		// Retry with unchanged form state.
+		await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+		await user.click(await screen.findByRole('button', { name: 'Void & create draft' }));
+
+		await waitFor(() => expect(mockModifyInvoice).toHaveBeenCalledTimes(3));
+		// The retry must not resend the already-completed update against the original
+		// (by now voided) invoice — only the failed add re-runs, against the recreated draft.
+		expect(mockModifyInvoice.mock.calls[2][0]).toBe('inv_draft_2');
+		expect(mockModifyInvoice.mock.calls[2][1]).toEqual({
+			type: 'line_item',
+			line_item_params: { action: 'add', items: [{ display_name: 'Setup fee', amount: '50', quantity: '1' }] },
+		});
+		await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/billing/invoices/inv_draft_2'));
+	});
+
 	it('cancelling the void confirmation returns to editing without saving', async () => {
 		mockGetInvoiceById.mockResolvedValue(
 			makeInvoice({

--- a/src/pages/customer/invoices/EditInvoicePage.tsx
+++ b/src/pages/customer/invoices/EditInvoicePage.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
@@ -30,6 +30,7 @@ import {
 	ExecuteInvoiceModifyPayload,
 	INVOICE_MODIFY_LINE_ITEM_ACTION,
 	InvoiceModifyAddLineItem,
+	InvoiceModifyResponse,
 	InvoiceModifyUpdateLineItem,
 	UpdateInvoicePayload,
 } from '@/types/dto';
@@ -60,6 +61,32 @@ interface LineItemOps {
 	adds: InvoiceModifyAddLineItem[];
 }
 
+/**
+ * Tracks how far a finalized-invoice save got, so a retry after a partial failure
+ * resumes instead of replaying from the original (now-voided) invoice.
+ *
+ * A finalized save is a sequence of independent backend calls, and the first one
+ * that touches line items voids the invoice and recreates it as a draft - every
+ * call after that must target the new draft's id, not the original. Without this,
+ * a retry rebuilds the same ops from unchanged form state and resends every step
+ * against `invoiceId`, which by then no longer accepts edits: at best the retry
+ * fails outright, at worst a second void-and-recreate produces a duplicate draft.
+ */
+interface SaveProgress {
+	targetId: string;
+	/** Step keys already executed successfully in this save; see stepKey below. */
+	done: Set<string>;
+}
+
+const stepKey = {
+	payload: 'payload',
+	paymentStatus: 'paymentStatus',
+	removes: 'removes',
+	update: (lineItemId: string) => `update:${lineItemId}`,
+	adds: 'adds',
+	status: 'status',
+} as const;
+
 const toLineItemRows = (invoice: Invoice): LineItemRow[] =>
 	(invoice.line_items ?? []).map((li) => ({
 		id: li.id,
@@ -78,6 +105,15 @@ const invoiceEditResponseSchema = z.object({
 const parseInvoiceForEdit = (invoice: Invoice): Invoice => {
 	invoiceEditResponseSchema.parse(invoice);
 	return invoice;
+};
+
+// The modify endpoint's { invoice } envelope gets the same guard, reusing
+// invoiceEditResponseSchema for the nested invoice rather than a second schema.
+const invoiceModifyResponseSchema = z.object({ invoice: invoiceEditResponseSchema });
+
+const parseModifyResponse = (resp: InvoiceModifyResponse): InvoiceModifyResponse => {
+	invoiceModifyResponseSchema.parse(resp);
+	return resp;
 };
 
 // Backend only accepts updates for invoices in these statuses.
@@ -231,6 +267,11 @@ const EditInvoicePage: FC = () => {
 	const hasChanges =
 		dueDateChanged || pdfUrlChanged || metadataChanged || applyDiscount || paymentStatusChanged || lineItemsChanged || invoiceStatusChanged;
 
+	// Only the finalized (void-and-recreate) path needs resume tracking: a plain draft
+	// save's targetId never changes, and its onError below already invalidates the
+	// invoice query, so a retry recomputes ops against fresh server state instead.
+	const saveProgressRef = useRef<SaveProgress | null>(null);
+
 	const { mutate: updateInvoice, isPending } = useMutation({
 		mutationFn: async ({
 			payload,
@@ -246,49 +287,72 @@ const EditInvoicePage: FC = () => {
 			// A finalized save voids the invoice and recreates it as a draft; every response
 			// carries the invoice the operation actually landed on, so chain later calls (and
 			// the success navigation) to that id. For drafts the id never changes — no-op.
-			let targetId = invoiceId!;
-			if (payload) {
-				const updated = await InvoiceApi.updateInvoice(targetId, payload);
-				targetId = updated?.id ?? targetId;
+			//
+			// Resuming from a prior partial failure: `done` and `targetId` reflect exactly how
+			// far that attempt got, so a retry with unchanged form state can't resend a step that
+			// already landed against an invoice that, by then, may no longer accept it.
+			const resuming = isFinalized ? saveProgressRef.current : null;
+			let targetId = resuming?.targetId ?? invoiceId!;
+			const done = new Set(resuming?.done);
+			const markDone = (key: string, newTargetId?: string) => {
+				done.add(key);
+				if (newTargetId) targetId = newTargetId;
+				if (isFinalized) saveProgressRef.current = { targetId, done: new Set(done) };
+			};
+
+			if (payload && !done.has(stepKey.payload)) {
+				const updated = parseInvoiceForEdit(await InvoiceApi.updateInvoice(targetId, payload));
+				markDone(stepKey.payload, updated?.id ?? targetId);
 			}
-			if (nextPaymentStatus) await InvoiceApi.updateInvoicePaymentStatus(targetId, { payment_status: nextPaymentStatus });
+			if (nextPaymentStatus && !done.has(stepKey.paymentStatus)) {
+				await InvoiceApi.updateInvoicePaymentStatus(targetId, { payment_status: nextPaymentStatus });
+				markDone(stepKey.paymentStatus);
+			}
 			if (ops) {
-				if (ops.removes.length > 0) {
+				if (ops.removes.length > 0 && !done.has(stepKey.removes)) {
 					const payload: ExecuteInvoiceModifyPayload = {
 						type: 'line_item',
 						line_item_params: { action: INVOICE_MODIFY_LINE_ITEM_ACTION.REMOVE, line_item_ids: ops.removes },
 					};
-					const resp = await InvoiceApi.modifyInvoice(targetId, payload);
-					targetId = resp?.invoice?.id ?? targetId;
+					const resp = parseModifyResponse(await InvoiceApi.modifyInvoice(targetId, payload));
+					markDone(stepKey.removes, resp?.invoice?.id ?? targetId);
 				}
 				// One update per call: the backend versions each edit individually.
 				for (const { line_item_id, update } of ops.updates) {
+					const key = stepKey.update(line_item_id);
+					if (done.has(key)) continue;
 					const payload: ExecuteInvoiceModifyPayload = {
 						type: 'line_item',
 						line_item_params: { action: INVOICE_MODIFY_LINE_ITEM_ACTION.UPDATE, line_item_id, update },
 					};
-					const resp = await InvoiceApi.modifyInvoice(targetId, payload);
-					targetId = resp?.invoice?.id ?? targetId;
+					const resp = parseModifyResponse(await InvoiceApi.modifyInvoice(targetId, payload));
+					markDone(key, resp?.invoice?.id ?? targetId);
 				}
-				if (ops.adds.length > 0) {
+				if (ops.adds.length > 0 && !done.has(stepKey.adds)) {
 					const payload: ExecuteInvoiceModifyPayload = {
 						type: 'line_item',
 						line_item_params: { action: INVOICE_MODIFY_LINE_ITEM_ACTION.ADD, items: ops.adds },
 					};
-					const resp = await InvoiceApi.modifyInvoice(targetId, payload);
-					targetId = resp?.invoice?.id ?? targetId;
+					const resp = parseModifyResponse(await InvoiceApi.modifyInvoice(targetId, payload));
+					markDone(stepKey.adds, resp?.invoice?.id ?? targetId);
 				}
 			}
 			// Status transition runs last: line-item edits must land while the invoice is
 			// still editable, and a finalize must see the finished draft.
-			if (nextInvoiceStatus === INVOICE_STATUS.VOIDED) {
-				await InvoiceApi.voidInvoice(targetId);
-			} else if (nextInvoiceStatus === INVOICE_STATUS.FINALIZED) {
-				await InvoiceApi.finalizeInvoice(targetId);
+			if (!done.has(stepKey.status)) {
+				if (nextInvoiceStatus === INVOICE_STATUS.VOIDED) {
+					await InvoiceApi.voidInvoice(targetId);
+					markDone(stepKey.status);
+				} else if (nextInvoiceStatus === INVOICE_STATUS.FINALIZED) {
+					await InvoiceApi.finalizeInvoice(targetId);
+					markDone(stepKey.status);
+				}
 			}
 			return targetId;
 		},
 		onSuccess: (targetId: string) => {
+			// Fully landed — the next save (if any, e.g. on the recreated draft) starts fresh.
+			saveProgressRef.current = null;
 			toast.success(t('invoices.edit.toast.updateSuccess'));
 			void refetchInvoiceQueries();
 			void refetchQueries(['invoiceEdit', invoiceId!]);
@@ -297,8 +361,10 @@ const EditInvoicePage: FC = () => {
 		},
 		onError: (error: Error) => {
 			if (isFinalized) {
-				// The void-and-recreate flow failed: keep the user's edits so they can
-				// fix and retry — reseeding from the server would wipe the form.
+				// The void-and-recreate flow failed partway through: keep the user's edits so
+				// they can fix and retry — reseeding from the server would wipe the form.
+				// saveProgressRef already reflects exactly how far this attempt got, so the
+				// retry (handled above) resumes rather than replaying completed steps.
 				toast.error(error.message || t('invoices.edit.toast.updateFailed'));
 				return;
 			}


### PR DESCRIPTION
## Summary
Addresses the CodeRabbit review comments on #1359. Six fixed, one already resolved by a later commit, one intentionally not attempted (needs backend support).

### Fixed
- **`EditInvoicePage.tsx`** (Major): a retry of a *failed, partway-through* finalized-invoice save (void-and-recreate) now resumes from the recreated draft instead of replaying already-completed steps against the original, by-then-voided invoice. Previously a retry with unchanged form state resent every step from `invoiceId`, risking a second void-and-recreate (duplicate draft) or a step silently failing against an invoice that no longer accepts it. Tracks per-step completion (`payload`/`paymentStatus`/`removes`/each line-item `update`/`adds`/`status`) across `mutate()` calls in a ref, cleared on full success. Added a regression test that fails without the fix and passes with it.
- **`EditInvoicePage.tsx`** (Minor): the `updateInvoice`/`modifyInvoice` mutation responses now go through the existing `invoiceEditResponseSchema` (reused via a small `{ invoice }` wrapper, not duplicated) before their `id` is trusted — previously only the initial `getInvoiceById` load was validated.
- **`PortalHeader.tsx`** (Minor): avatar initials use dark text on a light `primary_color` instead of always `text-white`, via the existing `isColorDark()` bridge in `portalTheme.ts` rather than a new check.
- **`InvoicesWidget.tsx`** (Minor): invoice list total now uses `formatMoney` (fixed 2 decimals) instead of `formatAmount` (no rounding), matching `InvoiceDetailDrawer` — a $2 invoice no longer reads differently between the list and its own drawer.
- **`InvoiceTableMenu.tsx`** (Major): added an optional `onEdit` callback so a caller can own the edit route instead of the menu constructing `RouteNames.invoices` itself. Scoped to just the new addition — this component has several other pre-existing `navigate()` calls (View Customer, View Subscription, Issue Credit Note) that are out of scope here; all 4 existing call sites keep working unchanged since `onEdit` defaults to the prior inline-navigate behavior when omitted.
- **`ar/customer-portal.json`** (Minor): added `count_zero`/`count_two`/`count_few`/`count_many` for `subscriptions.count`. I verified empirically (a throwaway repro against this app's real i18next config) that every count except `1` and `100+` was rendering the **English** `count_other` string (`"2 subscriptions"`) inside the Arabic portal — `fallbackLng: 'en'` engages per missing plural category rather than i18next falling back to `ar`'s own `count_other`, which is worse than the raw-key leak the original finding described. Re-ran the same repro after adding the CLDR forms; every count now resolves correctly in Arabic.

### Already resolved
- The "select remove button by accessible name" finding (`Trash2`/`lucide-trash2` selector) was already fixed in a later commit before this PR's base — its `commit_id` predates the current `develop` HEAD, and `EditInvoicePage.test.tsx` already uses `getByRole('button', { name: 'Remove line item' })`.

### Not attempted — needs backend support
- **`portalReturnUrl.ts`**'s localStorage session-token handoff (Major/security): the code already documents why it's there — the payment-provider tab opens `noopener,noreferrer` (a fresh browsing context sharing no `sessionStorage`), the token is capped at a 30-minute TTL, and it's same-origin only. The suggested proper fix (a backend-issued `HttpOnly` cookie or a single-use return-code exchange) needs backend API changes outside this repo. I didn't ship a frontend-only workaround that can't actually deliver that property — flagging this for backend+frontend follow-up instead.

## Test plan
- [x] `npx tsc --noEmit -p .` clean
- [x] `npx eslint` on all touched files — 0 errors (pre-existing warnings unchanged)
- [x] `npx vitest run` — all 804 tests pass (17 in `EditInvoicePage.test.tsx`, up from 16 — the new one confirmed to fail on the pre-fix code)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)