### PR TITLE
fix(modal-scroll-lock): stop a nested Dialog from closing the one it opened on top of

### DIFF
--- a/src/lib/modal-scroll-lock.test.ts
+++ b/src/lib/modal-scroll-lock.test.ts
@@ -41,6 +41,17 @@ const openDropdown = () => {
 	return { wrapper, content };
 };
 
+/** Stands in for a second Dialog (e.g. a line-item editor) opened on top of another. */
+const openNestedDialog = () => {
+	const content = document.createElement('div');
+	content.setAttribute('role', 'dialog');
+	content.setAttribute('data-state', 'open');
+	const child = document.createElement('button');
+	content.appendChild(child);
+	document.body.appendChild(content);
+	return { content, child };
+};
+
 const outsideEvent = (target: EventTarget) => {
 	const event = new Event('pointerdown', { cancelable: true });
 	Object.defineProperty(event, 'target', { value: target });
@@ -87,5 +98,26 @@ describe('useSheetOutsideDismissGuards', () => {
 		const later = outsideEvent(document.body);
 		result.current.onInteractOutside(later);
 		expect(later.defaultPrevented).toBe(false);
+	});
+
+	// ConfigureAddonDialog's charges-table Dialog stays open behind a line-item editor Dialog it
+	// opens on top of itself. A click inside that editor reaches the table dialog's dismissable
+	// layer as an "outside" event (different portal subtree) and must not close it.
+	it('does not dismiss when the outside-detected click lands inside a nested dialog', () => {
+		const { child } = openNestedDialog();
+		const { result } = renderHook(() => useSheetOutsideDismissGuards(true));
+
+		const event = outsideEvent(child);
+		result.current.onPointerDownOutside(event);
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it('still dismisses on a click outside everything, even while a nested dialog exists elsewhere in the DOM', () => {
+		openNestedDialog();
+		const { result } = renderHook(() => useSheetOutsideDismissGuards(true));
+
+		const event = outsideEvent(document.body);
+		result.current.onPointerDownOutside(event);
+		expect(event.defaultPrevented).toBe(false);
 	});
 });

--- a/src/lib/modal-scroll-lock.ts
+++ b/src/lib/modal-scroll-lock.ts
@@ -56,7 +56,21 @@ const PORTALED_OVERLAY_SELECTOR = [
 	'[data-radix-popover-content][data-state="open"]',
 ].join(', ');
 
-const isPortaledOverlayTarget = (target: EventTarget | null) => target instanceof Element && !!target.closest(PORTALED_OVERLAY_SELECTOR);
+/**
+ * A second, fully open Dialog/AlertDialog (e.g. an editor opened on top of a table that's shown
+ * inside another Dialog, like ConfigureAddonDialog's charges table + line-item editor). Kept out
+ * of PORTALED_OVERLAY_SELECTOR/hasOpenPortaledOverlay deliberately: that function is used as a
+ * "some overlay is open somewhere" check with no way to exclude the current dialog's own content,
+ * and a Dialog's own root always matches `[role="dialog"][data-state="open"]` while it's mounted -
+ * folding this in there would make every Dialog perpetually see "an overlay is open" (itself) and
+ * never dismiss on a genuine outside click. It's only safe to check by event target: Radix already
+ * only invokes onPointerDownOutside/onInteractOutside for a target outside the dialog's own DOM
+ * subtree, so a target that closest()-matches this selector is necessarily a *different* dialog.
+ */
+const NESTED_DIALOG_SELECTOR = '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]';
+
+const isPortaledOverlayTarget = (target: EventTarget | null) =>
+	target instanceof Element && (!!target.closest(PORTALED_OVERLAY_SELECTOR) || !!target.closest(NESTED_DIALOG_SELECTOR));
 
 const hasOpenPortaledOverlay = () => !!document.querySelector(PORTALED_OVERLAY_SELECTOR);
 


### PR DESCRIPTION
## Summary
- `ConfigureAddonDialog`'s charges-table Dialog stays open behind a line-item editor Dialog it opens on top of itself (e.g. "Change Quantity") whenever an addon has more than one charge. Both are non-modal Radix Dialogs in separate portal subtrees, so any click inside the editor was read by the underlying table dialog as an "outside" click, closing it - which cascades (via its `isOpen`-driven effect) to close the editor too. A completely ordinary click inside the editor (e.g. the Quantity input) was enough to dismiss both.
- `useSheetOutsideDismissGuards` already exists to stop exactly this kind of misfire for Popover/Select/Menu overlays nested inside a Dialog, but its selector list never covered a second, nested `Dialog`. Extended the target-based check (`isPortaledOverlayTarget`) - not the "is anything open anywhere" check, which can't safely distinguish a dialog from itself - to also recognize `[role="dialog"]`/`[role="alertdialog"]` as a legitimate overlay a click can land inside.

## Test plan
- [x] `npx tsc --noEmit -p .` passes
- [x] `npx eslint src/lib/modal-scroll-lock.ts src/lib/modal-scroll-lock.test.ts` - no new errors
- [x] `npx vitest run src/lib/modal-scroll-lock.test.ts` - 6/6 pass, including 2 new cases (nested-dialog click is protected; a genuine outside click still dismisses even while a nested dialog exists elsewhere)
- [x] Reproduced live against a real addon with two line items (one active, one terminated) on api-dev: before the fix, opening "Change Quantity" from the charges table and clicking the Quantity input closed both dialogs entirely. After the fix, both dialogs stay open and the field is editable; Cancel still correctly dismisses just the top dialog.