### PR TITLE
fix(RolePicker): keep every role checkbox clickable when Super Admin is selected

### DIFF
--- a/src/components/molecules/RolePicker/RolePicker.test.tsx
+++ b/src/components/molecules/RolePicker/RolePicker.test.tsx
@@ -28,18 +28,16 @@ describe('RolePicker', () => {
 		expect(onToggle).toHaveBeenCalledWith('writer');
 	});
 
-	it('disables every non-super_admin checkbox when super_admin is selected', () => {
-		render(<RolePicker roles={roles} selectedRoleIds={['super_admin']} onToggle={vi.fn()} />);
-		expect(screen.getByRole('checkbox', { name: 'Reader' })).toBeDisabled();
-		expect(screen.getByRole('checkbox', { name: 'Writer' })).toBeDisabled();
-		expect(screen.getByRole('checkbox', { name: 'Billing Admin' })).toBeDisabled();
-		expect(screen.getByRole('checkbox', { name: 'Super Admin' })).not.toBeDisabled();
-	});
-
-	it('re-enables every checkbox once super_admin is deselected', () => {
-		render(<RolePicker roles={roles} selectedRoleIds={[]} onToggle={vi.fn()} />);
+	it('keeps every checkbox clickable even when super_admin is selected', () => {
+		const onToggle = vi.fn();
+		render(<RolePicker roles={roles} selectedRoleIds={['super_admin']} onToggle={onToggle} />);
 		expect(screen.getByRole('checkbox', { name: 'Reader' })).not.toBeDisabled();
 		expect(screen.getByRole('checkbox', { name: 'Writer' })).not.toBeDisabled();
+		expect(screen.getByRole('checkbox', { name: 'Billing Admin' })).not.toBeDisabled();
+		expect(screen.getByRole('checkbox', { name: 'Super Admin' })).not.toBeDisabled();
+
+		fireEvent.click(screen.getByRole('checkbox', { name: 'Reader' }));
+		expect(onToggle).toHaveBeenCalledWith('reader');
 	});
 
 	it('allows multiple non-super_admin roles to be selected simultaneously', () => {

--- a/src/components/molecules/RolePicker/RolePicker.tsx
+++ b/src/components/molecules/RolePicker/RolePicker.tsx
@@ -3,7 +3,7 @@ import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import { AlertTriangle, Check } from 'lucide-react';
 import { Button } from '@/components/atoms';
 import { cn } from '@/lib/utils';
-import { RbacRole, SUPER_ADMIN_ROLE_ID } from '@/api/RbacApi';
+import { RbacRole } from '@/api/RbacApi';
 
 export interface RolePickerProps {
 	roles: RbacRole[];
@@ -25,10 +25,11 @@ export interface RolePickerProps {
 
 /**
  * Presentational multi-select role picker. Renders whatever roles it's given —
- * no branching on specific role IDs, no role-specific colors/icons, except
- * SUPER_ADMIN_ROLE_ID, which is exclusive with every other role (selecting it
- * clears/disables the rest). Each role is a full-row clickable card (native
- * <label>-to-<Checkbox> delegation, not just a small inner control).
+ * no branching on specific role IDs, no role-specific colors/icons. Every row
+ * stays clickable regardless of what else is selected, including Super Admin;
+ * `onToggle`'s caller decides what selecting a given role does to the rest.
+ * Each role is a full-row clickable card (native <label>-to-<Checkbox>
+ * delegation, not just a small inner control).
  */
 const RolePicker: FC<RolePickerProps> = ({
 	roles,
@@ -46,8 +47,6 @@ const RolePicker: FC<RolePickerProps> = ({
 	emptyLabel = 'No roles available.',
 	ariaLabel = 'Roles',
 }) => {
-	const isSuperAdminSelected = selectedRoleIds.includes(SUPER_ADMIN_ROLE_ID);
-
 	return (
 		<div className='flex flex-col gap-2'>
 			{title && <p className='text-sm font-medium text-content-zinc-bold'>{title}</p>}
@@ -73,22 +72,19 @@ const RolePicker: FC<RolePickerProps> = ({
 				<div role='group' aria-label={ariaLabel} className={cn('grid gap-2', roles.length > 5 ? 'sm:grid-cols-2' : 'grid-cols-1')}>
 					{roles.map((role) => {
 						const isChecked = selectedRoleIds.includes(role.id);
-						const isDisabled = isSuperAdminSelected && role.id !== SUPER_ADMIN_ROLE_ID;
 						const inputId = `role-${role.id}`;
 						return (
 							<label
 								key={role.id}
 								htmlFor={inputId}
 								className={cn(
-									'flex items-start gap-2.5 rounded-md border-2 px-3 py-2.5 transition-colors',
-									isDisabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
+									'flex items-start gap-2.5 rounded-md border-2 px-3 py-2.5 transition-colors cursor-pointer',
 									isChecked ? 'bg-surface-selected border-line-zinc-strong' : 'border-line hover:bg-surface-faint',
 								)}>
 								<CheckboxPrimitive.Root
 									id={inputId}
 									checked={isChecked}
 									onCheckedChange={() => onToggle(role.id)}
-									disabled={isDisabled}
 									aria-label={role.name}
 									className={cn(
 										'mt-0.5 h-4 w-4 shrink-0 rounded-full border shadow-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed',


### PR DESCRIPTION
## Summary
`RolePicker` (the shared component behind both the "Edit user roles" dialog and the "Add member" role selection) used to disable every other role's checkbox once Super Admin was checked — grayed out, `cursor-not-allowed`, `disabled` on the underlying Radix Checkbox.

## Fix
Removed the disabling. Both consumers' own toggle logic already supports Super Admin plus other roles selected simultaneously (selecting a non-`super_admin` role appends to the current selection rather than being blocked), so the disabling in `RolePicker` was the only thing standing in the way. Every row is now always clickable regardless of what else is selected.

Scoped to `RolePicker` only — this is a shared, presentational component with no special-cased behavior beyond this, so the fix applies consistently everywhere it's used (`EditUserRolesDialog`, `UsersSection`'s add-member flow) without touching either consumer.

## Test plan
- [x] Updated `RolePicker.test.tsx`'s test that asserted the old disabled-when-super_admin-selected behavior to assert the opposite, and that clicking a role while Super Admin is selected still fires `onToggle`
- [x] `npx tsc --noEmit -p .` clean
- [x] `npx eslint` on touched files — 0 errors
- [x] `npx vitest run` — all 805 tests pass
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Role selection remains available when Super Admin is selected.
  * All role checkboxes can now be clicked, including Reader.
  * Selecting a role correctly triggers the associated toggle action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->