### PR TITLE
feat(invoice): hide zero-amount line items behind toggle, coupon card styling

### DIFF
--- a/src/i18n/locales/ar/billing.json
+++ b/src/i18n/locales/ar/billing.json
@@ -70,6 +70,7 @@
 			"periodEnd": "نهاية الفترة",
 			"lineItemDescriptionPlaceholder": "وصف اختياري",
 			"servicePeriod": "فترة الخدمة",
+			"zeroChargesHidden": "بنود بقيمة صفر مخفية ({{hidden}})",
 			"itemColumn": "البند",
 			"noLineItems": "لا توجد بنود في هذه الفاتورة بعد.",
 			"newLineItem": "بند جديد"

--- a/src/i18n/locales/en/billing.json
+++ b/src/i18n/locales/en/billing.json
@@ -70,6 +70,7 @@
 			"periodEnd": "Period End",
 			"lineItemDescriptionPlaceholder": "Optional description",
 			"servicePeriod": "Service Period",
+			"zeroChargesHidden": "Zero-amount line items hidden ({{hidden}})",
 			"itemColumn": "Item",
 			"noLineItems": "No line items on this invoice yet.",
 			"newLineItem": "New line item"

--- a/src/pages/customer/invoices/EditInvoicePage.test.tsx
+++ b/src/pages/customer/invoices/EditInvoicePage.test.tsx
@@ -375,6 +375,28 @@ describe('EditInvoicePage', () => {
 		});
 	});
 
