### PR TITLE
fix(exports): let the manual export date picker open inside the dialog

### DIFF
--- a/src/components/atoms/DateTimePicker/DateTimePicker.tsx
+++ b/src/components/atoms/DateTimePicker/DateTimePicker.tsx
@@ -118,7 +118,7 @@ export const DateTimePicker: React.FC<Props> = ({ date, setDate, disabled, place
 						<span>{displayLabel}</span>
 					</button>
 				</PopoverTrigger>
-				<PopoverContent className='w-auto p-0' align='start' onInteractOutside={() => setIsOpen(false)}>
+				<PopoverContent className='w-auto p-0 z-[60] pointer-events-auto' align='start'>
 					<Calendar mode='single' selected={displayDate} onSelect={handleDateSelect} autoFocus />
 					{/* Time + timezone row — no nested browser picker */}
 					<div className='border-t border-border px-3 py-3 flex items-center gap-2'>

--- a/src/components/molecules/ForceRunDrawer/ForceRunDrawer.test.tsx
+++ b/src/components/molecules/ForceRunDrawer/ForceRunDrawer.test.tsx
@@ -47,7 +47,7 @@ describe('ForceRunDrawer date picker', () => {
 
 		fireEvent.click(screen.getByLabelText(commonEn.forceRun.customDateRange));
 		fireEvent.click(screen.getByRole('button', { name: commonEn.forceRun.startTimePlaceholder }));
-		fireEvent.click(screen.getByRole('gridcell', { name: '15' }));
+		fireEvent.click(screen.getByRole('button', { name: /15/ }));
 
 		expect(screen.getByRole('dialog', { name: commonEn.forceRun.title })).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: commonEn.forceRun.endTimePlaceholder })).toBeInTheDocument();

--- a/src/components/molecules/ForceRunDrawer/ForceRunDrawer.test.tsx
+++ b/src/components/molecules/ForceRunDrawer/ForceRunDrawer.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import '@testing-library/jest-dom';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { createInstance } from 'i18next';
+import type { i18n as I18nInstance } from 'i18next';
+import commonEn from '@/i18n/locales/en/common.json';
+import ForceRunDrawer from './ForceRunDrawer';
+
+let testI18n: I18nInstance;
+
+beforeAll(async () => {
+	const instance = createInstance();
+	await instance.use(initReactI18next).init({
+		lng: 'en',
+		fallbackLng: 'en',
+		ns: ['common'],
+		defaultNS: 'common',
+		resources: { en: { common: commonEn } },
+		interpolation: { escapeValue: false },
+	});
+	testI18n = instance;
+});
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => <I18nextProvider i18n={testI18n}>{children}</I18nextProvider>;
+
+function renderDrawer() {
+	return render(
+		<TestWrapper>
+			<ForceRunDrawer isOpen onOpenChange={vi.fn()} onConfirm={vi.fn()} />
+		</TestWrapper>,
+	);
+}
+
+describe('ForceRunDrawer date picker', () => {
+	it('opens the calendar when Start Time is clicked after selecting a custom date range', () => {
+		renderDrawer();
+
+		fireEvent.click(screen.getByLabelText(commonEn.forceRun.customDateRange));
+		fireEvent.click(screen.getByRole('button', { name: commonEn.forceRun.startTimePlaceholder }));
+
+		expect(screen.getByRole('grid')).toBeInTheDocument();
+	});
+
+	it('keeps the custom range fields after picking a day in the calendar', () => {
+		renderDrawer();
+
+		fireEvent.click(screen.getByLabelText(commonEn.forceRun.customDateRange));
+		fireEvent.click(screen.getByRole('button', { name: commonEn.forceRun.startTimePlaceholder }));
+		fireEvent.click(screen.getByRole('gridcell', { name: '15' }));
+
+		expect(screen.getByRole('dialog', { name: commonEn.forceRun.title })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: commonEn.forceRun.endTimePlaceholder })).toBeInTheDocument();
+	});
+});

--- a/src/components/molecules/ForceRunDrawer/ForceRunDrawer.tsx
+++ b/src/components/molecules/ForceRunDrawer/ForceRunDrawer.tsx
@@ -4,6 +4,7 @@ import { DateTimePicker } from '@/components/atoms';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
+import { useSheetOutsideDismissGuards } from '@/lib/modal-scroll-lock';
 import { useTranslation } from 'react-i18next';
 
 interface ForceRunDrawerProps {
@@ -31,6 +32,7 @@ const ForceRunDrawer: FC<ForceRunDrawerProps> = ({ isOpen, onOpenChange, onConfi
 	const [startTime, setStartTime] = useState<Date | undefined>(undefined);
 	const [endTime, setEndTime] = useState<Date | undefined>(undefined);
 	const [errors, setErrors] = useState<ValidationErrors>({});
+	const outsideDismissGuards = useSheetOutsideDismissGuards(isOpen);
 
 	const validate = useCallback((): ValidationErrors => {
 		const newErrors: ValidationErrors = {};
@@ -49,6 +51,13 @@ const ForceRunDrawer: FC<ForceRunDrawerProps> = ({ isOpen, onOpenChange, onConfi
 		setErrors({});
 		onOpenChange(false);
 	}, [onOpenChange]);
+
+	const handleOpenChange = useCallback(
+		(open: boolean) => {
+			if (!open) handleClose();
+		},
+		[handleClose],
+	);
 
 	const handleConfirm = useCallback(() => {
 		if (runType === RunType.CURRENT) {
@@ -78,8 +87,8 @@ const ForceRunDrawer: FC<ForceRunDrawerProps> = ({ isOpen, onOpenChange, onConfi
 	}, []);
 
 	return (
-		<Dialog open={isOpen} onOpenChange={handleClose}>
-			<DialogContent className='w-full max-w-md bg-surface'>
+		<Dialog open={isOpen} onOpenChange={handleOpenChange} modal={false}>
+			<DialogContent className='w-full max-w-md bg-surface' {...outsideDismissGuards}>
 				<DialogHeader>
 					<DialogTitle>{t('forceRun.title')}</DialogTitle>
 					<DialogDescription>{t('forceRun.description')}</DialogDescription>


### PR DESCRIPTION
## Summary
- The Manual Export dialog used a modal Radix dialog, so the portaled date picker was treated as an outside click and never stayed open.
- Match the rest of the app: non-modal dialog plus outside-click guards, and the same popover stacking as `DatePicker`.
- Add a regression test for custom range → Start Time → calendar visible, and for picking a day without dismissing the dialog.

## Test plan
- [ ] Open Export Details → Manual Export → Select custom date range → click Start Time; the calendar should stay open.
- [ ] Pick a start and end time, then Run Export; the run should start for that interval.
- [ ] Cancel / outside-click still closes the dialog when the picker is not open.
- [ ] `npx vitest run src/components/molecules/ForceRunDrawer/ForceRunDrawer.test.tsx`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Date-time picker interactions remain available without unexpectedly closing the popover.
  - Force Run drawer can be dismissed by clicking outside while preserving date and time selection interactions.

- **Tests**
  - Added coverage for custom date-range selection, calendar opening, day selection, and maintaining the dialog and end-time field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->