### PR TITLE
fix: address new CodeRabbit findings on release PR #1359

### DIFF
--- a/src/pages/auth/LoginForm.tsx
+++ b/src/pages/auth/LoginForm.tsx
@@ -1,7 +1,7 @@
 import supabase from '@/core/services/supbase/config';
 import React, { useState, useEffect } from 'react';
 import { toast } from 'react-hot-toast';
-import { data, useNavigate, useSearchParams } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import { useUser } from '@/hooks/UserContext';
 import { Button, Input } from '@/components/atoms';
 import { EyeIcon, EyeOff } from 'lucide-react';
@@ -85,7 +85,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ switchTab }) => {
 
 		if (config.app.env !== APP_ENV.SelfHosted) {
 			try {
-				const { error } = await supabase.auth.signInWithPassword({
+				const { data: authData, error } = await supabase.auth.signInWithPassword({
 					email,
 					password,
 				});
@@ -95,7 +95,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ switchTab }) => {
 					return;
 				}
 
-				userContext.setUser(data);
+				userContext.setUser(authData.user);
 				navigate('/');
 				toast.success('Login successful');
 			} catch (error) {

--- a/src/pages/customer/invoices/EditInvoicePage.tsx
+++ b/src/pages/customer/invoices/EditInvoicePage.tsx
@@ -33,6 +33,7 @@ import {
 	INVOICE_MODIFY_LINE_ITEM_ACTION,
 	InvoiceModifyAddLineItem,
 	InvoiceModifyUpdateLineItem,
+	LineItemRow,
 	UpdateInvoicePayload,
 } from '@/types/dto';
 import { RouteNames } from '@/core/routes/Routes';
@@ -46,18 +47,6 @@ import { cn } from '@/lib/utils';
 interface MetadataRow {
 	key: string;
 	value: string;
-}
-
-/** One editable line-item row. Rows without an id are new (to be added on save). */
-interface LineItemRow {
-	id?: string;
-	display_name: string;
-	quantity: string;
-	amount: string;
-	description: string;
-	/** ISO strings; empty when unset. */
-	period_start: string;
-	period_end: string;
 }
 
 /** The line-item operations a save must execute through the modify endpoint. */

--- a/src/types/dto/InvoiceApi.ts
+++ b/src/types/dto/InvoiceApi.ts
@@ -117,6 +117,18 @@ export interface InvoiceModifyResponse {
 	invoice: Invoice;
 }
 
+/** One editable line-item row on the invoice edit page. Rows without an id are new (to be added on save). */
+export interface LineItemRow {
+	id?: string;
+	display_name: string;
+	quantity: string;
+	amount: string;
+	description: string;
+	/** ISO strings; empty when unset. */
+	period_start: string;
+	period_end: string;
+}
+
 /** Request body for PUT /invoices/:id/payment (update payment status). */
 export interface UpdatePaymentStatusPayload {
 	payment_status: string;

--- a/src/types/dto/index.ts
+++ b/src/types/dto/index.ts
@@ -148,6 +148,7 @@ export type {
 	InvoiceModifyAddLineItem,
 	InvoiceModifyUpdateLineItem,
 	InvoiceModifyResponse,
+	LineItemRow,
 	UpdatePaymentStatusPayload,
 	UpdateInvoiceStatusPayload,
 	GetInvoicePreviewPayload,


### PR DESCRIPTION
## Summary
Addresses two new CodeRabbit findings from a later re-review of #1359 (after develop moved forward with #1374/#1377).

- **`LoginForm.tsx`** (Major, confirmed real bug): a successful Supabase login called `userContext.setUser(data)` where `data` resolved to react-router's imported `data()` loader/action helper — **not** the sign-in response. `signInWithPassword`'s actual result was discarded (only `error` was destructured), so the user context got set to a function reference instead of a user object on every hosted (non-self-hosted) login. Fixed by destructuring the response as `authData` and passing `authData.user`, matching the pattern `SignupConfirmation.tsx` already uses elsewhere. Removed the now-unused `data` import.
- **`EditInvoicePage.tsx`** (Minor, convention): moved the page-local `LineItemRow` interface to `src/types/dto/InvoiceApi.ts` (alongside the other invoice-modify DTOs this page already imports from there) and exported it through the barrel, per this repo's rule against page-local type contracts.

## Test plan
- [x] `npx tsc --noEmit -p .` clean
- [x] `npx eslint` on touched files — 0 errors (pre-existing warnings unchanged)
- [x] `npx vitest run` — all 809 tests pass
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)