### PR TITLE
feat(subscriptions): Addon quantity change in create subs

### DIFF
--- a/src/components/molecules/PriceQuantityCell/PriceQuantityCell.test.tsx
+++ b/src/components/molecules/PriceQuantityCell/PriceQuantityCell.test.tsx
@@ -1,0 +1,85 @@
+import type { ReactElement } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { createInstance } from 'i18next';
+import { describe, expect, it, vi, beforeAll } from 'vitest';
+import { PRICE_TYPE, type Price } from '@/models/Price';
+import PriceQuantityCell from './PriceQuantityCell';
+
+const makePrice = (overrides: Partial<Price> & Pick<Price, 'id' | 'type'>): Price =>
+	({
+		amount: '10',
+		...overrides,
+	}) as Price;
+
+const i18n = createInstance();
+
+beforeAll(async () => {
+	await i18n.use(initReactI18next).init({
+		lng: 'en',
+		fallbackLng: 'en',
+		ns: ['customers'],
+		defaultNS: 'customers',
+		resources: {
+			en: {
+				customers: {
+					organisms: { subscriptionPriceTable: { payAsYouGo: 'pay as you go' } },
+				},
+			},
+		},
+		interpolation: { escapeValue: false },
+	});
+});
+
+const renderCell = (ui: ReactElement) => render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>);
+
+describe('PriceQuantityCell', () => {
+	it('hides the quantity input for USAGE prices', () => {
+		renderCell(
+			<PriceQuantityCell
+				price={makePrice({ id: 'usage', type: PRICE_TYPE.USAGE })}
+				usageLabel='pay as you go'
+				ariaLabel='Quantity'
+				onPriceOverride={vi.fn()}
+				onResetOverride={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText('pay as you go')).toBeInTheDocument();
+		expect(screen.queryByLabelText('Quantity')).not.toBeInTheDocument();
+	});
+
+	it('prefills FIXED quantity from min_quantity', () => {
+		renderCell(
+			<PriceQuantityCell
+				price={makePrice({ id: 'fixed', type: PRICE_TYPE.FIXED, min_quantity: 3 })}
+				ariaLabel='Quantity'
+				onPriceOverride={vi.fn()}
+				onResetOverride={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByLabelText('Quantity')).toHaveValue('3');
+	});
+
+	it('emits a quantity override when the user changes a FIXED price away from the default', async () => {
+		const user = userEvent.setup();
+		const onPriceOverride = vi.fn();
+
+		renderCell(
+			<PriceQuantityCell
+				price={makePrice({ id: 'fixed', type: PRICE_TYPE.FIXED, min_quantity: 1 })}
+				ariaLabel='Quantity'
+				onPriceOverride={onPriceOverride}
+				onResetOverride={vi.fn()}
+			/>,
+		);
+
+		const input = screen.getByLabelText('Quantity');
+		await user.clear(input);
+		await user.type(input, '5');
+
+		expect(onPriceOverride).toHaveBeenCalledWith('fixed', { quantity: 5 });
+	});
+});

--- a/src/components/molecules/PriceQuantityCell/PriceQuantityCell.tsx
+++ b/src/components/molecules/PriceQuantityCell/PriceQuantityCell.tsx
@@ -1,0 +1,118 @@
+import { FC, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { DecimalUsageInput } from '@/components/atoms';
+import { PRICE_TYPE, type Price } from '@/models/Price';
+import type { Coupon } from '@/models';
+import type { ExtendedPriceOverride } from '@/utils/common/price_override_helpers';
+import { resolveQuantityFromInput } from '@/utils/subscription/quantityValidation';
+
+export interface PriceQuantityCellProps {
+	price: Price;
+	override?: ExtendedPriceOverride;
+	disabled?: boolean;
+	lineItemCoupon?: Coupon | null;
+	/** Controlled draft. Omit with `onQuantityChange` to let the cell keep its own draft. */
+	quantityInput?: string;
+	/** Pass string to set transient input (including '' for empty); pass null to clear transient after commit. */
+	onQuantityChange?: (value: string | null) => void;
+	onResetOverride: (priceId: string) => void;
+	onPriceOverride: (priceId: string, override: Partial<ExtendedPriceOverride>) => void;
+	onClearCoupon?: (priceId: string) => void;
+	usageLabel?: string;
+	ariaLabel?: string;
+}
+
+const isOnlyQuantityOverride = (override?: ExtendedPriceOverride): boolean =>
+	!!override &&
+	((Object.keys(override).length === 1 && override.quantity !== undefined) ||
+		(Object.keys(override).length === 2 && override.price_id !== undefined && override.quantity !== undefined));
+
+/**
+ * Quantity input for FIXED catalogue prices on create-sub plan charges and addon attach.
+ * USAGE prices are metered — the input is hidden.
+ */
+const PriceQuantityCell: FC<PriceQuantityCellProps> = ({
+	price,
+	override,
+	disabled = false,
+	lineItemCoupon,
+	quantityInput,
+	onQuantityChange,
+	onResetOverride,
+	onPriceOverride,
+	onClearCoupon,
+	usageLabel,
+	ariaLabel,
+}) => {
+	const { t } = useTranslation('customers');
+	const minQuantity = price.min_quantity ?? 1;
+	const currentQuantity = override?.quantity ?? minQuantity;
+	const [internalDraft, setInternalDraft] = useState<string | undefined>(undefined);
+	const isControlled = onQuantityChange !== undefined;
+	const draft = isControlled ? quantityInput : internalDraft;
+	const displayQuantity = draft ?? currentQuantity.toString();
+
+	const setDraft = (value: string | null) => {
+		if (onQuantityChange) {
+			onQuantityChange(value);
+			return;
+		}
+		setInternalDraft(value === null ? undefined : value);
+	};
+
+	// Clear transient only when override was removed (e.g. Reset Override) so we show minQuantity.
+	useEffect(() => {
+		if (override !== undefined) {
+			return;
+		}
+		if (isControlled) {
+			if (quantityInput == null || quantityInput === '') {
+				return;
+			}
+			onQuantityChange(null);
+			return;
+		}
+		setInternalDraft(undefined);
+	}, [override, isControlled, quantityInput, onQuantityChange]);
+
+	if (price.type !== PRICE_TYPE.FIXED) {
+		return <>{usageLabel ?? t('organisms.subscriptionPriceTable.payAsYouGo')}</>;
+	}
+
+	return (
+		<div className='w-20' data-interactive='true'>
+			<DecimalUsageInput
+				value={displayQuantity}
+				ariaLabel={ariaLabel}
+				onChange={(value) => {
+					if (value === '') {
+						setDraft('');
+						return;
+					}
+					const quantity = resolveQuantityFromInput(value, minQuantity);
+
+					if (quantity === minQuantity) {
+						if (isOnlyQuantityOverride(override)) {
+							onResetOverride(price.id);
+						} else if (override) {
+							const { quantity: _q, ...rest } = override;
+							onPriceOverride(price.id, { ...rest, quantity: undefined });
+						}
+						setDraft(isControlled && value !== quantity.toString() ? value : null);
+						return;
+					}
+
+					if (lineItemCoupon) onClearCoupon?.(price.id);
+					onPriceOverride(price.id, { quantity });
+					setDraft(quantity.toString());
+				}}
+				placeholder={minQuantity.toString()}
+				disabled={disabled}
+				precision={0}
+				min={0}
+			/>
+		</div>
+	);
+};
+
+export default PriceQuantityCell;

--- a/src/components/molecules/PriceQuantityCell/index.ts
+++ b/src/components/molecules/PriceQuantityCell/index.ts
@@ -1,0 +1,2 @@
+export { default as PriceQuantityCell } from './PriceQuantityCell';
+export type { PriceQuantityCellProps } from './PriceQuantityCell';

--- a/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonModal.tsx
+++ b/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonModal.tsx
@@ -16,6 +16,8 @@ import {
 	removePriceOverride,
 	updatePriceOverride,
 } from '@/utils/common/price_override_helpers';
+import { sanitizeAddonOverrideLineItemsForApi } from '@/utils/subscription/addonQuantity';
+import { PriceQuantityCell } from '@/components/molecules/PriceQuantityCell';
 import PriceOverrideDialog from '@/components/molecules/PriceOverrideDialog/PriceOverrideDialog';
 import ChargeValueCell from '@/components/molecules/ChargeValueCell/ChargeValueCell';
 import { DropdownMenu as UiDropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
@@ -138,13 +140,16 @@ const SubscriptionAddonModal: React.FC<Props> = ({
 
 		const commitments = (formData.line_item_commitments || {}) as LineItemCommitmentsMap;
 		const hasCommitments = Object.keys(commitments).length > 0;
-		const override_line_items = getLineItemOverrides(selectedAddonPrices, overriddenPrices);
+		const override_line_items = sanitizeAddonOverrideLineItemsForApi(
+			getLineItemOverrides(selectedAddonPrices, overriddenPrices),
+			selectedAddonPrices,
+		);
 		const addonData: AddAddonToSubscriptionRequest = {
 			addon_id: formData.addon_id!,
 			start_date: formData.start_date,
 			metadata: formData.metadata || {},
 			line_item_commitments: hasCommitments ? commitments : undefined,
-			override_line_items: override_line_items.length > 0 ? override_line_items : undefined,
+			override_line_items,
 		};
 
 		onSave(addonData);
@@ -241,6 +246,19 @@ const SubscriptionAddonModal: React.FC<Props> = ({
 				render: (row) => <span>{toSentenceCase(row.price.type || t('labels.na'))}</span>,
 			},
 			{
+				title: t('subscriptionAddon.columnQuantity'),
+				render: (row) => (
+					<PriceQuantityCell
+						price={row.price}
+						override={overriddenPrices[row.price.id]}
+						usageLabel={t('subscriptionAddon.quantityUsage')}
+						ariaLabel={t('subscriptionAddon.columnQuantity')}
+						onPriceOverride={handlePriceOverride}
+						onResetOverride={handleResetOverride}
+					/>
+				),
+			},
+			{
 				title: t('subscriptionAddon.columnPrice'),
 				render: (row) => <ChargeValueCell data={row.price} priceOverride={overriddenPrices[row.price.id]} />,
 			},
@@ -298,7 +316,7 @@ const SubscriptionAddonModal: React.FC<Props> = ({
 				},
 			},
 		],
-		[commitmentMap, handleConfigureCommitment, handleConfigurePrice, handleResetOverride, overriddenPrices, t],
+		[commitmentMap, handleConfigureCommitment, handleConfigurePrice, handlePriceOverride, handleResetOverride, overriddenPrices, t],
 	);
 
 	// const handleDateChange = useCallback(

--- a/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonTable.tsx
+++ b/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonTable.tsx
@@ -10,9 +10,11 @@ import AddonApi from '@/api/AddonApi';
 import { getTotalPayableTextWithCoupons } from '@/utils/common/helper_functions';
 import { Price, PRICE_TYPE } from '@/models/Price';
 import { BILLING_PERIOD } from '@/constants/constants';
-import { getCurrentPriceAmount, overrideLineItemsToMap, ExtendedPriceOverride } from '@/utils/common/price_override_helpers';
+import { ExtendedPriceOverride } from '@/utils/common/price_override_helpers';
 import { Coupon } from '@/models/Coupon';
 import { filterAddonPricesForSubscription } from '@/utils/subscription/addon_commitment_helpers';
+import { formatAddonQuantityDisplay, sumFixedAddonRecurringTotal } from '@/utils/subscription/addonQuantity';
+import type { OverrideLineItemRequest } from '@/types/dto/Subscription';
 
 interface Props {
 	data: AddAddonToSubscriptionRequest[];
@@ -28,6 +30,7 @@ interface Props {
 }
 const formatAddonCharges = (
 	prices: Price[] = [],
+	overrideLineItems: OverrideLineItemRequest[] = [],
 	priceOverrides: Record<string, ExtendedPriceOverride> = {},
 	coupons: Coupon[] = [],
 	t: TFunction<'common'>,
@@ -43,13 +46,14 @@ const formatAddonCharges = (
 		return hasUsage ? t('subscriptionAddon.dependsOnUsage') : t('labels.na');
 	}
 
-	// Calculate total recurring amount
-	const recurringTotal = recurringPrices.reduce((acc, charge) => {
-		const currentAmount = getCurrentPriceAmount(charge, priceOverrides);
-		return acc + parseFloat(currentAmount);
-	}, 0);
+	const fromLineItems = Object.fromEntries(
+		overrideLineItems.map((item) => [item.price_id, { quantity: item.quantity, amount: item.amount }]),
+	);
+	const fromPriceOverrides = Object.fromEntries(
+		Object.entries(priceOverrides).map(([id, override]) => [id, { quantity: override.quantity, amount: override.amount }]),
+	);
+	const recurringTotal = sumFixedAddonRecurringTotal(recurringPrices, { ...fromPriceOverrides, ...fromLineItems });
 
-	// Use the same helper as Preview component for consistent display
 	return getTotalPayableTextWithCoupons(recurringPrices, usagePrices, recurringTotal, coupons);
 };
 
@@ -147,15 +151,21 @@ const SubscriptionAddonTable: React.FC<Props> = ({
 				},
 			},
 			{
+				title: t('subscriptionAddon.columnQuantity'),
+				render: (row) => {
+					const addonDetails = getAddonDetails(row.addon_id);
+					const prices = filterAddonPricesForSubscription(addonDetails?.prices || [], billingPeriod, currency, billingPeriodCount);
+					return formatAddonQuantityDisplay(prices, row.override_line_items ?? [], t('subscriptionAddon.quantityUsage'));
+				},
+			},
+			{
 				title: t('subscriptionAddon.columnCharges'),
 				render: (row) => {
 					const addonDetails = getAddonDetails(row.addon_id);
 					const prices = filterAddonPricesForSubscription(addonDetails?.prices || [], billingPeriod, currency, billingPeriodCount);
-					// Each addon row carries its own overrides (set via "Override Price" in the addon
-					// editor) - the shared `priceOverrides` prop is keyed for the base plan's prices and
-					// never covers per-addon overrides, so it must not be the only source used here.
-					const rowOverrides = { ...priceOverrides, ...overrideLineItemsToMap(row.override_line_items) };
-					return <span>{formatAddonCharges(prices, rowOverrides, coupons, t)}</span>;
+					// Per-addon overrides (amount + quantity) live on the row; plan-level
+					// `priceOverrides` never covers addon catalogue price ids.
+					return <span>{formatAddonCharges(prices, row.override_line_items ?? [], priceOverrides, coupons, t)}</span>;
 				},
 			},
 			// {

--- a/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonTable.tsx
+++ b/src/components/molecules/SubscriptionAddonTable/SubscriptionAddonTable.tsx
@@ -1,20 +1,16 @@
 import { AddAddonToSubscriptionRequest } from '@/types/dto/Addon';
 import React, { useCallback, useMemo, useState, memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { TFunction } from 'i18next';
 import { AddButton, FormHeader, ActionButton } from '@/components/atoms';
 import FlexpriceTable, { ColumnData } from '../Table';
 import SubscriptionAddonModal from './SubscriptionAddonModal';
 import { useQuery } from '@tanstack/react-query';
 import AddonApi from '@/api/AddonApi';
-import { getTotalPayableTextWithCoupons } from '@/utils/common/helper_functions';
-import { Price, PRICE_TYPE } from '@/models/Price';
 import { BILLING_PERIOD } from '@/constants/constants';
 import { ExtendedPriceOverride } from '@/utils/common/price_override_helpers';
 import { Coupon } from '@/models/Coupon';
 import { filterAddonPricesForSubscription } from '@/utils/subscription/addon_commitment_helpers';
-import { formatAddonQuantityDisplay, sumFixedAddonRecurringTotal } from '@/utils/subscription/addonQuantity';
-import type { OverrideLineItemRequest } from '@/types/dto/Subscription';
+import { formatAddonCharges, formatAddonQuantityDisplay } from '@/utils/subscription/addonQuantity';
 
 interface Props {
 	data: AddAddonToSubscriptionRequest[];
@@ -28,34 +24,6 @@ interface Props {
 	billingPeriodCount?: number;
 	currency?: string;
 }
-const formatAddonCharges = (
-	prices: Price[] = [],
-	overrideLineItems: OverrideLineItemRequest[] = [],
-	priceOverrides: Record<string, ExtendedPriceOverride> = {},
-	coupons: Coupon[] = [],
-	t: TFunction<'common'>,
-): string => {
-	if (!prices || prices.length === 0) return t('labels.na');
-
-	const recurringPrices = prices.filter((p) => p.type === PRICE_TYPE.FIXED);
-	const usagePrices = prices.filter((p) => p.type === PRICE_TYPE.USAGE);
-
-	const hasUsage = usagePrices.length > 0;
-
-	if (recurringPrices.length === 0) {
-		return hasUsage ? t('subscriptionAddon.dependsOnUsage') : t('labels.na');
-	}
-
-	const fromLineItems = Object.fromEntries(
-		overrideLineItems.map((item) => [item.price_id, { quantity: item.quantity, amount: item.amount }]),
-	);
-	const fromPriceOverrides = Object.fromEntries(
-		Object.entries(priceOverrides).map(([id, override]) => [id, { quantity: override.quantity, amount: override.amount }]),
-	);
-	const recurringTotal = sumFixedAddonRecurringTotal(recurringPrices, { ...fromPriceOverrides, ...fromLineItems });
-
-	return getTotalPayableTextWithCoupons(recurringPrices, usagePrices, recurringTotal, coupons);
-};
 
 interface ExtendedAddon extends AddAddonToSubscriptionRequest {
 	internal_id: number;
@@ -165,7 +133,14 @@ const SubscriptionAddonTable: React.FC<Props> = ({
 					const prices = filterAddonPricesForSubscription(addonDetails?.prices || [], billingPeriod, currency, billingPeriodCount);
 					// Per-addon overrides (amount + quantity) live on the row; plan-level
 					// `priceOverrides` never covers addon catalogue price ids.
-					return <span>{formatAddonCharges(prices, row.override_line_items ?? [], priceOverrides, coupons, t)}</span>;
+					return (
+						<span>
+							{formatAddonCharges(prices, row.override_line_items ?? [], priceOverrides, coupons, {
+								empty: t('labels.na'),
+								dependsOnUsage: t('subscriptionAddon.dependsOnUsage'),
+							})}
+						</span>
+					);
 				},
 			},
 			// {

--- a/src/components/molecules/SubscriptionAddonsSection/AddAddonDialog.tsx
+++ b/src/components/molecules/SubscriptionAddonsSection/AddAddonDialog.tsx
@@ -27,6 +27,8 @@ import { ChevronDown, Pencil, RotateCcw, Target } from 'lucide-react';
 import { BsThreeDots } from 'react-icons/bs';
 import { usePriceOverrides } from '@/hooks/usePriceOverrides';
 import { getLineItemOverrides } from '@/utils/common/price_override_helpers';
+import { sanitizeAddonOverrideLineItemsForApi } from '@/utils/subscription/addonQuantity';
+import { PriceQuantityCell } from '@/components/molecules/PriceQuantityCell';
 import PriceOverrideDialog from '@/components/molecules/PriceOverrideDialog/PriceOverrideDialog';
 import ChargeValueCell from '@/components/molecules/ChargeValueCell/ChargeValueCell';
 import { DropdownMenu as UiDropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
@@ -100,7 +102,13 @@ const AddAddonDialog: React.FC<Props> = ({
 
 	// Reset form when modal opens/closes
 	const selectedAddonPrices = useMemo(
-		() => filterAddonPricesForSubscription((selectedAddonDetails?.prices as Price[]) || [], billingPeriod, currency, resolvedBillingPeriodCount),
+		() =>
+			filterAddonPricesForSubscription(
+				(selectedAddonDetails?.prices as Price[]) || [],
+				billingPeriod,
+				currency,
+				resolvedBillingPeriodCount,
+			),
 		[selectedAddonDetails, billingPeriod, currency, resolvedBillingPeriodCount],
 	);
 
@@ -179,12 +187,15 @@ const AddAddonDialog: React.FC<Props> = ({
 
 		setErrors({});
 		const line_item_commitments = sanitizeAddonLineItemCommitmentsForApi(lineItemCommitments, selectedAddonPrices);
-		const override_line_items = getLineItemOverrides(selectedAddonPrices, overriddenPrices);
+		const override_line_items = sanitizeAddonOverrideLineItemsForApi(
+			getLineItemOverrides(selectedAddonPrices, overriddenPrices),
+			selectedAddonPrices,
+		);
 		const addonData: AddAddonRequest = {
 			subscription_id: subscriptionId,
 			addon_id: formData.addon_id!,
 			line_item_commitments,
-			...(override_line_items.length > 0 ? { override_line_items } : {}),
+			...(override_line_items ? { override_line_items } : {}),
 			...(startDate ? { start_date: startDate.toISOString() } : {}),
 			...(cadence ? { cadence } : {}),
 			...(prorationBehavior ? { proration_behavior: prorationBehavior } : {}),
@@ -297,6 +308,19 @@ const AddAddonDialog: React.FC<Props> = ({
 				render: (row) => <span>{toSentenceCase(row.price.type || t('common:labels.na'))}</span>,
 			},
 			{
+				title: t('billing:subscriptions.addAddonDialog.columns.quantity'),
+				render: (row) => (
+					<PriceQuantityCell
+						price={row.price}
+						override={overriddenPrices[row.price.id]}
+						usageLabel={t('billing:subscriptions.addAddonDialog.quantityUsage')}
+						ariaLabel={t('billing:subscriptions.addAddonDialog.columns.quantity')}
+						onPriceOverride={overridePrice}
+						onResetOverride={resetOverride}
+					/>
+				),
+			},
+			{
 				title: t('billing:subscriptions.addAddonDialog.columns.price'),
 				render: (row) => <ChargeValueCell data={row.price} priceOverride={overriddenPrices[row.price.id]} />,
 			},
@@ -354,7 +378,7 @@ const AddAddonDialog: React.FC<Props> = ({
 				},
 			},
 		],
-		[lineItemCommitments, handleConfigureCommitment, handleConfigurePrice, overriddenPrices, resetOverride, t],
+		[lineItemCommitments, handleConfigureCommitment, handleConfigurePrice, overridePrice, overriddenPrices, resetOverride, t],
 	);
 
 	const filteredAddonOptions = useMemo(() => {

--- a/src/components/molecules/SubscriptionAddonsSection/AddAddonDialog.tsx
+++ b/src/components/molecules/SubscriptionAddonsSection/AddAddonDialog.tsx
@@ -166,6 +166,7 @@ const AddAddonDialog: React.FC<Props> = ({
 		onSuccess: () => {
 			toast.success(t('billing:subscriptions.addAddonDialog.toast.addonAddedSuccess'));
 			refetchQueries(['subscriptionActiveAddons', subscriptionId]);
+			refetchQueries(['subscriptionAddonLineItems', subscriptionId]);
 			refetchQueries(['subscriptionDetails', subscriptionId]);
 			refetchQueries(['subscriptionEdit', subscriptionId]);
 			refetchQueries(['subscriptionEntitlements', subscriptionId]);

--- a/src/components/molecules/SubscriptionAddonsSection/SubscriptionAddonsSection.tsx
+++ b/src/components/molecules/SubscriptionAddonsSection/SubscriptionAddonsSection.tsx
@@ -1,27 +1,28 @@
-import { FC, useState, useMemo, useCallback, ReactNode } from 'react';
+import { FC, useState, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { TFunction } from 'i18next';
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { Settings2, Trash2, Copy } from 'lucide-react';
-import { Button, Card, CardHeader, Chip, DatePicker, Dialog, AddButton, Select, Tooltip, NoDataCard } from '@/components/atoms';
+import { Button, Card, CardHeader, DatePicker, Dialog, AddButton, Select, Tooltip, NoDataCard } from '@/components/atoms';
 import { FlexpriceTable, ColumnData } from '@/components/molecules';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { BsThreeDots } from 'react-icons/bs';
 import SubscriptionApi from '@/api/SubscriptionApi';
-import { ADDON_ASSOCIATION_STATUS } from '@/models/AddonAssociation';
 import { AddonAssociationResponse, SubscriptionResponse } from '@/types/dto/Subscription';
 import { EXPAND } from '@/models';
 import { ADDON_PRORATION_BEHAVIOR } from '@/types/dto/Addon';
 import { BILLING_PERIOD } from '@/constants/constants';
-import { toSentenceCase, copyToClipboard } from '@/utils/common/helper_functions';
-import { Price, PRICE_TYPE } from '@/models/Price';
+import { copyToClipboard } from '@/utils/common/helper_functions';
 import { getCurrentPriceAmount } from '@/utils/common/price_override_helpers';
-import { getTotalPayableTextWithCoupons } from '@/utils/common/helper_functions';
+import {
+	attachedAddonLinesToDisplayInput,
+	formatAddonCharges,
+	formatAddonQuantityDisplay,
+	type AttachedAddonChargeLine,
+} from '@/utils/subscription/addonQuantity';
 import toast from 'react-hot-toast';
 import { cn } from '@/lib/utils';
 import AddAddonDialog from './AddAddonDialog';
 import ConfigureAddonDialog from './ConfigureAddonDialog';
-import { formatDateTimeWithSecondsAndTimezone } from '@/utils/common/format_date';
 import { refetchQueries } from '@/core/services/tanstack/ReactQueryProvider';
 import { useCurrentUserPermissions } from '@/hooks/useCurrentUserPermissions';
 
@@ -40,113 +41,6 @@ interface SubscriptionAddonsSectionProps {
 	subscriptionCurrentPeriodStart?: string;
 	subscriptionCurrentPeriodEnd?: string;
 }
-
-const formatAddonCharges = (prices: Price[] = []): string => {
-	if (!prices || prices.length === 0) return '--';
-
-	const recurringPrices = prices.filter((p) => p.type === PRICE_TYPE.FIXED);
-	const usagePrices = prices.filter((p) => p.type === PRICE_TYPE.USAGE);
-
-	const hasUsage = usagePrices.length > 0;
-
-	if (recurringPrices.length === 0) {
-		return hasUsage ? 'Depends on usage' : '--';
-	}
-
-	// Calculate total recurring amount
-	const recurringTotal = recurringPrices.reduce((acc, charge) => {
-		const currentAmount = getCurrentPriceAmount(charge, {});
-		return acc + parseFloat(currentAmount);
-	}, 0);
-
-	// Use the same helper as Preview component for consistent display
-	return getTotalPayableTextWithCoupons(recurringPrices, usagePrices, recurringTotal, []);
-};
-
-type AddonStatus = `${ADDON_ASSOCIATION_STATUS}`;
-
-const getStatusVariant = (status: AddonStatus): 'info' | 'default' | 'success' => {
-	switch (status) {
-		case 'upcoming':
-		case 'pending':
-		case 'scheduled':
-			return 'info';
-		case 'inactive':
-		case 'cancelled':
-			return 'default';
-		case 'active':
-		default:
-			return 'success';
-	}
-};
-
-const formatAddonAssociationTooltip = (association: AddonAssociationResponse, t: TFunction): ReactNode => {
-	const { start_date, end_date } = association;
-	const items: ReactNode[] = [];
-
-	if (start_date && start_date.trim() !== '') {
-		const parsed = new Date(start_date);
-		if (!isNaN(parsed.getTime())) {
-			items.push(
-				<div key='start' className='flex items-center gap-2'>
-					<span className='text-xs font-medium text-content-muted'>{t('labels.start')}</span>
-					<span className='text-sm font-medium'>{formatDateTimeWithSecondsAndTimezone(parsed)}</span>
-				</div>,
-			);
-		}
-	}
-
-	if (end_date && end_date.trim() !== '') {
-		const parsed = new Date(end_date);
-		if (!isNaN(parsed.getTime())) {
-			items.push(
-				<div key='end' className='flex items-center gap-2'>
-					<span className='text-xs font-medium text-content-muted'>{t('labels.end')}</span>
-					<span className='text-sm font-medium'>{formatDateTimeWithSecondsAndTimezone(parsed)}</span>
-				</div>,
-			);
-		}
-	}
-
-	if (items.length === 0) {
-		return <span className='text-sm'>{t('labels.noDateInformation')}</span>;
-	}
-
-	return <div className='flex flex-col gap-2'>{items}</div>;
-};
-
-interface AddonAssociationWithStatus extends AddonAssociationResponse {
-	precomputedStatus: AddonStatus;
-	statusVariant: 'info' | 'default' | 'success';
-	statusLabel: string;
-	tooltipContent: ReactNode;
-}
-
-const computeAssociationStatus = (association: AddonAssociationResponse): AddonStatus => {
-	const raw = association.addon_status?.toLowerCase() as AddonStatus | undefined;
-	if (
-		raw === ADDON_ASSOCIATION_STATUS.CANCELLED ||
-		raw === ADDON_ASSOCIATION_STATUS.INACTIVE ||
-		raw === ADDON_ASSOCIATION_STATUS.ACTIVE ||
-		raw === ADDON_ASSOCIATION_STATUS.UPCOMING ||
-		raw === ADDON_ASSOCIATION_STATUS.PENDING ||
-		raw === ADDON_ASSOCIATION_STATUS.SCHEDULED
-	) {
-		return raw;
-	}
-
-	// Fallback to date-based computation
-	const now = new Date();
-	if (association.start_date && association.start_date.trim() !== '') {
-		const start = new Date(association.start_date);
-		if (!isNaN(start.getTime()) && start > now) return 'upcoming';
-	}
-	if (association.end_date && association.end_date.trim() !== '') {
-		const end = new Date(association.end_date);
-		if (!isNaN(end.getTime()) && end < now) return 'inactive';
-	}
-	return 'active';
-};
 
 const SubscriptionAddonsSection: FC<SubscriptionAddonsSectionProps> = ({
 	subscriptionId,
@@ -232,33 +126,43 @@ const SubscriptionAddonsSection: FC<SubscriptionAddonsSectionProps> = ({
 		enabled: !!subscriptionId,
 	});
 
-	const pricesByAddonAssociationId = useMemo<Record<string, Price[]>>(() => {
-		const grouped: Record<string, Price[]> = {};
+	const chargeLinesByAddonAssociationId = useMemo<Record<string, AttachedAddonChargeLine[]>>(() => {
+		const grouped: Record<string, AttachedAddonChargeLine[]> = {};
 		for (const item of addonLineItemsResponse?.items ?? []) {
 			if (!item.addon_association_id || !item.price) continue;
-			(grouped[item.addon_association_id] ??= []).push(item.price);
+			const unitAmount = parseFloat(getCurrentPriceAmount(item.price, {}));
+			(grouped[item.addon_association_id] ??= []).push({
+				priceType: item.price_type ?? item.price.type,
+				quantity: item.quantity,
+				unitAmount: Number.isFinite(unitAmount) ? unitAmount : 0,
+				startDate: item.start_date,
+				endDate: item.end_date,
+				price: item.price,
+			});
 		}
 		return grouped;
 	}, [addonLineItemsResponse]);
 
 	const isLoading = isLoadingAddons || isLoadingAddonLineItems;
 
-	const processedAddonAssociations = useMemo<AddonAssociationWithStatus[]>(() => {
-		return addonAssociations.map((association) => {
-			const status = computeAssociationStatus(association);
-			const statusVariant = getStatusVariant(status);
-			const statusLabel = toSentenceCase(status || 'active');
-			const tooltipContent = formatAddonAssociationTooltip(association, t);
+	const getAddonDisplayInput = useCallback(
+		(association: AddonAssociationResponse) => {
+			const lines = chargeLinesByAddonAssociationId[association.id];
+			if (lines) {
+				return attachedAddonLinesToDisplayInput(lines);
+			}
+			return { prices: association.addon?.prices ?? [], overrideLineItems: [] };
+		},
+		[chargeLinesByAddonAssociationId],
+	);
 
-			return {
-				...association,
-				precomputedStatus: status,
-				statusVariant,
-				statusLabel,
-				tooltipContent,
-			};
-		});
-	}, [addonAssociations, t]);
+	const chargeLabels = useMemo(
+		() => ({
+			empty: t('common:labels.na'),
+			dependsOnUsage: t('common:subscriptionAddon.dependsOnUsage'),
+		}),
+		[t],
+	);
 
 	const addonNameToCancel = useMemo(() => {
 		if (!addonToCancel) return 'this addon';
@@ -318,34 +222,24 @@ const SubscriptionAddonsSection: FC<SubscriptionAddonsSectionProps> = ({
 		setCancelProrationBehavior('');
 	}, []);
 
-	const columns: ColumnData<AddonAssociationWithStatus>[] = useMemo(
+	const columns: ColumnData<AddonAssociationResponse>[] = useMemo(
 		() => [
 			{
-				title: 'Name',
+				title: t('common:subscriptionAddon.columnName'),
 				render: (row) => <span>{row.addon?.name || row.addon_id}</span>,
 			},
 			{
-				title: 'Status',
-				render: (row) => (
-					<Tooltip
-						content={row.tooltipContent}
-						delayDuration={0}
-						sideOffset={5}
-						className='bg-surface border border-line shadow-lg text-sm text-content px-4 py-3 rounded-lg max-w-[320px]'>
-						<span>
-							<Chip label={row.statusLabel} variant={row.statusVariant} />
-						</span>
-					</Tooltip>
-				),
+				title: t('common:subscriptionAddon.columnQuantity'),
+				render: (row) => {
+					const { prices, overrideLineItems } = getAddonDisplayInput(row);
+					return formatAddonQuantityDisplay(prices, overrideLineItems, t('common:subscriptionAddon.quantityUsage'));
+				},
 			},
 			{
-				title: 'Charges',
+				title: t('common:subscriptionAddon.columnCharges'),
 				render: (row) => {
-					// Falls back to the catalog default only if this association has no
-					// matching line items yet (e.g. a fetch error) — the common case reads
-					// the real, possibly-overridden line item prices grouped above.
-					const prices = pricesByAddonAssociationId[row.id] ?? row.addon?.prices ?? [];
-					return <span>{formatAddonCharges(prices)}</span>;
+					const { prices, overrideLineItems } = getAddonDisplayInput(row);
+					return <span>{formatAddonCharges(prices, overrideLineItems, {}, [], chargeLabels)}</span>;
 				},
 			},
 			{
@@ -415,7 +309,7 @@ const SubscriptionAddonsSection: FC<SubscriptionAddonsSectionProps> = ({
 				},
 			},
 		],
-		[dropdownOpen, handleCancel, readOnly, canWriteAddon, t, pricesByAddonAssociationId],
+		[dropdownOpen, handleCancel, readOnly, canWriteAddon, t, getAddonDisplayInput, chargeLabels],
 	);
 
 	const addButton = readOnly ? undefined : canWriteAddon ? (
@@ -445,10 +339,10 @@ const SubscriptionAddonsSection: FC<SubscriptionAddonsSectionProps> = ({
 
 	return (
 		<>
-			{processedAddonAssociations.length > 0 ? (
+			{addonAssociations.length > 0 ? (
 				<Card variant='notched'>
 					<CardHeader title={t('labels.addons')} cta={addButton} />
-					<FlexpriceTable showEmptyRow data={processedAddonAssociations} columns={columns} variant='no-bordered' />
+					<FlexpriceTable showEmptyRow data={addonAssociations} columns={columns} variant='no-bordered' />
 				</Card>
 			) : (
 				<NoDataCard title={t('labels.addons')} subtitle={t('labels.noAddonsAddedYet')} cta={addButton} />

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -157,6 +157,8 @@ export type { RectangleRadiogroupOption } from './RectangleRadiogroup';
 export { default as DropdownMenu, getCopyIdOption } from './DropdownMenu';
 export type { DropdownMenuOption } from './DropdownMenu';
 export { ChargeValueCell } from './ChargeValueCell';
+export { PriceQuantityCell } from './PriceQuantityCell';
+export type { PriceQuantityCellProps } from './PriceQuantityCell';
 
 // Query & Search
 export { QueryBuilder, PropertyFilterQueryBuilder, FilterPopover, SortDropdown, FilterMultiSelect } from './QueryBuilder';

--- a/src/components/organisms/Subscription/PhaseList.tsx
+++ b/src/components/organisms/Subscription/PhaseList.tsx
@@ -10,6 +10,7 @@ import { Coupon } from '@/models/Coupon';
 import { ExtendedPriceOverride } from '@/utils/common/price_override_helpers';
 import { BILLING_MODEL, TIER_MODE, PRICE_TYPE } from '@/models/Price';
 import { convertSubscriptionToPhaseData } from '@/utils/subscription/phaseConversion';
+import { parseNonNegativeQuantity } from '@/utils/subscription/quantityValidation';
 import { formatDateShort } from '@/utils/common/helper_functions';
 import { useTranslation } from 'react-i18next';
 
@@ -239,7 +240,7 @@ const PhaseList: React.FC<PhaseListProps> = ({
 				priceOverrides[override.price_id] = {
 					price_id: override.price_id,
 					amount: override.amount?.toString(),
-					quantity: override.quantity,
+					quantity: parseNonNegativeQuantity(override.quantity),
 					billing_model: billingModel,
 					tier_mode: override.tier_mode,
 					tiers: override.tiers,

--- a/src/components/organisms/Subscription/SubscriptionPriceTable.tsx
+++ b/src/components/organisms/Subscription/SubscriptionPriceTable.tsx
@@ -1,12 +1,12 @@
-import { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
-import { ColumnData, FlexpriceTable, LineItemCoupon } from '@/components/molecules';
+import { ColumnData, FlexpriceTable, LineItemCoupon, PriceQuantityCell } from '@/components/molecules';
 import PriceOverrideDialog from '@/components/molecules/PriceOverrideDialog/PriceOverrideDialog';
 import CommitmentConfigDialog from '@/components/molecules/CommitmentConfigDialog';
-import { Price, PRICE_TYPE, PRICE_UNIT_TYPE } from '@/models';
+import { Price, PRICE_UNIT_TYPE } from '@/models';
 import type { PriceBucketSize } from '@/models/Meter';
 import { ChevronDownIcon, ChevronUpIcon, Copy, Pencil, RotateCcw, Tag, Target, Trash2 } from 'lucide-react';
-import { FormHeader, DecimalUsageInput, AddButton, Chip } from '@/components/atoms';
+import { FormHeader, AddButton, Chip } from '@/components/atoms';
 import { ChargeValueCell } from '@/components/molecules';
 import { capitalize } from 'es-toolkit';
 import { Coupon } from '@/models';
@@ -25,18 +25,11 @@ import { BILLING_PERIOD, BUCKET_SIZE_NONE } from '@/constants/constants';
 import { isCadenceCompatible } from '@/utils/subscription/cadenceCompatibility';
 import { isOneTimePlanPrice } from '@/utils/subscription/planPricesForSubscriptionUi';
 import { useTranslation } from 'react-i18next';
+import { resolveQuantityFromInput } from '@/utils/subscription/quantityValidation';
+
+export { resolveQuantityFromInput };
 
 const DEFAULT_ROW_LIMIT = 5;
-
-/**
- * Resolves the committed quantity from a table-cell input string.
- * Falls back to `minQuantity` only when the input doesn't parse to a
- * number at all — a typed "0" must resolve to 0, not fall back.
- */
-export function resolveQuantityFromInput(value: string, minQuantity: number): number {
-	const parsed = parseInt(value, 10);
-	return Number.isNaN(parsed) ? minQuantity : parsed;
-}
 
 /**
  * Whether a price belongs in the table for the selected subscription billing period.
@@ -49,7 +42,9 @@ export function isPriceCompatibleWithBillingPeriod(
 	billingPeriod: string,
 	billingPeriodCount?: number,
 ): boolean {
-	return isOneTimePlanPrice(price) || isCadenceCompatible(billingPeriod, billingPeriodCount, price.billing_period, price.billing_period_count);
+	return (
+		isOneTimePlanPrice(price) || isCadenceCompatible(billingPeriod, billingPeriodCount, price.billing_period, price.billing_period_count)
+	);
 }
 
 type ChargeTableData = {
@@ -148,87 +143,6 @@ const PriceActionMenu: FC<PriceActionMenuProps> = ({
 					)}
 				</DropdownMenuContent>
 			</DropdownMenu>
-		</div>
-	);
-};
-
-interface PriceQuantityCellProps {
-	price: Price;
-	override?: ExtendedPriceOverride;
-	lineItemCoupon: Coupon | null | undefined;
-	quantityInput: string | undefined;
-	disabled: boolean;
-	/** Pass string to set transient input (including '' for empty); pass null to clear transient after commit. */
-	onQuantityChange: (value: string | null) => void;
-	onResetOverride: (priceId: string) => void;
-	onPriceOverride: (priceId: string, override: Partial<ExtendedPriceOverride>) => void;
-	onClearCoupon: (priceId: string) => void;
-}
-
-const PriceQuantityCell: FC<PriceQuantityCellProps> = ({
-	price,
-	override,
-	lineItemCoupon,
-	quantityInput,
-	disabled,
-	onQuantityChange,
-	onResetOverride,
-	onPriceOverride,
-	onClearCoupon,
-}) => {
-	const { t } = useTranslation('customers');
-	const minQuantity = price.min_quantity ?? 1;
-	const currentQuantity = override?.quantity ?? minQuantity;
-	const displayQuantity = quantityInput ?? currentQuantity.toString();
-
-	// Clear transient only when override was removed (e.g. Reset Override) so we show minQuantity.
-	// We do not clear when override.quantity matches quantityInput, to avoid clearing right after user types.
-	useEffect(() => {
-		if (override !== undefined || quantityInput == null || quantityInput === '') {
-			return;
-		}
-		onQuantityChange(null);
-	}, [override, quantityInput, onQuantityChange]);
-
-	if (price.type !== PRICE_TYPE.FIXED) {
-		return <>{t('organisms.subscriptionPriceTable.payAsYouGo')}</>;
-	}
-
-	return (
-		<div className='w-20' data-interactive='true'>
-			<DecimalUsageInput
-				value={displayQuantity}
-				onChange={(value) => {
-					if (value === '') {
-						onQuantityChange('');
-						return;
-					}
-					const quantity = resolveQuantityFromInput(value, minQuantity);
-
-					if (quantity === minQuantity) {
-						const onlyQuantityOverride =
-							override &&
-							((Object.keys(override).length === 1 && override.quantity !== undefined) ||
-								(Object.keys(override).length === 2 && override.price_id && override.quantity));
-						if (onlyQuantityOverride) {
-							onResetOverride(price.id);
-						} else if (override) {
-							const { quantity: _q, ...rest } = override;
-							onPriceOverride(price.id, rest);
-						}
-					} else {
-						if (lineItemCoupon) onClearCoupon(price.id);
-						onPriceOverride(price.id, { quantity });
-						// Keep transient value so display doesn't snap back before parent re-renders
-						onQuantityChange(quantity.toString());
-						return;
-					}
-					onQuantityChange(value === quantity.toString() ? null : value);
-				}}
-				placeholder={minQuantity.toString()}
-				disabled={disabled}
-				precision={0}
-			/>
 		</div>
 	);
 };

--- a/src/i18n/locales/ar/billing.json
+++ b/src/i18n/locales/ar/billing.json
@@ -424,9 +424,11 @@
 			"columns": {
 				"charge": "الرسم",
 				"type": "النوع",
+				"quantity": "الكمية",
 				"commitment": "الالتزام",
 				"price": "السعر"
 			},
+			"quantityUsage": "حسب الاستخدام",
 			"chargeFallback": "رسم",
 			"commitmentNotAvailable": "غير متاح",
 			"noDescription": "لا يوجد وصف",

--- a/src/i18n/locales/ar/common.json
+++ b/src/i18n/locales/ar/common.json
@@ -603,6 +603,8 @@
 		"addonRequired": "الإضافة مطلوبة",
 		"columnCharge": "الرسوم",
 		"columnType": "النوع",
+		"columnQuantity": "الكمية",
+		"quantityUsage": "حسب الاستخدام",
 		"columnCommitment": "الالتزام",
 		"notAvailable": "غير متاح",
 		"configure": "تهيئة",

--- a/src/i18n/locales/en/billing.json
+++ b/src/i18n/locales/en/billing.json
@@ -424,9 +424,11 @@
 			"columns": {
 				"charge": "Charge",
 				"type": "Type",
+				"quantity": "Quantity",
 				"commitment": "Commitment",
 				"price": "Price"
 			},
+			"quantityUsage": "pay as you go",
 			"chargeFallback": "Charge",
 			"commitmentNotAvailable": "Not available",
 			"noDescription": "No description",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -608,6 +608,8 @@
 		"addonRequired": "Addon is required",
 		"columnCharge": "Charge",
 		"columnType": "Type",
+		"columnQuantity": "Quantity",
+		"quantityUsage": "pay as you go",
 		"columnCommitment": "Commitment",
 		"notAvailable": "Not available",
 		"configure": "Configure",

--- a/src/pages/customer/customers/CreateCustomerSubscriptionPage.tsx
+++ b/src/pages/customer/customers/CreateCustomerSubscriptionPage.tsx
@@ -48,6 +48,7 @@ import { toSentenceCase } from '@/utils/common/helper_functions';
 import { ExtendedPriceOverride, getLineItemOverrides } from '@/utils/common/price_override_helpers';
 import { extractLineItemCommitments } from '@/utils/common/commitment_helpers';
 import { sanitizeAddonLineItemCommitmentsForApi, filterAddonPricesForSubscription } from '@/utils/subscription/addon_commitment_helpers';
+import { sanitizeAddonOverrideLineItemsForApi } from '@/utils/subscription/addonQuantity';
 import { extractSubscriptionBoundaries, extractFirstPhaseData } from '@/utils/subscription/phaseConversion';
 import { stripDisplayMeterFromLineItemRequest } from '@/utils/subscription/internalPriceToSubscriptionLineItemRequest';
 
@@ -677,9 +678,11 @@ const CreateCustomerSubscriptionPage: React.FC = () => {
 						// will actually be sent.
 						const prices = filterAddonPricesForSubscription(addonDetails?.prices as Price[] | undefined, billingPeriod, currency, 1);
 						const line_item_commitments = sanitizeAddonLineItemCommitmentsForApi(addon.line_item_commitments, prices);
+						const override_line_items = sanitizeAddonOverrideLineItemsForApi(addon.override_line_items, prices);
 						return {
 							...addon,
 							line_item_commitments,
+							override_line_items,
 						};
 					})
 				: undefined;

--- a/src/tests/subscriptions/subscriptionModifyPreviewPresentation.test.ts
+++ b/src/tests/subscriptions/subscriptionModifyPreviewPresentation.test.ts
@@ -165,7 +165,7 @@ describe('subscriptionModifyPreviewPresentation', () => {
 			expect(rows).toHaveLength(2);
 			expect(rows[0].kind).toBe('ended');
 			expect(rows[0].label).toBe('Ends');
-			expect(rows[0].quantityDisplay).toBe('—');
+			expect(rows[0].quantityDisplay).toBe('1');
 			expect(rows[1].kind).toBe('created');
 			expect(rows[1].label).toBe('New line');
 			expect(rows[1].quantityDisplay).toBe('45');

--- a/src/types/dto/Subscription.ts
+++ b/src/types/dto/Subscription.ts
@@ -435,8 +435,8 @@ export interface OverrideLineItemRequest {
 	// PriceID references the plan price to override
 	price_id: string;
 
-	// Quantity for this line item (optional)
-	quantity?: number;
+	// Quantity for this line item (optional). API expects a decimal string.
+	quantity?: number | string;
 
 	billing_model?: BILLING_MODEL;
 

--- a/src/utils/common/price_override_helpers.ts
+++ b/src/utils/common/price_override_helpers.ts
@@ -5,6 +5,7 @@ import { BUCKET_SIZE_NONE } from '@/constants/constants';
 import { LineItemCommitmentConfig } from '@/types/dto/LineItemCommitmentConfig';
 import type { CommitmentTimeBucket } from '@/types/dto/CommitmentTimeBucket';
 import type { OverrideLineItemRequest } from '@/types/dto/Subscription';
+import { parseNonNegativeQuantity } from '@/utils/subscription/quantityValidation';
 
 /**
  * Interface for line item overrides that will be sent to the backend
@@ -228,7 +229,7 @@ export const overrideLineItemsToMap = (items?: OverrideLineItemRequest[]): Recor
 		map[o.price_id] = {
 			price_id: o.price_id,
 			...(o.amount !== undefined ? { amount: String(o.amount) } : {}),
-			...(o.quantity !== undefined ? { quantity: o.quantity } : {}),
+			...(o.quantity !== undefined ? { quantity: parseNonNegativeQuantity(o.quantity) } : {}),
 			...(o.billing_model ? { billing_model: isSlab ? ('SLAB_TIERED' as const) : o.billing_model } : {}),
 			...(o.tier_mode && !isSlab ? { tier_mode: o.tier_mode } : {}),
 			...(o.tiers ? { tiers: o.tiers } : {}),

--- a/src/utils/subscription/addonQuantity.test.ts
+++ b/src/utils/subscription/addonQuantity.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import { PRICE_TYPE } from '@/models/Price';
+import type { Price } from '@/models/Price';
+import type { OverrideLineItemRequest } from '@/types/dto/Subscription';
+import { getLineItemOverrides } from '@/utils/common/price_override_helpers';
+import {
+	formatAddonQuantityDisplay,
+	getDefaultFixedPriceQuantity,
+	getResolvedFixedPriceQuantity,
+	sanitizeAddonOverrideLineItemsForApi,
+	sumFixedAddonRecurringTotal,
+} from './addonQuantity';
+
+const makePrice = (overrides: Partial<Price> & Pick<Price, 'id' | 'type'>): Price =>
+	({
+		amount: '10',
+		min_quantity: undefined,
+		...overrides,
+	}) as Price;
+
+describe('getDefaultFixedPriceQuantity', () => {
+	it('uses min_quantity when the FIXED price has one', () => {
+		expect(getDefaultFixedPriceQuantity(makePrice({ id: 'p1', type: PRICE_TYPE.FIXED, min_quantity: 3 }))).toBe(3);
+	});
+
+	it('defaults FIXED prices without min_quantity to 1', () => {
+		expect(getDefaultFixedPriceQuantity(makePrice({ id: 'p1', type: PRICE_TYPE.FIXED }))).toBe(1);
+	});
+
+	it('returns 0 for USAGE prices so quantity is never sent', () => {
+		expect(getDefaultFixedPriceQuantity(makePrice({ id: 'p1', type: PRICE_TYPE.USAGE, min_quantity: 5 }))).toBe(0);
+	});
+});
+
+describe('getResolvedFixedPriceQuantity', () => {
+	const fixed = makePrice({ id: 'p1', type: PRICE_TYPE.FIXED, min_quantity: 2 });
+
+	it('prefers an explicit numeric override, including zero', () => {
+		expect(getResolvedFixedPriceQuantity(fixed, 5)).toBe(5);
+		expect(getResolvedFixedPriceQuantity(fixed, 0)).toBe(0);
+	});
+
+	it('parses a decimal-string override', () => {
+		expect(getResolvedFixedPriceQuantity(fixed, '7')).toBe(7);
+	});
+
+	it('falls back to min_quantity when the override is missing or invalid', () => {
+		expect(getResolvedFixedPriceQuantity(fixed, undefined)).toBe(2);
+		expect(getResolvedFixedPriceQuantity(fixed, 'abc')).toBe(2);
+	});
+
+	it('returns 0 for USAGE even when an override is present', () => {
+		const usage = makePrice({ id: 'p1', type: PRICE_TYPE.USAGE });
+		expect(getResolvedFixedPriceQuantity(usage, 4)).toBe(0);
+	});
+});
+
+describe('formatAddonQuantityDisplay', () => {
+	it('shows the override quantity for a single FIXED price', () => {
+		const prices = [makePrice({ id: 'price_fixed', type: PRICE_TYPE.FIXED })];
+		expect(formatAddonQuantityDisplay(prices, [{ price_id: 'price_fixed', quantity: '5' }], 'pay as you go')).toBe('5');
+	});
+
+	it('prefills min_quantity when quantity is omitted', () => {
+		const prices = [makePrice({ id: 'price_fixed', type: PRICE_TYPE.FIXED, min_quantity: 3 })];
+		expect(formatAddonQuantityDisplay(prices, [], 'pay as you go')).toBe('3');
+	});
+
+	it('hides quantity for USAGE-only addons', () => {
+		const prices = [makePrice({ id: 'price_usage', type: PRICE_TYPE.USAGE })];
+		expect(formatAddonQuantityDisplay(prices, [{ price_id: 'price_usage', quantity: '5' }], 'pay as you go')).toBe('pay as you go');
+	});
+
+	it('joins distinct FIXED quantities', () => {
+		const prices = [makePrice({ id: 'a', type: PRICE_TYPE.FIXED }), makePrice({ id: 'b', type: PRICE_TYPE.FIXED, min_quantity: 2 })];
+		expect(
+			formatAddonQuantityDisplay(
+				prices,
+				[
+					{ price_id: 'a', quantity: '5' },
+					{ price_id: 'b', quantity: '2' },
+				],
+				'pay as you go',
+			),
+		).toBe('5, 2');
+	});
+});
+
+describe('sumFixedAddonRecurringTotal', () => {
+	it('multiplies unit amount by overridden quantity', () => {
+		const prices = [
+			makePrice({ id: 'fixed-1', type: PRICE_TYPE.FIXED, amount: '10' }),
+			makePrice({ id: 'usage-1', type: PRICE_TYPE.USAGE, amount: '99' }),
+		];
+
+		expect(sumFixedAddonRecurringTotal(prices, { 'fixed-1': { quantity: '5' } })).toBe(50);
+	});
+
+	it('uses min_quantity when quantity is omitted', () => {
+		const prices = [makePrice({ id: 'fixed-1', type: PRICE_TYPE.FIXED, amount: '4', min_quantity: 3 })];
+
+		expect(sumFixedAddonRecurringTotal(prices, {})).toBe(12);
+	});
+
+	it('uses an amount override when present', () => {
+		const prices = [makePrice({ id: 'fixed-1', type: PRICE_TYPE.FIXED, amount: '10' })];
+
+		expect(sumFixedAddonRecurringTotal(prices, { 'fixed-1': { amount: 8, quantity: 2 } })).toBe(16);
+	});
+});
+
+describe('sanitizeAddonOverrideLineItemsForApi', () => {
+	const fixed = makePrice({ id: 'price_fixed', type: PRICE_TYPE.FIXED });
+	const usage = makePrice({ id: 'price_usage', type: PRICE_TYPE.USAGE });
+
+	it('stringifies FIXED quantity and keeps the catalogue price_id', () => {
+		const items: OverrideLineItemRequest[] = [{ price_id: 'price_fixed', quantity: 5 }];
+
+		expect(sanitizeAddonOverrideLineItemsForApi(items, [fixed])).toEqual([{ price_id: 'price_fixed', quantity: '5' }]);
+	});
+
+	it('keeps quantity 0 for FIXED prices', () => {
+		const items: OverrideLineItemRequest[] = [{ price_id: 'price_fixed', quantity: 0 }];
+
+		expect(sanitizeAddonOverrideLineItemsForApi(items, [fixed])).toEqual([{ price_id: 'price_fixed', quantity: '0' }]);
+	});
+
+	it('drops quantity on USAGE prices', () => {
+		const items: OverrideLineItemRequest[] = [{ price_id: 'price_usage', quantity: 3 }];
+
+		expect(sanitizeAddonOverrideLineItemsForApi(items, [usage])).toBeUndefined();
+	});
+
+	it('keeps a USAGE override that still has another field after quantity is stripped', () => {
+		const items: OverrideLineItemRequest[] = [{ price_id: 'price_usage', quantity: 3, amount: 9 }];
+
+		expect(sanitizeAddonOverrideLineItemsForApi(items, [usage])).toEqual([{ price_id: 'price_usage', amount: 9 }]);
+	});
+
+	it('keeps the first entry when the same price_id is duplicated', () => {
+		const items: OverrideLineItemRequest[] = [
+			{ price_id: 'price_fixed', quantity: 2 },
+			{ price_id: 'price_fixed', quantity: 9 },
+		];
+
+		expect(sanitizeAddonOverrideLineItemsForApi(items, [fixed])).toEqual([{ price_id: 'price_fixed', quantity: '2' }]);
+	});
+
+	it('returns undefined when there are no overrides', () => {
+		expect(sanitizeAddonOverrideLineItemsForApi(undefined, [fixed])).toBeUndefined();
+		expect(sanitizeAddonOverrideLineItemsForApi([], [fixed])).toBeUndefined();
+	});
+
+	it('maps create-sub quantity through getLineItemOverrides into addons[].override_line_items', () => {
+		const items = getLineItemOverrides([fixed], {
+			price_fixed: { price_id: 'price_fixed', quantity: 5 },
+		});
+
+		expect(sanitizeAddonOverrideLineItemsForApi(items, [fixed])).toEqual([{ price_id: 'price_fixed', quantity: '5' }]);
+	});
+});

--- a/src/utils/subscription/addonQuantity.test.ts
+++ b/src/utils/subscription/addonQuantity.test.ts
@@ -4,11 +4,15 @@ import type { Price } from '@/models/Price';
 import type { OverrideLineItemRequest } from '@/types/dto/Subscription';
 import { getLineItemOverrides } from '@/utils/common/price_override_helpers';
 import {
+	attachedAddonLinesToDisplayInput,
+	formatAddonCharges,
 	formatAddonQuantityDisplay,
 	getDefaultFixedPriceQuantity,
 	getResolvedFixedPriceQuantity,
+	isAttachedAddonLineActive,
 	sanitizeAddonOverrideLineItemsForApi,
 	sumFixedAddonRecurringTotal,
+	type AttachedAddonChargeLine,
 } from './addonQuantity';
 
 const makePrice = (overrides: Partial<Price> & Pick<Price, 'id' | 'type'>): Price =>
@@ -86,6 +90,22 @@ describe('formatAddonQuantityDisplay', () => {
 	});
 });
 
+describe('formatAddonCharges', () => {
+	const labels = { empty: '--', dependsOnUsage: 'Depends on usage' };
+
+	it('formats quantity × unit charge the same way create-sub does', () => {
+		const prices = [makePrice({ id: 'fixed-1', type: PRICE_TYPE.FIXED, amount: '100', currency: 'usd' })];
+
+		expect(formatAddonCharges(prices, [{ price_id: 'fixed-1', quantity: '5' }], {}, [], labels)).toBe('$500.00');
+	});
+
+	it('returns the usage label when there is no FIXED price', () => {
+		const prices = [makePrice({ id: 'usage-1', type: PRICE_TYPE.USAGE, amount: '99', currency: 'usd' })];
+
+		expect(formatAddonCharges(prices, [], {}, [], labels)).toBe('Depends on usage');
+	});
+});
+
 describe('sumFixedAddonRecurringTotal', () => {
 	it('multiplies unit amount by overridden quantity', () => {
 		const prices = [
@@ -157,5 +177,67 @@ describe('sanitizeAddonOverrideLineItemsForApi', () => {
 		});
 
 		expect(sanitizeAddonOverrideLineItemsForApi(items, [fixed])).toEqual([{ price_id: 'price_fixed', quantity: '5' }]);
+	});
+});
+
+const now = new Date('2026-09-08T12:00:00Z');
+const fixedPrice = makePrice({ id: 'price_fixed', type: PRICE_TYPE.FIXED, amount: '100', currency: 'usd' });
+
+const activeLine: AttachedAddonChargeLine = {
+	priceType: PRICE_TYPE.FIXED,
+	quantity: 5,
+	unitAmount: 100,
+	startDate: '2026-01-01T00:00:00Z',
+	price: fixedPrice,
+};
+
+const upcomingLine: AttachedAddonChargeLine = {
+	priceType: PRICE_TYPE.FIXED,
+	quantity: 3,
+	unitAmount: 100,
+	startDate: '2026-10-01T00:00:00Z',
+	price: fixedPrice,
+};
+
+describe('isAttachedAddonLineActive', () => {
+	it('treats a started line without an end date as active', () => {
+		expect(isAttachedAddonLineActive(activeLine, now)).toBe(true);
+	});
+
+	it('treats a future start date as inactive', () => {
+		expect(isAttachedAddonLineActive(upcomingLine, now)).toBe(false);
+	});
+
+	it('treats an ended line as inactive', () => {
+		expect(isAttachedAddonLineActive({ ...activeLine, endDate: '2026-08-01T00:00:00Z' }, now)).toBe(false);
+	});
+});
+
+describe('attachedAddonLinesToDisplayInput', () => {
+	const labels = { empty: '--', dependsOnUsage: 'Depends on usage' };
+
+	it('maps active lines into the create-sub prices + override_line_items shape', () => {
+		const input = attachedAddonLinesToDisplayInput([activeLine, upcomingLine], now);
+
+		expect(input.overrideLineItems).toEqual([{ price_id: 'price_fixed', quantity: 5, amount: 100 }]);
+		expect(formatAddonQuantityDisplay(input.prices, input.overrideLineItems, 'pay as you go')).toBe('5');
+		expect(formatAddonCharges(input.prices, input.overrideLineItems, {}, [], labels)).toBe('$500.00');
+	});
+
+	it('falls back to upcoming FIXED quantity when no line is currently active', () => {
+		const input = attachedAddonLinesToDisplayInput([upcomingLine], now);
+
+		expect(input.overrideLineItems).toEqual([{ price_id: 'price_fixed', quantity: 3, amount: 100 }]);
+		expect(formatAddonQuantityDisplay(input.prices, input.overrideLineItems, 'pay as you go')).toBe('3');
+		expect(formatAddonCharges(input.prices, input.overrideLineItems, {}, [], labels)).toBe('$300.00');
+	});
+
+	it('keeps FIXED display when the embedded price is missing type', () => {
+		const untypedPrice = { ...fixedPrice, type: undefined } as unknown as typeof fixedPrice;
+		const line: AttachedAddonChargeLine = { ...upcomingLine, price: untypedPrice };
+		const input = attachedAddonLinesToDisplayInput([line], now);
+
+		expect(formatAddonQuantityDisplay(input.prices, input.overrideLineItems, 'pay as you go')).toBe('3');
+		expect(formatAddonCharges(input.prices, input.overrideLineItems, {}, [], labels)).toBe('$300.00');
 	});
 });

--- a/src/utils/subscription/addonQuantity.ts
+++ b/src/utils/subscription/addonQuantity.ts
@@ -1,5 +1,7 @@
 import { PRICE_TYPE, type Price } from '@/models/Price';
 import type { OverrideLineItemRequest } from '@/types/dto/Subscription';
+import { getTotalPayableTextWithCoupons } from '@/utils/common/helper_functions';
+import type { ExtendedPriceOverride } from '@/utils/common/price_override_helpers';
 import { parseNonNegativeQuantity } from './quantityValidation';
 
 type QuantityOverride = number | string | undefined;
@@ -35,6 +37,39 @@ export function formatAddonQuantityDisplay(prices: Price[], overrideLineItems: O
 
 	const overridesByPriceId = Object.fromEntries(overrideLineItems.map((item) => [item.price_id, item]));
 	return fixedPrices.map((price) => String(getResolvedFixedPriceQuantity(price, overridesByPriceId[price.id]?.quantity))).join(', ');
+}
+
+export type AddonChargeLabels = {
+	empty: string;
+	dependsOnUsage: string;
+};
+
+/** Shared Name/Quantity/Charges formatting used by create, edit, and overview addon tables. */
+export function formatAddonCharges(
+	prices: Price[] = [],
+	overrideLineItems: OverrideLineItemRequest[] = [],
+	priceOverrides: Record<string, ExtendedPriceOverride> = {},
+	coupons: { type: string; amount_off?: string; percentage_off?: string }[] = [],
+	labels: AddonChargeLabels,
+): string {
+	if (!prices || prices.length === 0) return labels.empty;
+
+	const recurringPrices = prices.filter((price) => price.type === PRICE_TYPE.FIXED);
+	const usagePrices = prices.filter((price) => price.type === PRICE_TYPE.USAGE);
+
+	if (recurringPrices.length === 0) {
+		return usagePrices.length > 0 ? labels.dependsOnUsage : labels.empty;
+	}
+
+	const fromLineItems = Object.fromEntries(
+		overrideLineItems.map((item) => [item.price_id, { quantity: item.quantity, amount: item.amount }]),
+	);
+	const fromPriceOverrides = Object.fromEntries(
+		Object.entries(priceOverrides).map(([id, override]) => [id, { quantity: override.quantity, amount: override.amount }]),
+	);
+	const recurringTotal = sumFixedAddonRecurringTotal(recurringPrices, { ...fromPriceOverrides, ...fromLineItems });
+
+	return getTotalPayableTextWithCoupons(recurringPrices, usagePrices, recurringTotal, coupons);
 }
 
 /** Unit amount × qty for FIXED addon prices. USAGE prices are ignored. */
@@ -98,4 +133,79 @@ export function sanitizeAddonOverrideLineItemsForApi(
 	}
 
 	return sanitized.length > 0 ? sanitized : undefined;
+}
+
+const DEFAULT_LINE_ITEM_END_DATE = '0001-01-01T00:00:00Z';
+
+/** Existing subscription addon line used for quantity / charges display (edit + overview). */
+export type AttachedAddonChargeLine = {
+	priceType: PRICE_TYPE;
+	quantity: number | string;
+	unitAmount: number;
+	startDate?: string;
+	endDate?: string;
+	price?: Price;
+};
+
+/** Same window as Charges-table ACTIVE: started and not ended. */
+export function isAttachedAddonLineActive(line: Pick<AttachedAddonChargeLine, 'startDate' | 'endDate'>, now: Date = new Date()): boolean {
+	if (line.startDate?.trim()) {
+		const start = new Date(line.startDate);
+		if (!isNaN(start.getTime()) && start > now) {
+			return false;
+		}
+	}
+	if (line.endDate?.trim() && line.endDate !== DEFAULT_LINE_ITEM_END_DATE) {
+		const end = new Date(line.endDate);
+		if (!isNaN(end.getTime()) && end < now) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function isAttachedAddonLineEnded(line: Pick<AttachedAddonChargeLine, 'endDate'>, now: Date): boolean {
+	if (line.endDate?.trim() && line.endDate !== DEFAULT_LINE_ITEM_END_DATE) {
+		const end = new Date(line.endDate);
+		return !isNaN(end.getTime()) && end < now;
+	}
+	return false;
+}
+
+function normalizeAttachedPrice(line: AttachedAddonChargeLine): Price | undefined {
+	if (!line.price) {
+		return undefined;
+	}
+	if (line.price.type) {
+		return line.price;
+	}
+	return { ...line.price, type: line.priceType };
+}
+
+/** Prefer active lines; if none, keep upcoming so qty 3 is not shown as "pay as you go". */
+export function attachedAddonLinesToDisplayInput(
+	lines: AttachedAddonChargeLine[],
+	now: Date = new Date(),
+): { prices: Price[]; overrideLineItems: OverrideLineItemRequest[] } {
+	const displayable = lines.filter((line) => line.price && !isAttachedAddonLineEnded(line, now));
+	const selected = displayable.filter((line) => isAttachedAddonLineActive(line, now));
+	const source = selected.length > 0 ? selected : displayable;
+
+	const prices: Price[] = [];
+	const overrideLineItems: OverrideLineItemRequest[] = [];
+
+	for (const line of source) {
+		const price = normalizeAttachedPrice(line);
+		if (!price) {
+			continue;
+		}
+		prices.push(price);
+		overrideLineItems.push({
+			price_id: price.id,
+			quantity: line.quantity,
+			amount: line.unitAmount,
+		});
+	}
+
+	return { prices, overrideLineItems };
 }

--- a/src/utils/subscription/addonQuantity.ts
+++ b/src/utils/subscription/addonQuantity.ts
@@ -1,0 +1,101 @@
+import { PRICE_TYPE, type Price } from '@/models/Price';
+import type { OverrideLineItemRequest } from '@/types/dto/Subscription';
+import { parseNonNegativeQuantity } from './quantityValidation';
+
+type QuantityOverride = number | string | undefined;
+
+export type AddonChargeOverride = {
+	quantity?: QuantityOverride;
+	amount?: number | string;
+};
+
+/** Catalogue default for a FIXED addon price: `min_quantity` or 1. USAGE never has a billed qty. */
+export function getDefaultFixedPriceQuantity(price: Pick<Price, 'type' | 'min_quantity'>): number {
+	if (price.type !== PRICE_TYPE.FIXED) {
+		return 0;
+	}
+	return price.min_quantity ?? 1;
+}
+
+/** Resolved FIXED qty for display / preview. USAGE always 0 so it cannot leak into totals. */
+export function getResolvedFixedPriceQuantity(price: Pick<Price, 'type' | 'min_quantity'>, overrideQuantity?: QuantityOverride): number {
+	if (price.type !== PRICE_TYPE.FIXED) {
+		return 0;
+	}
+	const parsed = parseNonNegativeQuantity(overrideQuantity);
+	return parsed !== undefined ? parsed : getDefaultFixedPriceQuantity(price);
+}
+
+/** Outer addons-table qty: FIXED resolved quantities, or the usage label when there is no FIXED price. */
+export function formatAddonQuantityDisplay(prices: Price[], overrideLineItems: OverrideLineItemRequest[] = [], usageLabel: string): string {
+	const fixedPrices = prices.filter((price) => price.type === PRICE_TYPE.FIXED);
+	if (fixedPrices.length === 0) {
+		return usageLabel;
+	}
+
+	const overridesByPriceId = Object.fromEntries(overrideLineItems.map((item) => [item.price_id, item]));
+	return fixedPrices.map((price) => String(getResolvedFixedPriceQuantity(price, overridesByPriceId[price.id]?.quantity))).join(', ');
+}
+
+/** Unit amount × qty for FIXED addon prices. USAGE prices are ignored. */
+export function sumFixedAddonRecurringTotal(prices: Price[], overridesByPriceId: Record<string, AddonChargeOverride>): number {
+	return prices
+		.filter((price) => price.type === PRICE_TYPE.FIXED)
+		.reduce((acc, price) => {
+			const override = overridesByPriceId[price.id];
+			const unitAmount = override?.amount !== undefined ? Number(override.amount) : parseFloat(price.amount);
+			const quantity = getResolvedFixedPriceQuantity(price, override?.quantity);
+			return acc + (Number.isFinite(unitAmount) ? unitAmount : 0) * quantity;
+		}, 0);
+}
+
+const hasRemainingOverrideField = (item: OverrideLineItemRequest): boolean =>
+	item.quantity !== undefined ||
+	item.amount !== undefined ||
+	item.billing_model !== undefined ||
+	item.tier_mode !== undefined ||
+	(item.tiers !== undefined && item.tiers.length > 0) ||
+	item.transform_quantity !== undefined ||
+	item.price_unit_amount !== undefined ||
+	(item.price_unit_tiers !== undefined && item.price_unit_tiers.length > 0) ||
+	item.bucket_size !== undefined;
+
+/**
+ * Prepare `addons[].override_line_items` for POST /subscriptions.
+ * Quantity is a decimal string; USAGE prices must not send quantity; duplicate price_ids are dropped.
+ */
+export function sanitizeAddonOverrideLineItemsForApi(
+	items: OverrideLineItemRequest[] | undefined,
+	prices: Price[],
+): OverrideLineItemRequest[] | undefined {
+	if (!items || items.length === 0) {
+		return undefined;
+	}
+
+	const pricesById = new Map(prices.map((price) => [price.id, price]));
+	const seen = new Set<string>();
+	const sanitized: OverrideLineItemRequest[] = [];
+
+	for (const item of items) {
+		if (seen.has(item.price_id)) {
+			continue;
+		}
+		seen.add(item.price_id);
+
+		const price = pricesById.get(item.price_id);
+		const next: OverrideLineItemRequest = { ...item };
+		const parsedQuantity = parseNonNegativeQuantity(item.quantity);
+
+		if (price?.type === PRICE_TYPE.USAGE || parsedQuantity === undefined) {
+			delete next.quantity;
+		} else {
+			next.quantity = String(parsedQuantity);
+		}
+
+		if (hasRemainingOverrideField(next)) {
+			sanitized.push(next);
+		}
+	}
+
+	return sanitized.length > 0 ? sanitized : undefined;
+}

--- a/src/utils/subscription/addon_commitment_helpers.ts
+++ b/src/utils/subscription/addon_commitment_helpers.ts
@@ -24,7 +24,9 @@ export function filterAddonPricesForSubscription(
 		filtered = filtered.filter((p) => p.currency?.toLowerCase() === currency.toLowerCase());
 	}
 	if (billingPeriod) {
-		filtered = filtered.filter((p) => isOneTimePlanPrice(p) || isCadenceCompatible(billingPeriod, billingPeriodCount, p.billing_period, p.billing_period_count));
+		filtered = filtered.filter(
+			(p) => isOneTimePlanPrice(p) || isCadenceCompatible(billingPeriod, billingPeriodCount, p.billing_period, p.billing_period_count),
+		);
 	}
 	return filtered;
 }

--- a/src/utils/subscription/quantityValidation.test.ts
+++ b/src/utils/subscription/quantityValidation.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from 'vitest';
-import { isValidNonNegativeQuantityString } from './quantityValidation';
+import { isValidNonNegativeQuantityString, parseNonNegativeQuantity } from './quantityValidation';
+
+describe('parseNonNegativeQuantity', () => {
+	it('parses numbers and decimal strings', () => {
+		expect(parseNonNegativeQuantity(5)).toBe(5);
+		expect(parseNonNegativeQuantity('7')).toBe(7);
+		expect(parseNonNegativeQuantity(0)).toBe(0);
+	});
+
+	it('returns undefined for missing or invalid values', () => {
+		expect(parseNonNegativeQuantity(undefined)).toBeUndefined();
+		expect(parseNonNegativeQuantity('')).toBeUndefined();
+		expect(parseNonNegativeQuantity('abc')).toBeUndefined();
+		expect(parseNonNegativeQuantity(-1)).toBeUndefined();
+	});
+});
 
 describe('isValidNonNegativeQuantityString', () => {
 	it('accepts zero', () => {

--- a/src/utils/subscription/quantityValidation.ts
+++ b/src/utils/subscription/quantityValidation.ts
@@ -1,3 +1,25 @@
+/** Coerce an API quantity (decimal string or number) into a UI number. */
+export function parseNonNegativeQuantity(value: number | string | undefined): number | undefined {
+	if (value === undefined || value === '') {
+		return undefined;
+	}
+	const n = typeof value === 'number' ? value : parseFloat(value);
+	if (!Number.isFinite(n) || n < 0) {
+		return undefined;
+	}
+	return n;
+}
+
+/**
+ * Resolves the committed quantity from a table-cell input string.
+ * Falls back to `minQuantity` only when the input doesn't parse to a
+ * number at all — a typed "0" must resolve to 0, not fall back.
+ */
+export function resolveQuantityFromInput(value: string, minQuantity: number): number {
+	const parsed = parseInt(value, 10);
+	return Number.isNaN(parsed) ? minQuantity : parsed;
+}
+
 /**
  * Validates a raw quantity input string (as typed in a form field).
  * Accepts 0 and any positive number; rejects negative numbers, empty

--- a/src/utils/subscription/subscriptionModifyPreviewPresentation.ts
+++ b/src/utils/subscription/subscriptionModifyPreviewPresentation.ts
@@ -208,7 +208,7 @@ export function buildLineItemChangeRows(lineItems: ChangedLineItem[]): LineItemC
 			case SUBSCRIPTION_MODIFY_LINE_ITEM_ACTION.UPDATED:
 				return { id: li.id, kind: 'updated', label: 'Updated', quantityDisplay: qty, periodDisplay };
 			case SUBSCRIPTION_MODIFY_LINE_ITEM_ACTION.ENDED:
-				return { id: li.id, kind: 'ended', label: 'Ends', quantityDisplay: '—', periodDisplay };
+				return { id: li.id, kind: 'ended', label: 'Ends', quantityDisplay: qty, periodDisplay };
 			default:
 				return { id: li.id, kind: 'other', label: 'Change', quantityDisplay: qty, periodDisplay };
 		}


### PR DESCRIPTION
<img width="2312" height="1374" alt="Screenshot 2026-09-08 at 6 08 55 PM" src="https://github.com/user-attachments/assets/94352fb6-db67-4148-9b75-fce018cdcef2" />
<img width="2044" height="1100" alt="Screenshot 2026-09-08 at 5 57 32 PM" src="https://github.com/user-attachments/assets/0387c779-7199-4b49-92e9-945cdeb65d73" />
<img width="2024" height="1242" alt="Screenshot 2026-09-08 at 5 56 29 PM" src="https://github.com/user-attachments/assets/a8ac32bb-b60f-41e1-8ffa-9d5e537d34b0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quantity editing and reset controls for fixed-price subscription add-ons.
  * Added quantity displays for add-on charges, including “pay as you go” labels for usage-based pricing.
  * Updated recurring totals to reflect selected quantities and price overrides.
  * Add-on details now reflect quantities from active subscription line items.
* **Bug Fixes**
  * Improved validation and handling of decimal, zero, missing, and invalid quantities.
  * Ended subscription line items now display their actual quantities.
* **Localization**
  * Added English and Arabic translations for quantity-related labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->