### PR TITLE
style(wallet-alerts): downgrade percentage note from a warning alert to plain text

### DIFF
--- a/src/components/molecules/WalletAlertDialog/WalletAlertDialog.tsx
+++ b/src/components/molecules/WalletAlertDialog/WalletAlertDialog.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { AlertTriangle } from 'lucide-react';
 import { Dialog, Button, SegmentedControl, Toggle, InfoIcon } from '@/components/atoms';
 import toast from 'react-hot-toast';
 import { WalletAlertThresholdCard } from '@/components/molecules';
@@ -138,10 +137,7 @@ const WalletAlertDialog: React.FC<WalletAlertDialogProps> = ({ open, alertSettin
 						disabled={isSaving || !draft.alert_enabled}
 					/>
 					{draft.alert_threshold_type === 'percentage' && (
-						<div className='flex max-w-[560px] items-start gap-1.5 text-warning'>
-							<AlertTriangle className='mt-0.5 h-3.5 w-3.5 shrink-0' />
-							<p className='text-[13px] leading-relaxed'>{t('wallet.alerts.percentageWarning')}</p>
-						</div>
+						<p className='max-w-[560px] text-[13px] leading-relaxed text-content-secondary'>{t('wallet.alerts.percentageWarning')}</p>
 					)}
 				</div>
 

--- a/src/pages/settings/alerts/WalletAlertSettings.tsx
+++ b/src/pages/settings/alerts/WalletAlertSettings.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { AlertTriangle } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Card, InfoIcon, Loader, SegmentedControl, Tooltip } from '@/components/atoms';
@@ -121,10 +120,9 @@ const WalletAlertSettingsSection = () => {
 							disabled={isDisabled}
 						/>
 						{draft.alert_threshold_type === 'percentage' && (
-							<div className='flex max-w-[560px] items-start gap-1.5 text-warning'>
-								<AlertTriangle className='mt-0.5 h-3.5 w-3.5 shrink-0' />
-								<p className='text-[13px] leading-relaxed'>{t('alerts.walletAlerts.percentageWarning')}</p>
-							</div>
+							<p className='max-w-[560px] text-[13px] leading-relaxed text-content-secondary'>
+								{t('alerts.walletAlerts.percentageWarning')}
+							</p>
 						)}
 					</div>
 					<div className='space-y-4'>


### PR DESCRIPTION
## Summary
Follow-up to #1380, which merged before this fix landed.

The Percentage-mode note ("Percentage alerts apply only to ongoing balance. Credit-balance alerts are not evaluated in Percentage mode.") was styled as a warning alert (orange `text-warning`, `AlertTriangle` icon), which read as an error state to users even though it's purely informational — percentage mode just doesn't apply to credit-balance alerts, nothing is wrong with the input. Downgrades it to a plain secondary-text paragraph on both the per-wallet alert dialog and the tenant-level Settings page.

## Test plan
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx eslint` on both changed files — 0 errors (1 pre-existing warning per file, unrelated to this change)
- [x] `npx vitest run` — 841/841 passing
- [x] Verified live in the browser: the note now renders as plain text with no icon or warning color, on both surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Restyled percentage-threshold warning messages as plain secondary text.
  - Removed warning icons and colored alert containers from wallet alert settings and dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->