### PR TITLE
fix(Sidebar): stop a stale delayed nav from clobbering a fast child click

### DIFF
--- a/src/components/molecules/Sidebar/SidebarItem.test.tsx
+++ b/src/components/molecules/Sidebar/SidebarItem.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MemoryRouter } from 'react-router';
+import SidebarItem from './SidebarItem';
+import { SidebarProvider } from '@/components/ui';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+// SidebarProvider's useIsMobile hook reads this; jsdom doesn't implement it.
+window.matchMedia =
+	window.matchMedia ||
+	((query: string) => ({
+		matches: false,
+		media: query,
+		onchange: null,
+		addListener: vi.fn(),
+		removeListener: vi.fn(),
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+		dispatchEvent: vi.fn(),
+	}));
+
+vi.mock('react-router', async () => {
+	const actual = await vi.importActual<typeof import('react-router')>('react-router');
+	return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const baseItem = {
+	title: 'Product Catalog',
+	url: '/product-catalog/features',
+	items: [
+		{ title: 'Features', url: '/product-catalog/features' },
+		{ title: 'Plans', url: '/product-catalog/plan' },
+	],
+};
+
+/** Mirrors SidebarMenu.tsx's own open/close state wiring, so a click that toggles
+ *  `isOpen` actually re-renders the Collapsible open, exposing the same timing
+ *  the real sidebar has - rendering SidebarItem with a static `isOpen` prop would
+ *  never open the section a click is meant to open. */
+const StatefulSidebarItem = ({ initialOpen = false }: { initialOpen?: boolean }) => {
+	const [isOpen, setIsOpen] = useState(initialOpen);
+	return <SidebarItem {...baseItem} isOpen={isOpen} onToggle={setIsOpen} />;
+};
+
+const renderItem = (props: { initialOpen?: boolean } = {}) =>
+	render(
+		<MemoryRouter>
+			<SidebarProvider>
+				<StatefulSidebarItem {...props} />
+			</SidebarProvider>
+		</MemoryRouter>,
+	);
+
+describe('SidebarItem', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		mockNavigate.mockReset();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("cancels the parent section's delayed default-page navigation when a child link is clicked first", () => {
+		renderItem({ initialOpen: false });
+
+		// Opening the section schedules a delayed navigate to its own default page
+		// (Features).
+		act(() => {
+			fireEvent.click(screen.getByText('Product Catalog'));
+		});
+
+		// Before that delay elapses, the user (or a fast automated click) goes straight
+		// to a specific child instead - the section is now open, so this is reachable.
+		act(() => {
+			fireEvent.click(screen.getByText('Plans'));
+		});
+
+		act(() => {
+			vi.advanceTimersByTime(150);
+		});
+
+		// The stale Features navigation must not fire and clobber the Plans link's own
+		// (React Router native, not mocked) navigation.
+		expect(mockNavigate).not.toHaveBeenCalledWith('/product-catalog/features');
+	});
+
+	it('still navigates to the default page when nothing else is clicked before the delay', () => {
+		renderItem({ initialOpen: false });
+
+		act(() => {
+			fireEvent.click(screen.getByText('Product Catalog'));
+		});
+
+		act(() => {
+			vi.advanceTimersByTime(150);
+		});
+
+		expect(mockNavigate).toHaveBeenCalledWith('/product-catalog/features');
+	});
+});

--- a/src/components/molecules/Sidebar/SidebarItem.tsx
+++ b/src/components/molecules/Sidebar/SidebarItem.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect, useRef } from 'react';
 import { NavItem } from './SidebarMenu';
 import {
 	SidebarMenuButton,
@@ -37,6 +37,28 @@ const SidebarItem: FC<SidebarItemProps> = (item) => {
 		item.onToggle?.(open);
 	};
 
+	// Delayed so the accordion's own opening animation isn't interrupted by an
+	// immediate route change. Tracked in a ref (not fire-and-forget) so a child
+	// link clicked before it fires - the expected next step once the section is
+	// open - can cancel it; otherwise the stale default-page navigation lands
+	// a beat after the child's own, silently overriding wherever the user (or a
+	// fast automated click) actually asked to go.
+	const pendingNavigateRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(
+		() => () => {
+			if (pendingNavigateRef.current) clearTimeout(pendingNavigateRef.current);
+		},
+		[],
+	);
+
+	const cancelPendingNavigate = () => {
+		if (pendingNavigateRef.current) {
+			clearTimeout(pendingNavigateRef.current);
+			pendingNavigateRef.current = null;
+		}
+	};
+
 	// Handle click for items with children - toggle accordion on regular click
 	// but allow modifier keys (Cmd/Ctrl) to work naturally with Link
 	const handleMainItemClick = (event: React.MouseEvent) => {
@@ -52,10 +74,12 @@ const SidebarItem: FC<SidebarItemProps> = (item) => {
 			event.preventDefault(); // Prevent navigation
 			const willOpen = !isOpen;
 			item.onToggle?.(willOpen);
+			cancelPendingNavigate();
 
 			// If opening and URL is not '#', navigate to it after a small delay
 			if (willOpen && item.url && item.url !== '#') {
-				setTimeout(() => {
+				pendingNavigateRef.current = setTimeout(() => {
+					pendingNavigateRef.current = null;
 					navigate(item.url);
 				}, 100);
 			}
@@ -134,7 +158,7 @@ const SidebarItem: FC<SidebarItemProps> = (item) => {
 											asChild
 											isActive={subActive}
 											className={cn('w-full font-light text-content-black transition-colors duration-200')}>
-											<Link to={subItem.url} className='flex items-center gap-2'>
+											<Link to={subItem.url} className='flex items-center gap-2' onClick={cancelPendingNavigate}>
 												{SubIcon && (
 													<SubIcon
 														absoluteStrokeWidth


### PR DESCRIPTION
## Summary
Resolves the e2e failure blocking #1359 (release PR, Playwright job): `e2e/journeys/navigation/sidebar.spec.ts`'s "reaches the product catalog through its nested entries" landed on `/product-catalog/features` instead of `/product-catalog/plan`.

## Root cause
Clicking a sidebar section header with children (e.g. "Product Catalog") opens it and schedules `navigate(item.url)` **100ms later** — a default landing page for the section, delayed so it doesn't interrupt the accordion's opening animation ([SidebarItem.tsx](src/components/molecules/Sidebar/SidebarItem.tsx)). That timeout was never cancelled, so a child link clicked within that same 100ms window — open the section, then immediately go to "Plans", well within reach of a real click and routine for Playwright — navigates correctly to `/product-catalog/plan`, and then the stale timeout fires a beat later and navigates *again* to the parent's own default page (Features), silently overwriting it. This matches the failing run's URL exactly (`fetchPlans_*` and `fetchFeatures_*` filter params both present — consistent with two navigations landing back-to-back).

## Fix
Track the scheduled timeout in a ref; clear it whenever a child link in the same section is clicked (and on unmount). A subsequent click always wins over the section's own delayed default-page navigation instead of being silently clobbered by it a moment later.

## Test plan
- [x] Added `SidebarItem.test.tsx`: reproduces the race with fake timers — confirmed it **fails** on the pre-fix code (the stale navigate does fire) and **passes** with the fix — plus a test that the default-page navigation still fires normally when nothing else is clicked first
- [x] `npx tsc --noEmit -p .` clean
- [x] `npx eslint` on touched files — 0 errors
- [x] `npx vitest run` — all 811 tests pass
- [x] `npm run build` succeeds
- [ ] Playwright's sidebar navigation spec passes in CI (can't verify locally without the E2E secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed sidebar navigation so selecting a child link no longer gets overridden by a previously scheduled default-page navigation.
  - Improved navigation cleanup when sidebar sections are closed or unmounted.
- **Tests**
  - Added coverage for sidebar default navigation and child-link selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->