### PR TITLE
fix(subscription-addons): reflect overridden addon price in the Add Subscription table

### DIFF
--- a/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonModal.tsx
+++ b/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonModal.tsx
@@ -1,5 +1,4 @@
 import { AddAddonToSubscriptionRequest, AddonResponse } from '@/types/dto/Addon';
-import { OverrideLineItemRequest } from '@/types/dto/Subscription';
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Button, DatePicker } from '@/components/atoms';
 import Dialog from '@/components/atoms/Dialog';
@@ -8,11 +7,12 @@ import AddonApi from '@/api/AddonApi';
 import { Select } from '@/components/atoms';
 import { toSentenceCase } from '@/utils/common/helper_functions';
 import { ColumnData, FlexpriceTable } from '@/components/molecules';
-import { BILLING_MODEL, Price, PRICE_TYPE, TIER_MODE } from '@/models/Price';
+import { Price, PRICE_TYPE } from '@/models/Price';
 import { BILLING_PERIOD } from '@/constants/constants';
 import {
 	ExtendedPriceOverride,
 	getLineItemOverrides,
+	overrideLineItemsToMap,
 	removePriceOverride,
 	updatePriceOverride,
 } from '@/utils/common/price_override_helpers';
@@ -47,27 +47,6 @@ interface FormErrors {
 
 type AddonChargeRow = {
 	price: Price;
-};
-
-/** Rehydrate the ExtendedPriceOverride map from a stored backend-shaped override array (edit mode). */
-const backendOverridesToMap = (items?: OverrideLineItemRequest[]): Record<string, ExtendedPriceOverride> => {
-	const map: Record<string, ExtendedPriceOverride> = {};
-	(items ?? []).forEach((o) => {
-		const isSlab = o.billing_model === BILLING_MODEL.TIERED && o.tier_mode === TIER_MODE.SLAB;
-		map[o.price_id] = {
-			price_id: o.price_id,
-			...(o.amount !== undefined ? { amount: String(o.amount) } : {}),
-			...(o.quantity !== undefined ? { quantity: o.quantity } : {}),
-			...(o.billing_model ? { billing_model: isSlab ? ('SLAB_TIERED' as const) : o.billing_model } : {}),
-			...(o.tier_mode && !isSlab ? { tier_mode: o.tier_mode } : {}),
-			...(o.tiers ? { tiers: o.tiers } : {}),
-			...(o.transform_quantity ? { transform_quantity: o.transform_quantity } : {}),
-			...(o.bucket_size ? { bucket_size: o.bucket_size } : {}),
-			...(o.price_unit_amount ? { price_unit_amount: o.price_unit_amount } : {}),
-			...(o.price_unit_tiers ? { price_unit_tiers: o.price_unit_tiers } : {}),
-		};
-	});
-	return map;
 };
 
 const SubscriptionAddonModal: React.FC<Props> = ({
@@ -113,7 +92,7 @@ const SubscriptionAddonModal: React.FC<Props> = ({
 				// Find addon details for editing
 				const addonDetails = addons.find((addon) => addon.id === data.addon_id) ?? null;
 				setSelectedAddonDetails(addonDetails);
-				setOverriddenPrices(backendOverridesToMap(data.override_line_items));
+				setOverriddenPrices(overrideLineItemsToMap(data.override_line_items));
 			} else {
 				setFormData({
 					...getEmptyAddon(),

--- a/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonTable.tsx
+++ b/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonTable.tsx
@@ -10,7 +10,7 @@ import AddonApi from '@/api/AddonApi';
 import { getTotalPayableTextWithCoupons } from '@/utils/common/helper_functions';
 import { Price, PRICE_TYPE } from '@/models/Price';
 import { BILLING_PERIOD } from '@/constants/constants';
-import { getCurrentPriceAmount, ExtendedPriceOverride } from '@/utils/common/price_override_helpers';
+import { getCurrentPriceAmount, overrideLineItemsToMap, ExtendedPriceOverride } from '@/utils/common/price_override_helpers';
 import { Coupon } from '@/models/Coupon';
 import { filterAddonPricesForSubscription } from '@/utils/subscription/addon_commitment_helpers';
 
@@ -151,7 +151,11 @@ const SubscriptionAddonTable: React.FC<Props> = ({
 				render: (row) => {
 					const addonDetails = getAddonDetails(row.addon_id);
 					const prices = filterAddonPricesForSubscription(addonDetails?.prices || [], billingPeriod, currency, billingPeriodCount);
-					return <span>{formatAddonCharges(prices, priceOverrides, coupons, t)}</span>;
+					// Each addon row carries its own overrides (set via "Override Price" in the addon
+					// editor) - the shared `priceOverrides` prop is keyed for the base plan's prices and
+					// never covers per-addon overrides, so it must not be the only source used here.
+					const rowOverrides = { ...priceOverrides, ...overrideLineItemsToMap(row.override_line_items) };
+					return <span>{formatAddonCharges(prices, rowOverrides, coupons, t)}</span>;
 				},
 			},
 			// {

--- a/src/utils/common/price_override_helpers.ts
+++ b/src/utils/common/price_override_helpers.ts
@@ -4,6 +4,7 @@ import { PriceBucketSize } from '@/models/Meter';
 import { BUCKET_SIZE_NONE } from '@/constants/constants';
 import { LineItemCommitmentConfig } from '@/types/dto/LineItemCommitmentConfig';
 import type { CommitmentTimeBucket } from '@/types/dto/CommitmentTimeBucket';
+import type { OverrideLineItemRequest } from '@/types/dto/Subscription';
 
 /**
  * Interface for line item overrides that will be sent to the backend
@@ -214,6 +215,30 @@ export const updatePriceOverride = (
 		...overrides,
 		[priceId]: merged,
 	};
+};
+
+/**
+ * Rehydrate an ExtendedPriceOverride map from a stored backend-shaped override array,
+ * e.g. an addon's own `override_line_items` set when it was added to a subscription.
+ */
+export const overrideLineItemsToMap = (items?: OverrideLineItemRequest[]): Record<string, ExtendedPriceOverride> => {
+	const map: Record<string, ExtendedPriceOverride> = {};
+	(items ?? []).forEach((o) => {
+		const isSlab = o.billing_model === BILLING_MODEL.TIERED && o.tier_mode === TIER_MODE.SLAB;
+		map[o.price_id] = {
+			price_id: o.price_id,
+			...(o.amount !== undefined ? { amount: String(o.amount) } : {}),
+			...(o.quantity !== undefined ? { quantity: o.quantity } : {}),
+			...(o.billing_model ? { billing_model: isSlab ? ('SLAB_TIERED' as const) : o.billing_model } : {}),
+			...(o.tier_mode && !isSlab ? { tier_mode: o.tier_mode } : {}),
+			...(o.tiers ? { tiers: o.tiers } : {}),
+			...(o.transform_quantity ? { transform_quantity: o.transform_quantity } : {}),
+			...(o.bucket_size ? { bucket_size: o.bucket_size } : {}),
+			...(o.price_unit_amount ? { price_unit_amount: o.price_unit_amount } : {}),
+			...(o.price_unit_tiers ? { price_unit_tiers: o.price_unit_tiers } : {}),
+		};
+	});
+	return map;
 };
 
 /**


### PR DESCRIPTION
## Summary
- On the Add Subscription page, the Addons summary table computed each row's Charges from a `priceOverrides` prop that `SubscriptionForm` never actually passes in, so overriding an addon's price via "Override Price" in the addon editor still displayed the addon's original list price in the table (and briefly on the resulting subscription's Details/Edit pages, until data settled).
- Each addon row now derives its overrides from its own `override_line_items` (set when the price was overridden), via a shared `overrideLineItemsToMap` helper moved into `price_override_helpers.ts` - `SubscriptionAddonModal` now uses the same helper instead of its own local copy.

## Test plan
- [x] `npx tsc --noEmit -p .` passes
- [x] `npx eslint` on touched files: no new errors
- [x] Manually reproduced against api-dev: created an addon with a $100 fixed charge, added it to a new subscription, overrode the charge to $10 via the "..." → "Override Price" action - the Addons table on the Add Subscription page now shows $10.00 instead of $100.00
- [x] Created the subscription and confirmed both the subscription Details page and the Edit page show the $10 override correctly (no stale $100)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected subscription add-on charge displays to include row-specific price overrides.
  * Improved editing of subscription add-ons by accurately restoring previously saved override values.
  * Ensured tiered slab pricing is displayed consistently when loading saved configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->