+	it('hides zero-amount line items behind the show-zero-charges toggle', async () => {
+		mockGetInvoiceById.mockResolvedValue(
+			makeInvoice({
+				line_items: [
+					{ id: 'li_1', display_name: 'Consulting', quantity: '2', amount: 300 },
+					{ id: 'li_2', display_name: 'Free tier', quantity: '1', amount: 0 },
+				],
+			}),
+		);
+		const user = userEvent.setup();
+		renderPage();
+
+		// Matches the invoice preview: zero-amount rows are hidden by default, with a count hint.
+		expect(await screen.findByText('Consulting')).toBeInTheDocument();
+		expect(screen.queryByText('Free tier')).not.toBeInTheDocument();
+		expect(screen.getByText('Zero-amount line items hidden (1)')).toBeInTheDocument();
+
+		await user.click(screen.getByRole('switch'));
+		expect(screen.getByText('Free tier')).toBeInTheDocument();
+		expect(screen.queryByText('Zero-amount line items hidden (1)')).not.toBeInTheDocument();
+	});
+
 	it('cancelling the row editor restores the original line item values', async () => {
 		mockGetInvoiceById.mockResolvedValue(
 			makeInvoice({ line_items: [{ id: 'li_1', display_name: 'Consulting', quantity: '2', amount: 300 }] }),

--- a/src/pages/customer/invoices/EditInvoicePage.tsx
+++ b/src/pages/customer/invoices/EditInvoicePage.tsx
@@ -19,6 +19,7 @@ import {
 	Select,
 	Spacer,
 	Textarea,
+	Toggle,
 } from '@/components/atoms';
 import { InvoiceLineItemTable } from '@/components/molecules';
 import { AddChargesButton } from '@/components/organisms/PlanForm/SetupChargesSection';
@@ -155,6 +156,8 @@ const EditInvoicePage: FC = () => {
 	// Rows render as a read-only table; clicking one expands it into an inline editor.
 	// The snapshot backs Cancel; isNew rows are discarded on Cancel instead of restored.
 	const [rowEditor, setRowEditor] = useState<{ index: number; snapshot: LineItemRow; isNew: boolean } | null>(null);
+	// Matches the invoice preview: zero-amount rows are hidden until toggled on.
+	const [showZeroCharges, setShowZeroCharges] = useState(false);
 	const [isVoidConfirmOpen, setIsVoidConfirmOpen] = useState(false);
 
 	const {
@@ -470,6 +473,13 @@ const EditInvoicePage: FC = () => {
 		setLineItemRows((prev) => [...prev, blank]);
 	};
 
+	// The row being edited and unsaved new rows always stay visible so they can't
+	// vanish mid-edit; everything else follows the zero-charges toggle.
+	const isRowVisible = (row: LineItemRow, index: number): boolean =>
+		showZeroCharges || rowEditor?.index === index || !row.id || Number(row.amount || '0') !== 0;
+
+	const hiddenZeroChargeCount = lineItemRows.filter((row, index) => !isRowVisible(row, index)).length;
+
 	const handleRowEditorCancel = () => {
 		if (!rowEditor) return;
 		if (rowEditor.isNew) {
@@ -621,7 +631,11 @@ const EditInvoicePage: FC = () => {
 							/>
 						</div>
 						{isEditable && (
-							<div className='mt-6'>
+							<div
+								className={cn(
+									'mt-6 max-w-3xl rounded-lg border p-4 transition-colors',
+									applyDiscount ? 'border-primary bg-muted/40' : 'border-line hover:bg-muted/20',
+								)}>
 								<Checkbox
 									id='apply-discount'
 									checked={applyDiscount}
@@ -645,13 +659,21 @@ const EditInvoicePage: FC = () => {
 									<p className='text-sm text-content-zinc-muted'>{t('invoices.edit.finalizedEditHint')}</p>
 								</div>
 							)}
-							<FormHeader
-								title={t('invoices.edit.lineItemsTitle')}
-								subtitle={t('invoices.edit.manualEditHint')}
-								variant='sub-header'
-								titleClassName='font-semibold'
-								subtitleClassName='!mt-1 text-sm text-content-zinc-muted'
-							/>
+							<div className='flex items-start justify-between gap-4'>
+								<FormHeader
+									title={t('invoices.edit.lineItemsTitle')}
+									subtitle={t('invoices.edit.manualEditHint')}
+									variant='sub-header'
+									titleClassName='font-semibold'
+									subtitleClassName='!mt-1 text-sm text-content-zinc-muted'
+								/>
+								<Toggle
+									checked={showZeroCharges}
+									onChange={setShowZeroCharges}
+									label={t('invoices.details.showZeroCharges')}
+									className='shrink-0'
+								/>
+							</div>
 							<div className='mt-4 overflow-hidden rounded-lg border border-line'>
 								<div className='overflow-x-auto'>
 									<table className='w-full border-collapse'>
@@ -681,7 +703,7 @@ const EditInvoicePage: FC = () => {
 												</tr>
 											)}
 											{lineItemRows.map((row, index) =>
-												rowEditor?.index === index ? (
+												!isRowVisible(row, index) ? null : rowEditor?.index === index ? (
 													<tr key={row.id ?? `new-${index}`} className='border-b border-line-subtle bg-muted/20'>
 														<td colSpan={5} className='p-4'>
 															<div className='max-w-3xl'>
@@ -779,6 +801,13 @@ const EditInvoicePage: FC = () => {
 														</td>
 													</tr>
 												),
+											)}
+											{hiddenZeroChargeCount > 0 && (
+												<tr>
+													<td colSpan={5} className='py-2.5 px-4 text-center text-xs text-content-zinc-muted'>
+														{t('invoices.edit.zeroChargesHidden', { hidden: hiddenZeroChargeCount })}
+													</td>
+												</tr>
 											)}
 										</tbody>
 									</table>


### PR DESCRIPTION
## What

Follow-up to #1374 — makes the edit page's line-item table match the invoice preview, and improves the reapply-coupon control.

### Zero-amount rows hidden by default
Subscription invoices generate a line item per charge/meter, so the edit table showed a dozen $0 usage rows the preview hides — confusing when the two views disagree. Now:

- Zero-amount rows are hidden by default, behind the **same "Show Zero Charges" toggle** (same label/i18n key and `Toggle` atom as `InvoiceLineItemTable`), placed at the section's top-right.
- A muted in-table hint row — *"Zero-amount line items hidden (N)"* — explains where the rest went instead of the table just looking short.
- The row currently open in the inline editor and unsaved new rows (which start at $0) are **always visible**, so nothing can vanish mid-edit. Editing an existing row down to $0 and collapsing it moves it into the hidden set, consistent with the preview's definition.
- Display-only filtering: indices, the save diff, and the modify-API ops are untouched.

### Coupon control
"Reapply coupon discounts" becomes a bordered option card that highlights (primary border + subtle fill) when checked, instead of a floating checkbox.

## Testing

- New test: zero rows hidden by default with the count hint, revealed by the switch
- Page suite 20/20, full suite 807/807, tsc + eslint clean
- Verified live against api-dev on the seeded env: editing a row to $0 hides it behind the "(1)" hint, the toggle restores it, and the checked coupon card renders highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)