### PR TITLE
fix(subscription-addons): show the actual (possibly overridden) addon charge

### DIFF
--- a/src/components/molecules/SubscriptionAddonsSection/SubscriptionAddonsSection.tsx
+++ b/src/components/molecules/SubscriptionAddonsSection/SubscriptionAddonsSection.tsx
@@ -10,6 +10,7 @@ import { BsThreeDots } from 'react-icons/bs';
 import SubscriptionApi from '@/api/SubscriptionApi';
 import { ADDON_ASSOCIATION_STATUS } from '@/models/AddonAssociation';
 import { AddonAssociationResponse, SubscriptionResponse } from '@/types/dto/Subscription';
+import { EXPAND } from '@/models';
 import { ADDON_PRORATION_BEHAVIOR } from '@/types/dto/Addon';
 import { BILLING_PERIOD } from '@/constants/constants';
 import { toSentenceCase, copyToClipboard } from '@/utils/common/helper_functions';
@@ -192,7 +193,7 @@ const SubscriptionAddonsSection: FC<SubscriptionAddonsSectionProps> = ({
 	// Fetch active addons (backend returns { items, pagination })
 	const {
 		data: addonAssociationsResponse,
-		isLoading,
+		isLoading: isLoadingAddons,
 		isError,
 	} = useQuery({
 		queryKey: ['subscriptionActiveAddons', subscriptionId],
@@ -211,6 +212,36 @@ const SubscriptionAddonsSection: FC<SubscriptionAddonsSectionProps> = ({
 		const response = addonAssociationsResponse as any;
 		return response.items ?? response ?? [];
 	}, [addonAssociationsResponse]);
+
+	// The Charges column must reflect each addon's actual subscription line items — which
+	// carry any per-subscription price override — rather than the addon's catalog default
+	// prices (`association.addon.prices`, which never change after an override). Fetched
+	// once for the whole subscription and grouped client-side to avoid one request per row.
+	// Query key matches what ConfigureAddonDialog already refetches on every line-item
+	// mutation (see its `invalidateAddonQueries`), so an override there updates this table too.
+	const { data: addonLineItemsResponse, isLoading: isLoadingAddonLineItems } = useQuery({
+		queryKey: ['subscriptionAddonLineItems', subscriptionId],
+		queryFn: async () =>
+			SubscriptionApi.searchSubscriptionLineItems({
+				subscription_ids: [subscriptionId],
+				active_filter: true,
+				expand: `${EXPAND.PRICES}.${EXPAND.METERS}`,
+				limit: 100,
+				offset: 0,
+			}),
+		enabled: !!subscriptionId,
+	});
+
+	const pricesByAddonAssociationId = useMemo<Record<string, Price[]>>(() => {
+		const grouped: Record<string, Price[]> = {};
+		for (const item of addonLineItemsResponse?.items ?? []) {
+			if (!item.addon_association_id || !item.price) continue;
+			(grouped[item.addon_association_id] ??= []).push(item.price);
+		}
+		return grouped;
+	}, [addonLineItemsResponse]);
+
+	const isLoading = isLoadingAddons || isLoadingAddonLineItems;
 
 	const processedAddonAssociations = useMemo<AddonAssociationWithStatus[]>(() => {
 		return addonAssociations.map((association) => {
@@ -310,7 +341,10 @@ const SubscriptionAddonsSection: FC<SubscriptionAddonsSectionProps> = ({
 			{
 				title: 'Charges',
 				render: (row) => {
-					const prices = row.addon?.prices || [];
+					// Falls back to the catalog default only if this association has no
+					// matching line items yet (e.g. a fetch error) — the common case reads
+					// the real, possibly-overridden line item prices grouped above.
+					const prices = pricesByAddonAssociationId[row.id] ?? row.addon?.prices ?? [];
 					return <span>{formatAddonCharges(prices)}</span>;
 				},
 			},
@@ -381,7 +415,7 @@ const SubscriptionAddonsSection: FC<SubscriptionAddonsSectionProps> = ({
 				},
 			},
 		],
-		[dropdownOpen, handleCancel, readOnly, canWriteAddon, t],
+		[dropdownOpen, handleCancel, readOnly, canWriteAddon, t, pricesByAddonAssociationId],
 	);
 
 	const addButton = readOnly ? undefined : canWriteAddon ? (
@@ -428,7 +462,9 @@ const SubscriptionAddonsSection: FC<SubscriptionAddonsSectionProps> = ({
 					billingPeriod={subscriptionDetails?.billing_period}
 					billingPeriodCount={
 						subscriptionBillingPeriodCount ??
-						(subscriptionContextResolved ? undefined : (subscriptionDetailsFetched as SubscriptionResponse | undefined)?.billing_period_count)
+						(subscriptionContextResolved
+							? undefined
+							: (subscriptionDetailsFetched as SubscriptionResponse | undefined)?.billing_period_count)
 					}
 					currency={subscriptionDetails?.currency}
 					currentPeriodEndIso={subscriptionDetails?.current_period_end}


### PR DESCRIPTION
## Summary
The Addons summary table (shown on both the subscription Details page and the Edit page, via the shared `SubscriptionAddonsSection`) has a "Charges" column that read `row.addon.prices` — the addon's catalog default prices — instead of the subscription's own line items for that addon association.

A price override applied when adding the addon (via "Override Price" in the Add Addon dialog's charges table) is correctly saved to the subscription's line item, but the summary table never reflected it: it kept showing the unmodified catalog price indefinitely.

## Fix
- Fetch the subscription's line items once (`SubscriptionApi.searchSubscriptionLineItems`, no addon filter — returns every line item for the subscription in one call) using the query key `['subscriptionAddonLineItems', subscriptionId]`. That key was already being invalidated by `ConfigureAddonDialog`'s `invalidateAddonQueries` on every line-item mutation, but nothing had registered a query under it yet — this wires that up.
- Group the line items by `addon_association_id` and use each addon association's real line-item prices for its Charges cell, falling back to the catalog default only if no line items are available for it yet.

## Test plan
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx eslint` — 0 errors
- [x] `npx vitest run` — 841/841 passing
- [x] Verified live against the dev backend: added an addon, overrode its fixed charge from $10 to $25,000 via the Add Addon dialog, and confirmed:
  - The Edit page's Addons table shows $25,000.00 (was $10.00 before the fix)
  - The read-only Details page's Addons table shows $25,000.00 too
  - A second, non-overridden instance of the same addon correctly still shows $10.00 (no false-positive override leakage)
- [x] Cleaned up the test addon associations from the shared test environment afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Subscription add-ons now display current subscription pricing when available.
  - Catalog pricing is used as a fallback when subscription pricing cannot be retrieved.
  - Loading indicators remain active until both add-on and pricing information finish loading.
  - Expanded pricing and usage details are now supported in charge displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->