### PR TITLE
feat(pricing): Percentage Fee billing model for usage and fixed charges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2658,33 +2658,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-focus-scope": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
@@ -3708,33 +3681,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-focus-scope": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
@@ -3823,33 +3769,6 @@
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4324,33 +4243,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-focus-scope": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
@@ -4608,33 +4500,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-portal": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
@@ -4718,24 +4583,6 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
-      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-callback-ref": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     ]
   },
   "overrides": {
+    "@radix-ui/react-dismissable-layer": "1.1.19",
     "@storybook/addon-actions": {
       "uuid": "^11.1.1"
     },

--- a/src/components/molecules/PriceOverrideDialog/PriceOverrideDialog.tsx
+++ b/src/components/molecules/PriceOverrideDialog/PriceOverrideDialog.tsx
@@ -10,6 +10,8 @@ import { BUCKET_SIZE_NONE, priceBucketSizeOptions } from '@/constants/constants'
 import { ExtendedPriceOverride } from '@/utils/common/price_override_helpers';
 import VolumeTieredPricingForm from '@/components/organisms/PlanForm/VolumeTieredPricingForm';
 import { PremiumFeatureIcon } from '../PremiumFeature/PremiumFeature';
+import { decimalAmountToPercentage, isPercentagePrice, percentageToDecimalAmount } from '@/utils/common/percentage_price_helpers';
+import { formatPercentageAmount } from '@/utils/common/price_helpers';
 import { useTranslation } from 'react-i18next';
 import type { LineItem } from '@/models/Subscription';
 import type { UpdateSubscriptionLineItemRequest } from '@/types/dto/Subscription';
@@ -40,6 +42,13 @@ interface Props {
 	onLineItemUpdate?: (updateData: UpdateSubscriptionLineItemRequest) => void | Promise<void>;
 	isSaving?: boolean;
 }
+
+/**
+ * Seeds the amount field from a stored amount. A percentage charge stores the decimal equivalent
+ * ("0.025"), so the field has to show the percentage it stands for ("2.5") instead.
+ */
+const toAmountFieldValue = (stored: string | undefined, asPercentage: boolean): string =>
+	asPercentage ? decimalAmountToPercentage(stored || '') : (stored ?? '');
 
 const PriceOverrideDialog: FC<Props> = ({
 	isOpen,
@@ -114,6 +123,18 @@ const PriceOverrideDialog: FC<Props> = ({
 	// Detect price unit type
 	const isCustomPriceUnit = price.price_unit_type === PRICE_UNIT_TYPE.CUSTOM;
 
+	// A percentage charge is a FLAT_FEE tagged in the price's metadata. An override can't change that
+	// metadata, so the amount field only reads as a percentage while the model stays on the price's
+	// own - switching to PACKAGE/TIERED here makes the override a plain currency-priced charge.
+	const isPercentage = isPercentagePrice(price);
+	const showAsPercentage = isPercentage && overrideBillingModel === price.billing_model;
+
+	/** Strips input formatting and, while the field reads as a percentage, converts 2.5 -> "0.025". */
+	const resolveStoredAmount = (value: string): string => {
+		const raw = removeFormatting(value);
+		return showAsPercentage ? percentageToDecimalAmount(raw) : raw;
+	};
+
 	// Check if this price is currently overridden
 	useEffect(() => {
 		const currentOverride = overriddenPrices[price.id];
@@ -123,10 +144,15 @@ const PriceOverrideDialog: FC<Props> = ({
 		if (isCurrentlyOverridden) {
 			// Initialize from override or original price based on price unit type
 			if (isCustomPriceUnit) {
-				setOverrideAmount(currentOverride.price_unit_amount || price.price_unit_amount || price.price_unit_config?.amount || '');
+				setOverrideAmount(
+					toAmountFieldValue(
+						currentOverride.price_unit_amount || price.price_unit_amount || price.price_unit_config?.amount || '',
+						isPercentage,
+					),
+				);
 				setOverrideTiers(currentOverride.price_unit_tiers || price.price_unit_tiers || []);
 			} else {
-				setOverrideAmount(currentOverride.amount || price.amount);
+				setOverrideAmount(toAmountFieldValue(currentOverride.amount || price.amount, isPercentage));
 				setOverrideTiers(currentOverride.tiers || price.tiers || []);
 			}
 			setOverrideQuantity(currentOverride.quantity);
@@ -150,7 +176,7 @@ const PriceOverrideDialog: FC<Props> = ({
 			// Initialize amount and tiers based on price unit type
 			if (isCustomPriceUnit) {
 				const initialAmount = price.price_unit_amount || price.price_unit_config?.amount || '';
-				setOverrideAmount(initialAmount);
+				setOverrideAmount(toAmountFieldValue(initialAmount, isPercentage));
 
 				// Initialize with original price_unit_tiers if they exist, otherwise start with one default tier
 				if (price.price_unit_tiers && price.price_unit_tiers.length > 0) {
@@ -172,7 +198,7 @@ const PriceOverrideDialog: FC<Props> = ({
 					]);
 				}
 			} else {
-				setOverrideAmount(price.amount);
+				setOverrideAmount(toAmountFieldValue(price.amount, isPercentage));
 
 				// Initialize with original tiers if they exist, otherwise start with one default tier
 				if (price.tiers && price.tiers.length > 0) {
@@ -217,6 +243,7 @@ const PriceOverrideDialog: FC<Props> = ({
 		price.bucket_size,
 		showEffectiveFrom,
 		isCustomPriceUnit,
+		isPercentage,
 	]);
 
 	const buildPriceOverride = (): Partial<ExtendedPriceOverride> => {
@@ -224,16 +251,17 @@ const PriceOverrideDialog: FC<Props> = ({
 
 		// Handle amount/price_unit_amount based on price unit type and billing model
 		if (overrideBillingModel !== BILLING_MODEL.TIERED && overrideBillingModel !== 'SLAB_TIERED') {
+			const enteredAmount = overrideAmount ? resolveStoredAmount(overrideAmount) : '';
 			if (isCustomPriceUnit) {
 				// For CUSTOM prices, use price_unit_amount
 				const originalAmount = price.price_unit_amount || price.price_unit_config?.amount || '';
-				if (overrideAmount && removeFormatting(overrideAmount) !== originalAmount) {
-					override.price_unit_amount = removeFormatting(overrideAmount);
+				if (enteredAmount && enteredAmount !== originalAmount) {
+					override.price_unit_amount = enteredAmount;
 				}
 			} else {
 				// For FIAT prices, use amount
-				if (overrideAmount && removeFormatting(overrideAmount) !== price.amount) {
-					override.amount = removeFormatting(overrideAmount);
+				if (enteredAmount && enteredAmount !== price.amount) {
+					override.amount = enteredAmount;
 				}
 			}
 		}
@@ -336,7 +364,7 @@ const PriceOverrideDialog: FC<Props> = ({
 
 		// Reset amount and tiers based on price unit type
 		if (isCustomPriceUnit) {
-			setOverrideAmount(price.price_unit_amount || price.price_unit_config?.amount || '');
+			setOverrideAmount(toAmountFieldValue(price.price_unit_amount || price.price_unit_config?.amount || '', isPercentage));
 			if (price.price_unit_tiers && price.price_unit_tiers.length > 0) {
 				setOverrideTiers(
 					price.price_unit_tiers.map((tier) => ({
@@ -355,7 +383,7 @@ const PriceOverrideDialog: FC<Props> = ({
 				]);
 			}
 		} else {
-			setOverrideAmount(price.amount);
+			setOverrideAmount(toAmountFieldValue(price.amount, isPercentage));
 			if (price.tiers && price.tiers.length > 0) {
 				setOverrideTiers(
 					price.tiers.map((tier) => ({
@@ -389,10 +417,15 @@ const PriceOverrideDialog: FC<Props> = ({
 		if (currentOverride) {
 			// Restore from override based on price unit type
 			if (isCustomPriceUnit) {
-				setOverrideAmount(currentOverride.price_unit_amount || price.price_unit_amount || price.price_unit_config?.amount || '');
+				setOverrideAmount(
+					toAmountFieldValue(
+						currentOverride.price_unit_amount || price.price_unit_amount || price.price_unit_config?.amount || '',
+						isPercentage,
+					),
+				);
 				setOverrideTiers(currentOverride.price_unit_tiers || price.price_unit_tiers || []);
 			} else {
-				setOverrideAmount(currentOverride.amount || price.amount);
+				setOverrideAmount(toAmountFieldValue(currentOverride.amount || price.amount, isPercentage));
 				setOverrideTiers(currentOverride.tiers || price.tiers || []);
 			}
 			setOverrideQuantity(currentOverride.quantity);
@@ -409,7 +442,7 @@ const PriceOverrideDialog: FC<Props> = ({
 		} else {
 			// Reset to original values based on price unit type
 			if (isCustomPriceUnit) {
-				setOverrideAmount(price.price_unit_amount || price.price_unit_config?.amount || '');
+				setOverrideAmount(toAmountFieldValue(price.price_unit_amount || price.price_unit_config?.amount || '', isPercentage));
 				if (price.price_unit_tiers && price.price_unit_tiers.length > 0) {
 					setOverrideTiers(
 						price.price_unit_tiers.map((tier) => ({
@@ -428,7 +461,7 @@ const PriceOverrideDialog: FC<Props> = ({
 					]);
 				}
 			} else {
-				setOverrideAmount(price.amount);
+				setOverrideAmount(toAmountFieldValue(price.amount, isPercentage));
 				if (price.tiers && price.tiers.length > 0) {
 					setOverrideTiers(
 						price.tiers.map((tier) => ({
@@ -481,9 +514,9 @@ const PriceOverrideDialog: FC<Props> = ({
 		let amountChanged: boolean;
 		if (isCustomPriceUnit) {
 			const originalAmount = price.price_unit_amount || price.price_unit_config?.amount || '';
-			amountChanged = !!(overrideAmount && removeFormatting(overrideAmount) !== originalAmount);
+			amountChanged = !!(overrideAmount && resolveStoredAmount(overrideAmount) !== originalAmount);
 		} else {
-			amountChanged = !!(overrideAmount && removeFormatting(overrideAmount) !== price.amount);
+			amountChanged = !!(overrideAmount && resolveStoredAmount(overrideAmount) !== price.amount);
 		}
 
 		// Compare tiers/price_unit_tiers based on price unit type
@@ -552,6 +585,7 @@ const PriceOverrideDialog: FC<Props> = ({
 
 	const originalFormatted = formatAmount(getDisplayAmount());
 	const displaySymbol = getDisplaySymbol();
+	const originalPriceDisplay = isPercentage ? formatPercentageAmount(getDisplayAmount()) : `${displaySymbol}${originalFormatted}`;
 	const chargeDisplayName = price.meter?.name || price.description || t('priceDialogs.thisChargeFallback');
 
 	const handleDialogOpenChange = (open: boolean) => {
@@ -576,10 +610,7 @@ const PriceOverrideDialog: FC<Props> = ({
 					{/* Original Price Display */}
 					<div className='flex items-center justify-between p-3 bg-surface-subtle rounded-lg'>
 						<div className='text-sm text-content-tertiary'>{t('priceDialogs.originalPrice')}</div>
-						<div className='font-medium'>
-							{displaySymbol}
-							{originalFormatted}
-						</div>
+						<div className='font-medium'>{originalPriceDisplay}</div>
 					</div>
 
 					{/* Billing Model Override - Only show for USAGE price types */}
@@ -614,14 +645,16 @@ const PriceOverrideDialog: FC<Props> = ({
 					{overrideBillingModel !== BILLING_MODEL.TIERED && overrideBillingModel !== 'SLAB_TIERED' && (
 						<div className='space-y-2'>
 							<label className='text-sm font-medium text-content-secondary'>
-								{t('priceDialogs.overrideAmountLabel', { unit: isCustomPriceUnit ? displaySymbol : price.currency })}
+								{showAsPercentage
+									? t('priceDialogs.overridePercentageLabel')
+									: t('priceDialogs.overrideAmountLabel', { unit: isCustomPriceUnit ? displaySymbol : price.currency })}
 							</label>
 							<Input
 								type='formatted-number'
 								value={overrideAmount}
 								onChange={setOverrideAmount}
-								placeholder={t('priceDialogs.enterNewAmountOptional')}
-								suffix={displaySymbol}
+								placeholder={showAsPercentage ? t('priceDialogs.enterNewPercentageOptional') : t('priceDialogs.enterNewAmountOptional')}
+								suffix={showAsPercentage ? '%' : displaySymbol}
 								className='w-full'
 							/>
 						</div>

--- a/src/components/molecules/PricingCard/PricingCard.tsx
+++ b/src/components/molecules/PricingCard/PricingCard.tsx
@@ -12,6 +12,7 @@ import { PlanType } from '@/constants/planTypes';
 import { cn } from '@/lib/utils';
 import { PRICE_TYPE } from '@/models/Price';
 import { normalizeCardProps } from '@/pricing/schema';
+import { formatPercentageAmount } from '@/utils/common/price_helpers';
 import { JsonObject } from '@/types/common';
 export interface UsageCharge {
 	amount?: string;
@@ -25,6 +26,11 @@ export interface UsageCharge {
 	}> | null;
 	matter_name?: string;
 	meter_name?: string;
+	/**
+	 * Set when the charge is a percentage fee: `amount` holds the decimal equivalent ("0.025") and is
+	 * rendered as the percentage it stands for, with no currency symbol and no per-unit suffix.
+	 */
+	is_percentage?: boolean;
 }
 
 export interface PricingCardProps {
@@ -37,6 +43,8 @@ export interface PricingCardProps {
 		billingPeriod?: string;
 		type?: PRICE_TYPE;
 		displayType: PlanType;
+		/** See {@link UsageCharge.is_percentage}. */
+		is_percentage?: boolean;
 	};
 	usageCharges?: UsageCharge[];
 	entitlements: Array<{
@@ -133,6 +141,9 @@ const formatEntitlementValue = ({
 const formatUsageCharge = (charge: UsageCharge, t: TFunction<'common'>) => {
 	if (!charge.amount) return '';
 
+	// A percentage fee prices the metered value itself, so "per unit"/"per package" don't apply.
+	if (charge.is_percentage) return formatPercentageAmount(charge.amount);
+
 	const sym = getCurrencySymbol(charge.currency || '');
 	const amt = `${sym}${formatAmount(charge.amount)}`;
 
@@ -150,6 +161,7 @@ const formatUsageCharge = (charge: UsageCharge, t: TFunction<'common'>) => {
 /** Compact usage line for AI pricing preview (/unit instead of per unit). */
 const formatUsageChargeCompact = (charge: UsageCharge, t: TFunction<'common'>) => {
 	if (!charge.amount) return '';
+	if (charge.is_percentage) return formatPercentageAmount(charge.amount);
 	const sym = getCurrencySymbol(charge.currency || '');
 	const amt = formatAmount(charge.amount);
 	if (charge.billing_model === 'PACKAGE') {
@@ -292,7 +304,11 @@ const PricingCard: React.FC<PricingCardProps> = (rawProps) => {
 
 	// Fall back to FIXED chrome when displayType is missing/invalid so `config` is never undefined.
 	const config = priceDisplayConfig[price.displayType] ?? priceDisplayConfig[PlanType.FIXED];
-	const displayAmount = config.text || `${getCurrencySymbol(price.currency || '')}${formatAmount(price.amount || '')}`;
+	const displayAmount =
+		config.text ||
+		(price.is_percentage
+			? formatPercentageAmount(price.amount || '')
+			: `${getCurrencySymbol(price.currency || '')}${formatAmount(price.amount || '')}`);
 	const hasUsageCharges = usageCharges.length > 0;
 
 	const chargeLimit = isSetupPreview ? usageCharges.length : VISIBLE_LIMIT;

--- a/src/components/molecules/UpdatePriceDialog/UpdatePriceDialog.tsx
+++ b/src/components/molecules/UpdatePriceDialog/UpdatePriceDialog.tsx
@@ -14,6 +14,16 @@ import { BUCKET_SIZE_NONE, priceBucketSizeOptions } from '@/constants/constants'
 import { formatDateTimeWithSecondsAndTimezone } from '@/utils/common/format_date';
 import { PremiumFeatureIcon } from '../PremiumFeature/PremiumFeature';
 import { useMeterForCommitment } from '@/hooks/useMeterForCommitment';
+import {
+	PERCENTAGE_BILLING_MODEL,
+	PercentageBillingModel,
+	decimalAmountToPercentage,
+	isPercentagePrice,
+	percentageToDecimalAmount,
+	withPercentageMetadata,
+	withoutPercentageMetadata,
+} from '@/utils/common/percentage_price_helpers';
+import { formatPercentageAmount } from '@/utils/common/price_helpers';
 import { useTranslation } from 'react-i18next';
 
 interface UpdatePriceDialogProps {
@@ -33,13 +43,20 @@ const UpdatePriceDialog: FC<UpdatePriceDialogProps> = ({ isOpen, onOpenChange, p
 			{ label: t('priceDialogs.billingModels.package'), value: BILLING_MODEL.PACKAGE },
 			{ label: t('priceDialogs.billingModels.volumeTiered'), value: BILLING_MODEL.TIERED },
 			{ label: t('priceDialogs.billingModels.slabTiered'), value: 'SLAB_TIERED' },
+			{ label: t('priceDialogs.billingModels.percentageFee'), value: PERCENTAGE_BILLING_MODEL },
 		],
 		[t],
 	);
 
+	// A percentage charge is a FLAT_FEE tagged in metadata; the dialog works in whole percentages and
+	// converts back to the stored decimal on save.
+	const isPercentage = isPercentagePrice(price);
+
 	const [overrideAmount, setOverrideAmount] = useState('');
 	const [overrideQuantity, setOverrideQuantity] = useState<number | undefined>(undefined);
-	const [overrideBillingModel, setOverrideBillingModel] = useState<BILLING_MODEL | 'SLAB_TIERED'>(price.billing_model);
+	const [overrideBillingModel, setOverrideBillingModel] = useState<BILLING_MODEL | 'SLAB_TIERED' | PercentageBillingModel>(
+		isPercentage ? PERCENTAGE_BILLING_MODEL : price.billing_model,
+	);
 	const [overrideTierMode, setOverrideTierMode] = useState<TIER_MODE>(price.tier_mode || TIER_MODE.VOLUME);
 	const [overrideTiers, setOverrideTiers] = useState<CreatePriceTier[]>([]);
 	const [overrideTransformQuantity, setOverrideTransformQuantity] = useState<TransformQuantity>({
@@ -62,7 +79,7 @@ const UpdatePriceDialog: FC<UpdatePriceDialogProps> = ({ isOpen, onOpenChange, p
 	useEffect(() => {
 		if (isOpen) {
 			setOverrideQuantity(1);
-			setOverrideBillingModel(price.billing_model);
+			setOverrideBillingModel(isPercentage ? PERCENTAGE_BILLING_MODEL : price.billing_model);
 			setOverrideTierMode(price.tier_mode || TIER_MODE.VOLUME);
 
 			// Initialize amount and tiers based on price unit type
@@ -90,7 +107,7 @@ const UpdatePriceDialog: FC<UpdatePriceDialogProps> = ({ isOpen, onOpenChange, p
 				}
 			} else {
 				// For FIAT prices, use amount and tiers
-				setOverrideAmount(price.amount);
+				setOverrideAmount(isPercentage ? decimalAmountToPercentage(price.amount || '') : price.amount);
 
 				if (price.tiers && price.tiers.length > 0) {
 					setOverrideTiers(
@@ -115,7 +132,7 @@ const UpdatePriceDialog: FC<UpdatePriceDialogProps> = ({ isOpen, onOpenChange, p
 			setEffectiveFrom(undefined);
 			setOverrideBucketSize((price.bucket_size as PriceBucketSize | undefined) ?? '');
 		}
-	}, [isOpen, price, isCustomPriceUnit]);
+	}, [isOpen, price, isCustomPriceUnit, isPercentage]);
 
 	const { mutateAsync: updatePrice, isPending: isUpdatingPrice } = useMutation({
 		mutationFn: async ({ priceId, data }: { priceId: string; data: UpdatePriceRequest }) => {
@@ -128,31 +145,45 @@ const UpdatePriceDialog: FC<UpdatePriceDialogProps> = ({ isOpen, onOpenChange, p
 
 	const isLoading = isUpdatingPrice;
 
+	/** Strips input formatting and, for the percentage model, converts 2.5 -> "0.025" for storage. */
+	const resolveStoredAmount = (value: string, asPercentage: boolean): string => {
+		const raw = removeFormatting(value);
+		return asPercentage ? percentageToDecimalAmount(raw) : raw;
+	};
+
 	const handleUpdate = async () => {
 		const updateData: UpdatePriceRequest = {};
+		const willBePercentage = overrideBillingModel === PERCENTAGE_BILLING_MODEL;
 
 		// Handle amount/price_unit_amount based on price unit type and billing model
 		if (overrideBillingModel !== BILLING_MODEL.TIERED && overrideBillingModel !== 'SLAB_TIERED') {
+			// The field holds a percentage while that model is selected - store the decimal equivalent.
+			const enteredAmount = overrideAmount ? resolveStoredAmount(overrideAmount, willBePercentage) : '';
 			if (isCustomPriceUnit) {
 				// For CUSTOM prices, use price_unit_amount
 				const originalAmount = price.price_unit_amount || price.price_unit_config?.amount || '';
-				if (overrideAmount && removeFormatting(overrideAmount) !== originalAmount) {
-					updateData.price_unit_amount = removeFormatting(overrideAmount);
+				if (enteredAmount && enteredAmount !== originalAmount) {
+					updateData.price_unit_amount = enteredAmount;
 				}
 			} else {
 				// For FIAT prices, use amount
-				if (overrideAmount && removeFormatting(overrideAmount) !== price.amount) {
-					updateData.amount = removeFormatting(overrideAmount);
+				if (enteredAmount && enteredAmount !== price.amount) {
+					updateData.amount = enteredAmount;
 				}
 			}
 		}
 
-		// Billing model override
-		if (overrideBillingModel !== price.billing_model) {
-			if (overrideBillingModel === 'SLAB_TIERED') {
+		// Billing model override. Percentage is a UI-only model stored as FLAT_FEE, so the marker in
+		// metadata - added or removed - is what actually records the switch.
+		if (willBePercentage !== isPercentage) {
+			updateData.metadata = willBePercentage ? withPercentageMetadata(price.metadata) : (withoutPercentageMetadata(price.metadata) ?? {});
+		}
+		const resolvedBillingModel = willBePercentage ? BILLING_MODEL.FLAT_FEE : overrideBillingModel;
+		if (resolvedBillingModel !== price.billing_model) {
+			if (resolvedBillingModel === 'SLAB_TIERED') {
 				updateData.billing_model = BILLING_MODEL.TIERED;
 			} else {
-				updateData.billing_model = overrideBillingModel as BILLING_MODEL;
+				updateData.billing_model = resolvedBillingModel as BILLING_MODEL;
 			}
 		}
 
@@ -213,7 +244,7 @@ const UpdatePriceDialog: FC<UpdatePriceDialogProps> = ({ isOpen, onOpenChange, p
 	};
 
 	const hasChanges = () => {
-		const originalBillingModel = price.billing_model;
+		const originalBillingModel = isPercentage ? PERCENTAGE_BILLING_MODEL : price.billing_model;
 		const originalTierMode = price.tier_mode || TIER_MODE.VOLUME;
 
 		let billingModelChanged: boolean;
@@ -230,12 +261,13 @@ const UpdatePriceDialog: FC<UpdatePriceDialogProps> = ({ isOpen, onOpenChange, p
 		}
 
 		// Compare amount/price_unit_amount based on price unit type
+		const enteredAmount = overrideAmount ? resolveStoredAmount(overrideAmount, overrideBillingModel === PERCENTAGE_BILLING_MODEL) : '';
 		let amountChanged: boolean;
 		if (isCustomPriceUnit) {
 			const originalAmount = price.price_unit_amount || price.price_unit_config?.amount || '';
-			amountChanged = !!(overrideAmount && removeFormatting(overrideAmount) !== originalAmount);
+			amountChanged = !!(enteredAmount && enteredAmount !== originalAmount);
 		} else {
-			amountChanged = !!(overrideAmount && removeFormatting(overrideAmount) !== price.amount);
+			amountChanged = !!(enteredAmount && enteredAmount !== price.amount);
 		}
 
 		// Compare tiers/price_unit_tiers based on price unit type
@@ -306,6 +338,9 @@ const UpdatePriceDialog: FC<UpdatePriceDialogProps> = ({ isOpen, onOpenChange, p
 
 	const originalFormatted = formatAmount(getDisplayAmount());
 	const displaySymbol = getDisplaySymbol();
+	// Percentage charges show "2.5%" and drop the currency symbol; the input carries a % suffix too.
+	const showAsPercentage = overrideBillingModel === PERCENTAGE_BILLING_MODEL;
+	const originalPriceDisplay = isPercentage ? formatPercentageAmount(getDisplayAmount()) : `${displaySymbol}${originalFormatted}`;
 	const chargeDisplayName = price.meter?.name || price.description || t('priceDialogs.thisChargeFallback');
 
 	return (
@@ -324,10 +359,7 @@ const UpdatePriceDialog: FC<UpdatePriceDialogProps> = ({ isOpen, onOpenChange, p
 				<div className='space-y-4'>
 					<div className='flex items-center justify-between p-3 bg-surface-subtle rounded-lg'>
 						<div className='text-sm text-content-tertiary'>{t('priceDialogs.originalPrice')}</div>
-						<div className='font-medium'>
-							{displaySymbol}
-							{originalFormatted}
-						</div>
+						<div className='font-medium'>{originalPriceDisplay}</div>
 					</div>
 
 					{price.type === PRICE_TYPE.USAGE && (
@@ -359,14 +391,16 @@ const UpdatePriceDialog: FC<UpdatePriceDialogProps> = ({ isOpen, onOpenChange, p
 					{overrideBillingModel !== BILLING_MODEL.TIERED && overrideBillingModel !== 'SLAB_TIERED' && (
 						<div className='space-y-2'>
 							<label className='text-sm font-medium text-content-secondary'>
-								{t('priceDialogs.overrideAmountLabel', { unit: isCustomPriceUnit ? displaySymbol : price.currency })}
+								{showAsPercentage
+									? t('priceDialogs.overridePercentageLabel')
+									: t('priceDialogs.overrideAmountLabel', { unit: isCustomPriceUnit ? displaySymbol : price.currency })}
 							</label>
 							<Input
 								type='formatted-number'
 								value={overrideAmount}
 								onChange={setOverrideAmount}
-								placeholder={t('priceDialogs.enterNewAmountOptional')}
-								suffix={displaySymbol}
+								placeholder={showAsPercentage ? t('priceDialogs.enterNewPercentageOptional') : t('priceDialogs.enterNewAmountOptional')}
+								suffix={showAsPercentage ? '%' : displaySymbol}
 								className='w-full'
 							/>
 						</div>

--- a/src/components/organisms/PlanForm/RecurringChargePreview.tsx
+++ b/src/components/organisms/PlanForm/RecurringChargePreview.tsx
@@ -8,6 +8,7 @@ import { Pencil } from 'lucide-react';
 import { InternalPrice } from './SetupChargesSection';
 import { formatAmount } from '@/components/atoms/Input/Input';
 import { ChargeValueCell } from '@/components/molecules';
+import { isPercentagePrice } from '@/utils/common/percentage_price_helpers';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
@@ -49,9 +50,10 @@ const RecurringChargePreview: FC<Props> = ({ charge, onEditClicked, onDeleteClic
 	const displayCurrency =
 		charge.price_unit_type === PRICE_UNIT_TYPE.CUSTOM ? charge.price_unit_config?.price_unit || charge.currency : charge.currency;
 
-	// Flat fee charges render a simple "amount / period" string; package and tiered charges
-	// reuse ChargeValueCell, which knows how to format package sizes and tier summaries.
-	const isFlatFee = !charge.billing_model || charge.billing_model === BILLING_MODEL.FLAT_FEE;
+	// Flat fee charges render a simple "amount / period" string; package, tiered and percentage
+	// charges reuse ChargeValueCell, which knows how to format package sizes, tier summaries, and the
+	// percentage a flat-fee amount stands for.
+	const isFlatFee = (!charge.billing_model || charge.billing_model === BILLING_MODEL.FLAT_FEE) && !isPercentagePrice(charge);
 
 	return (
 		<div className='gap-2 w-full flex justify-between group min-h-9 items-center rounded-md border bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground hover:bg-surface-subtle transition-colors mb-2'>

--- a/src/components/organisms/PlanForm/RecurringChargesForm.tsx
+++ b/src/components/organisms/PlanForm/RecurringChargesForm.tsx
@@ -19,6 +19,14 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { Calculator } from 'lucide-react';
 import { SubscriptionCalculatorContent } from '@/components/organisms/EntityChargesPage/SubscriptionCalculator';
 import { toast } from 'react-hot-toast';
+import {
+	PERCENTAGE_BILLING_MODEL,
+	decimalAmountToPercentage,
+	isPercentagePrice,
+	percentageToDecimalAmount,
+	withPercentageMetadata,
+	withoutPercentageMetadata,
+} from '@/utils/common/percentage_price_helpers';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
@@ -57,13 +65,28 @@ function mapStoredTiersToFormTiers(tiers: StoredPriceTier[]): PriceTier[] {
 	});
 }
 
+/**
+ * The selector value for a price: PERCENTAGE for a flat fee tagged as percentage in metadata,
+ * otherwise the price's own billing model.
+ */
+function resolveBillingModelSelection(price: Partial<InternalPrice>): string {
+	return isPercentagePrice(price) ? PERCENTAGE_BILLING_MODEL : price.billing_model || BILLING_MODEL.FLAT_FEE;
+}
+
 function syncBillingModelFormStateFromPrice(
 	price: Partial<InternalPrice>,
 	setBillingModel: (value: string) => void,
 	setPackagedFee: (value: { unit: string; price: string }) => void,
 	setTieredPrices: (value: PriceTier[]) => void,
+	setPercentageFee: (value: string) => void,
 ) {
-	setBillingModel(price.billing_model || BILLING_MODEL.FLAT_FEE);
+	setBillingModel(resolveBillingModelSelection(price));
+
+	if (isPercentagePrice(price)) {
+		// Stored as the decimal equivalent - show the user the percentage they entered.
+		setPercentageFee(decimalAmountToPercentage(price.amount || ''));
+		return;
+	}
 
 	if (price.billing_model === BILLING_MODEL.PACKAGE) {
 		const packageAmount = price.amount ?? price.price_unit_config?.amount ?? '';
@@ -115,13 +138,16 @@ const RecurringChargesForm = ({
 
 	// Billing-model-specific state. `billingModel` holds the selector value which may be the
 	// frontend-only 'SLAB_TIERED' option (maps to TIERED with SLAB tier_mode on submit).
-	const [billingModel, setBillingModel] = useState<string>(price.billing_model || BILLING_MODEL.FLAT_FEE);
+	const [billingModel, setBillingModel] = useState<string>(() => resolveBillingModelSelection(price));
+	const [percentageFee, setPercentageFee] = useState<string>(() =>
+		isPercentagePrice(price) ? decimalAmountToPercentage(price.amount || '') : '',
+	);
 	const [packagedFee, setPackagedFee] = useState<{ unit: string; price: string }>({
 		unit: price.transform_quantity?.divide_by?.toString() || '',
 		price: price.billing_model === BILLING_MODEL.PACKAGE ? price.amount || '' : '',
 	});
 	const [tieredPrices, setTieredPrices] = useState<PriceTier[]>(getDefaultTiers);
-	const [modelErrors, setModelErrors] = useState({ packagedModelError: '', tieredModelError: '' });
+	const [modelErrors, setModelErrors] = useState({ packagedModelError: '', tieredModelError: '', percentageModelError: '' });
 
 	// Hydrate form when editing an existing charge (avoid resetting in-progress new charge edits)
 	useEffect(() => {
@@ -154,12 +180,15 @@ const RecurringChargesForm = ({
 			return updated;
 		});
 
-		syncBillingModelFormStateFromPrice(price, setBillingModel, setPackagedFee, setTieredPrices);
+		syncBillingModelFormStateFromPrice(price, setBillingModel, setPackagedFee, setTieredPrices, setPercentageFee);
 	}, [price, entityName]);
 
 	const isPackage = billingModel === BILLING_MODEL.PACKAGE;
 	const isTiered = billingModel === BILLING_MODEL.TIERED || billingModel === 'SLAB_TIERED';
 	const isFlatFee = billingModel === BILLING_MODEL.FLAT_FEE;
+	// Percentage Fee is a selector-only model: persisted as FLAT_FEE with the decimal equivalent of the
+	// entered percentage (5 -> "0.05") plus a metadata marker, so it reads back as a percentage.
+	const isPercentage = billingModel === PERCENTAGE_BILLING_MODEL;
 	const isCustomUnit = localPrice.price_unit_type === PRICE_UNIT_TYPE.CUSTOM;
 
 	// Get the current currency/price unit value for the selector
@@ -203,7 +232,7 @@ const RecurringChargesForm = ({
 
 	const validate = () => {
 		const newErrors: Partial<Record<keyof InternalPrice, string>> = {};
-		const newModelErrors = { packagedModelError: '', tieredModelError: '' };
+		const newModelErrors = { packagedModelError: '', tieredModelError: '', percentageModelError: '' };
 
 		if (!localPrice.billing_period) {
 			newErrors.billing_period = 'Billing Period is required';
@@ -223,6 +252,17 @@ const RecurringChargesForm = ({
 
 		if (isFlatFee && !localPrice.amount) {
 			newErrors.amount = 'Price is required';
+		}
+
+		if (isPercentage) {
+			if (percentageFee.trim() === '') {
+				newModelErrors.percentageModelError = 'Percentage is required';
+			} else {
+				const percentageAmount = parseFloat(percentageFee);
+				if (isNaN(percentageAmount) || percentageAmount < 0) {
+					newModelErrors.percentageModelError = 'Percentage must be a valid number greater than or equal to 0';
+				}
+			}
 		}
 
 		if (isPackage) {
@@ -272,7 +312,7 @@ const RecurringChargesForm = ({
 		setErrors(newErrors);
 		setModelErrors(newModelErrors);
 
-		const modelError = newModelErrors.packagedModelError || newModelErrors.tieredModelError;
+		const modelError = newModelErrors.packagedModelError || newModelErrors.tieredModelError || newModelErrors.percentageModelError;
 		if (modelError) toast.error(modelError);
 
 		return Object.keys(newErrors).length === 0 && !modelError;
@@ -281,10 +321,16 @@ const RecurringChargesForm = ({
 	const handleSubmit = () => {
 		if (!validate()) return;
 
-		const resolvedBillingModel = isTiered ? BILLING_MODEL.TIERED : (billingModel as BILLING_MODEL);
+		const resolvedBillingModel = isTiered ? BILLING_MODEL.TIERED : isPercentage ? BILLING_MODEL.FLAT_FEE : (billingModel as BILLING_MODEL);
 
 		// Build the per-model amount / transform_quantity / tiers for FIAT prices
-		const amount = isFlatFee ? localPrice.amount : isPackage ? packagedFee.price : undefined;
+		const amount = isFlatFee
+			? localPrice.amount
+			: isPercentage
+				? percentageToDecimalAmount(percentageFee)
+				: isPackage
+					? packagedFee.price
+					: undefined;
 		const transformQuantity = isPackage ? { divide_by: Number(packagedFee.unit) } : undefined;
 		const tiers = isTiered
 			? (tieredPrices.map((tier) => ({
@@ -299,8 +345,8 @@ const RecurringChargesForm = ({
 		// Build price_unit_config for custom price units based on billing model
 		let priceUnitConfig = localPrice.price_unit_config;
 		if (isCustomUnit && localPrice.price_unit_config) {
-			if (isFlatFee) {
-				priceUnitConfig = { ...localPrice.price_unit_config, amount: localPrice.amount };
+			if (isFlatFee || isPercentage) {
+				priceUnitConfig = { ...localPrice.price_unit_config, amount };
 			} else if (isPackage) {
 				priceUnitConfig = { ...localPrice.price_unit_config, amount: packagedFee.price };
 			} else if (isTiered) {
@@ -322,6 +368,9 @@ const RecurringChargesForm = ({
 			...baseLocalPrice,
 			type: localPrice.type ?? PRICE_TYPE.FIXED,
 			billing_model: resolvedBillingModel,
+			// Set explicitly (not just when percentage) so switching an existing percentage charge to
+			// another billing model drops the marker instead of inheriting it from the spread above.
+			metadata: isPercentage ? withPercentageMetadata(localPrice.metadata) : withoutPercentageMetadata(localPrice.metadata),
 			price_unit_config: priceUnitConfig,
 			entity_type: entityType,
 			entity_id: entityId || '',
@@ -426,6 +475,25 @@ const RecurringChargesForm = ({
 						</div>
 					}
 				/>
+			)}
+
+			{isPercentage && (
+				<div className='space-y-1'>
+					<Input
+						onChange={(value) => {
+							const decimalRegex = /^\d*\.?\d*$/;
+							if (decimalRegex.test(value) || value === '') {
+								setPercentageFee(value);
+							}
+						}}
+						value={percentageFee}
+						variant='formatted-number'
+						label={t('catalog:plans.organisms.priceForm.price')}
+						placeholder={t('catalog:plans.organisms.usageForm.percentagePlaceholder')}
+						error={modelErrors.percentageModelError}
+						suffix={<span className='text-content-slate-muted'>%</span>}
+					/>
+				</div>
 			)}
 
 			{isPackage && (

--- a/src/components/organisms/PlanForm/UsagePricingForm.tsx
+++ b/src/components/organisms/PlanForm/UsagePricingForm.tsx
@@ -22,6 +22,14 @@ import { ENTITY_STATUS } from '@/models/base';
 import { CurrencyPriceUnitSelector } from '@/components/molecules';
 import { CurrencyPriceUnitSelection, isPriceUnitOption } from '@/types/common';
 import { useMeterForCommitment } from '@/hooks/useMeterForCommitment';
+import {
+	PERCENTAGE_BILLING_MODEL,
+	decimalAmountToPercentage,
+	isPercentagePrice,
+	percentageToDecimalAmount,
+	withPercentageMetadata,
+	withoutPercentageMetadata,
+} from '@/utils/common/percentage_price_helpers';
 import { useTranslation } from 'react-i18next';
 
 /**
@@ -103,7 +111,19 @@ export const billingModels: SelectOption[] = [
 		label: 'Slab Tiered',
 		description: 'Tiers apply progressively as quantity increases.',
 	}, // Maps to TIERED with SLAB tier_mode
+	{
+		value: PERCENTAGE_BILLING_MODEL,
+		label: 'Percentage Fee',
+		description: 'Charge a percentage of the billable value.',
+	}, // Maps to FLAT_FEE with the decimal equivalent + a percentage metadata marker
 ];
+
+/**
+ * The selector value for a price: PERCENTAGE for a flat fee tagged as percentage in metadata,
+ * otherwise the price's own billing model.
+ */
+const resolveBillingModelSelection = (price: Partial<InternalPrice>): string =>
+	isPercentagePrice(price) ? PERCENTAGE_BILLING_MODEL : price.billing_model || billingModels[0].value;
 
 // ONETIME isn't offered for usage charges (they're inherently metered/recurring), but older prices
 // may still have it saved — fall back to MONTHLY rather than leaving the Select without a matching option.
@@ -126,7 +146,7 @@ const UsagePricingForm: FC<Props> = ({
 	const [currency, setCurrency] = useState(price.currency || currencyOptions[0].value);
 	const [priceUnitType, setPriceUnitType] = useState<PRICE_UNIT_TYPE>(price.price_unit_type || PRICE_UNIT_TYPE.FIAT);
 	const [priceUnitConfig, setPriceUnitConfig] = useState(price.price_unit_config);
-	const [billingModel, setBillingModel] = useState(price.billing_model || billingModels[0].value);
+	const [billingModel, setBillingModel] = useState<string>(() => resolveBillingModelSelection(price));
 	const [selectedFeature, setSelectedFeature] = useState<Feature | undefined>(undefined);
 	const [groupId, setGroupId] = useState<string | undefined>(price.group_id);
 	const [displayName, setDisplayName] = useState<string>(price.display_name || '');
@@ -135,7 +155,9 @@ const UsagePricingForm: FC<Props> = ({
 		{ from: 1, up_to: null, unit_amount: '', flat_amount: '0' },
 	]);
 	const [billingPeriod, setBillingPeriod] = useState(normalizeUsageBillingPeriod(price.billing_period));
-	const [flatFee, setFlatFee] = useState<string>(price.amount || '');
+	const isInitiallyPercentage = isPercentagePrice(price);
+	const [flatFee, setFlatFee] = useState<string>(isInitiallyPercentage ? '' : price.amount || '');
+	const [percentageFee, setPercentageFee] = useState<string>(isInitiallyPercentage ? decimalAmountToPercentage(price.amount || '') : '');
 	const [packagedFee, setPackagedFee] = useState<{ unit: string; price: string }>({
 		unit: '',
 		price: '',
@@ -156,6 +178,7 @@ const UsagePricingForm: FC<Props> = ({
 		flatModelError: '',
 		packagedModelError: '',
 		tieredModelError: '',
+		percentageModelError: '',
 	});
 
 	// Query to find feature by meter_id when editing
@@ -211,14 +234,17 @@ const UsagePricingForm: FC<Props> = ({
 			setCurrency(price.currency || currencyOptions[0].value);
 			setPriceUnitType(price.price_unit_type || PRICE_UNIT_TYPE.FIAT);
 			setPriceUnitConfig(price.price_unit_config);
-			setBillingModel(price.billing_model || billingModels[0].value);
+			setBillingModel(resolveBillingModelSelection(price));
 			// Set display_name from price or feature name (will be set when feature is loaded)
 			setDisplayName(price.display_name || '');
 			setBillingPeriod(normalizeUsageBillingPeriod(price.billing_period));
 			setStartDate(price.start_date ? new Date(price.start_date) : undefined);
 			setBucketSize((price.bucket_size as PriceBucketSize | undefined) ?? '');
 
-			if (price.billing_model === BILLING_MODEL.FLAT_FEE) {
+			if (isPercentagePrice(price)) {
+				// Stored as the decimal equivalent - show the user the percentage they entered.
+				setPercentageFee(decimalAmountToPercentage(price.amount || ''));
+			} else if (price.billing_model === BILLING_MODEL.FLAT_FEE) {
 				setFlatFee(price.amount || '');
 			} else if (price.billing_model === BILLING_MODEL.PACKAGE) {
 				setPackagedFee({
@@ -263,6 +289,7 @@ const UsagePricingForm: FC<Props> = ({
 			flatModelError: '',
 			packagedModelError: '',
 			tieredModelError: '',
+			percentageModelError: '',
 		});
 
 		if (!selectedFeature?.meter_id) {
@@ -383,6 +410,20 @@ const UsagePricingForm: FC<Props> = ({
 			}
 		}
 
+		// Percentage validation
+		if (billingModel === PERCENTAGE_BILLING_MODEL) {
+			if (!percentageFee || percentageFee.trim() === '') {
+				setInputErrors((prev) => ({ ...prev, percentageModelError: 'Percentage is required' }));
+				return false;
+			}
+
+			const percentageAmount = parseFloat(percentageFee);
+			if (isNaN(percentageAmount) || percentageAmount < 0) {
+				setInputErrors((prev) => ({ ...prev, percentageModelError: 'Percentage must be a valid number greater than or equal to 0' }));
+				return false;
+			}
+		}
+
 		return true;
 	};
 
@@ -397,14 +438,22 @@ const UsagePricingForm: FC<Props> = ({
 	const handleSubmit = () => {
 		if (!validate()) return;
 
+		// Percentage is a UI-only billing model: the backend stores it as a FLAT_FEE whose amount is
+		// the decimal equivalent of what the user typed (5 -> "0.05"), with a metadata marker so the
+		// charge reads back as a percentage. Everything below treats it exactly like a flat fee apart
+		// from the amount conversion and that marker.
+		const isPercentage = billingModel === PERCENTAGE_BILLING_MODEL;
+		const isFlatFeeLike = billingModel === billingModels[0].value || isPercentage;
+		const flatFeeAmount = isPercentage ? percentageToDecimalAmount(percentageFee) : flatFee;
+
 		// Build price_unit_config for custom price units based on billing model
 		let finalPriceUnitConfig = priceUnitConfig;
 		if (priceUnitType === PRICE_UNIT_TYPE.CUSTOM && priceUnitConfig) {
-			if (billingModel === billingModels[0].value) {
+			if (isFlatFeeLike) {
 				// FLAT_FEE: Set amount in price_unit_config
 				finalPriceUnitConfig = {
 					...priceUnitConfig,
-					amount: flatFee,
+					amount: flatFeeAmount,
 				};
 			} else if (billingModel === billingModels[1].value) {
 				// PACKAGE: Set amount in price_unit_config
@@ -432,7 +481,10 @@ const UsagePricingForm: FC<Props> = ({
 			price_unit_type: priceUnitType,
 			price_unit_config: finalPriceUnitConfig,
 			billing_period: billingPeriod,
-			billing_model: billingModel as BILLING_MODEL,
+			billing_model: (isPercentage ? BILLING_MODEL.FLAT_FEE : billingModel) as BILLING_MODEL,
+			// Set explicitly (not just when percentage) so switching an existing percentage charge to
+			// another billing model drops the marker instead of inheriting it from the spread below.
+			metadata: isPercentage ? withPercentageMetadata(price.metadata) : withoutPercentageMetadata(price.metadata),
 			type: PRICE_TYPE.USAGE,
 			billing_period_count: 1,
 			invoice_cadence: INVOICE_CADENCE.ARREAR,
@@ -446,11 +498,11 @@ const UsagePricingForm: FC<Props> = ({
 
 		let finalPrice: Partial<Price>;
 
-		if (billingModel === billingModels[0].value) {
+		if (isFlatFeeLike) {
 			// FLAT_FEE: For FIAT, set amount directly; for CUSTOM, amount is in price_unit_config
 			finalPrice = {
 				...basePrice,
-				...(priceUnitType === PRICE_UNIT_TYPE.FIAT ? { amount: flatFee } : {}),
+				...(priceUnitType === PRICE_UNIT_TYPE.FIAT ? { amount: flatFeeAmount } : {}),
 			};
 		} else if (billingModel === billingModels[1].value) {
 			// PACKAGE: For FIAT, set amount directly; for CUSTOM, amount is in price_unit_config
@@ -624,6 +676,26 @@ const UsagePricingForm: FC<Props> = ({
 							}
 						}}
 						suffix={<span className='text-content-slate-muted'>{`/ unit / ${formatBillingPeriodForPrice(billingPeriod)}`}</span>}
+					/>
+				</div>
+			)}
+
+			{billingModel === PERCENTAGE_BILLING_MODEL && (
+				<div className='space-y-2'>
+					<Input
+						placeholder={t('catalog:plans.organisms.usageForm.percentagePlaceholder')}
+						variant='formatted-number'
+						error={inputErrors.percentageModelError}
+						label={t('catalog:plans.organisms.priceForm.price')}
+						value={percentageFee}
+						onChange={(e) => {
+							// Validate decimal input
+							const decimalRegex = /^\d*\.?\d*$/;
+							if (decimalRegex.test(e) || e === '') {
+								setPercentageFee(e);
+							}
+						}}
+						suffix={<span className='text-content-slate-muted'>%</span>}
 					/>
 				</div>
 			)}

--- a/src/components/organisms/Subscription/PriceOverrideSummary.tsx
+++ b/src/components/organisms/Subscription/PriceOverrideSummary.tsx
@@ -3,6 +3,8 @@ import { Price, PRICE_UNIT_TYPE } from '@/models/Price';
 import { SubscriptionLineItemOverrideRequest } from '@/utils/common/price_override_helpers';
 import { formatAmount } from '@/components/atoms/Input/Input';
 import { getCurrencySymbol } from '@/utils/common/helper_functions';
+import { isPercentagePrice } from '@/utils/common/percentage_price_helpers';
+import { formatPercentageAmount } from '@/utils/common/price_helpers';
 import { Check } from 'lucide-react';
 import { Card } from '@/components/atoms';
 import { useTranslation } from 'react-i18next';
@@ -36,21 +38,21 @@ const PriceOverrideSummary: FC<Props> = ({ overrides, prices, className }) => {
 		const descriptions: string[] = [];
 		const isCustomPriceUnit = price.price_unit_type === PRICE_UNIT_TYPE.CUSTOM;
 		const displaySymbol = getDisplaySymbol(price);
+		// A percentage charge stores the decimal equivalent - both sides of the arrow read as
+		// percentages, with no currency symbol.
+		const isPercentage = isPercentagePrice(price);
+		const formatMoney = (amount: string) => (isPercentage ? formatPercentageAmount(amount) : `${displaySymbol}${formatAmount(amount)}`);
 
 		// Handle amount/price_unit_amount based on price unit type
 		if (isCustomPriceUnit) {
 			// For CUSTOM prices, use price_unit_amount
 			if (override.price_unit_amount !== undefined) {
-				const originalAmount = formatAmount(getDisplayAmount(price));
-				const newAmount = formatAmount(override.price_unit_amount);
-				descriptions.push(`Amount: ${displaySymbol}${originalAmount} → ${displaySymbol}${newAmount}`);
+				descriptions.push(`Amount: ${formatMoney(getDisplayAmount(price))} → ${formatMoney(override.price_unit_amount)}`);
 			}
 		} else {
 			// For FIAT prices, use amount
 			if (override.amount !== undefined) {
-				const originalAmount = formatAmount(price.amount);
-				const newAmount = formatAmount(override.amount.toString());
-				descriptions.push(`Amount: ${displaySymbol}${originalAmount} → ${displaySymbol}${newAmount}`);
+				descriptions.push(`Amount: ${formatMoney(price.amount)} → ${formatMoney(override.amount.toString())}`);
 			}
 		}
 

--- a/src/components/organisms/Subscription/SubscriptionPriceTable.tsx
+++ b/src/components/organisms/Subscription/SubscriptionPriceTable.tsx
@@ -18,6 +18,8 @@ import { LineItemCommitmentConfig } from '@/types/dto/LineItemCommitmentConfig';
 import type { CommitmentTimeBucket } from '@/types/dto/CommitmentTimeBucket';
 import type { AddedSubscriptionLineItem } from './AddSubscriptionChargeDialog';
 import { getCurrencySymbol, copyToClipboard, getBucketSizeLabel } from '@/utils/common/helper_functions';
+import { formatPercentageAmount } from '@/utils/common/price_helpers';
+import { isPercentagePrice } from '@/utils/common/percentage_price_helpers';
 import { formatBillingPeriodForPrice } from '@/utils/common/helper_functions';
 import { resolveBucketSize } from '@/utils/common/commitment_helpers';
 import { formatAmount } from '@/components/atoms/Input/Input';
@@ -49,7 +51,9 @@ export function isPriceCompatibleWithBillingPeriod(
 	billingPeriod: string,
 	billingPeriodCount?: number,
 ): boolean {
-	return isOneTimePlanPrice(price) || isCadenceCompatible(billingPeriod, billingPeriodCount, price.billing_period, price.billing_period_count);
+	return (
+		isOneTimePlanPrice(price) || isCadenceCompatible(billingPeriod, billingPeriodCount, price.billing_period, price.billing_period_count)
+	);
 }
 
 type ChargeTableData = {
@@ -266,12 +270,15 @@ export interface Props {
 function formatAddedLineItemPrice(item: AddedSubscriptionLineItem, fallbackCurrency?: string): string {
 	const p = item.price;
 	if (!p) return '--';
+	const amount = p.amount ?? p.price_unit_config?.amount ?? '0';
+	// A percentage charge is stored as a flat fee whose amount is the decimal equivalent - render the
+	// percentage it stands for, with no currency symbol and no billing-period suffix.
+	if (isPercentagePrice(p)) return formatPercentageAmount(amount);
 	const currency =
 		p.price_unit_type === PRICE_UNIT_TYPE.CUSTOM
 			? p.price_unit_config?.price_unit
 			: ((p as { currency?: string }).currency ?? fallbackCurrency);
 	const symbol = currency ? getCurrencySymbol(currency) : '';
-	const amount = p.amount ?? p.price_unit_config?.amount ?? '0';
 	const period = p.billing_period ? formatBillingPeriodForPrice(p.billing_period) : '';
 	return `${symbol}${formatAmount(amount)}${period ? ` / ${period}` : ''}`;
 }

--- a/src/i18n/locales/ar/catalog.json
+++ b/src/i18n/locales/ar/catalog.json
@@ -500,6 +500,7 @@
 				"selectBillingPeriod": "اختر فترة الفوترة",
 				"per": "لكل",
 				"amountPlaceholder": "0.00",
+				"percentagePlaceholder": "0",
 				"bucketSize": "حجم الدفعة (اختياري)",
 				"bucketSizeNone": "بدون تجميع",
 				"bucketSizePlaceholder": "بدون تجميع",
@@ -1037,7 +1038,8 @@
 			"flatFee": "رسوم ثابتة",
 			"package": "حزمة",
 			"volumeTiered": "شرائح حجمية",
-			"slabTiered": "شرائح طبقية"
+			"slabTiered": "شرائح طبقية",
+			"percentageFee": "رسوم بنسبة مئوية"
 		},
 		"originalPrice": "السعر الأصلي",
 		"billingModel": "نموذج الفوترة",
@@ -1069,6 +1071,8 @@
 		"failedUpdateToast": "فشل تحديث السعر",
 		"toastScheduled": "سيسري {{name}} اعتبارًا من {{date}}.",
 		"toastUpdated": "تم تحديث {{name}} بنجاح.",
-		"fallbackPriceName": "سعر"
+		"fallbackPriceName": "سعر",
+		"overridePercentageLabel": "تجاوز النسبة المئوية",
+		"enterNewPercentageOptional": "أدخل نسبة مئوية جديدة (اختياري)"
 	}
 }

--- a/src/i18n/locales/en/catalog.json
+++ b/src/i18n/locales/en/catalog.json
@@ -502,6 +502,7 @@
 				"selectBillingPeriod": "Select The Billing Period",
 				"per": "per",
 				"amountPlaceholder": "0.00",
+				"percentagePlaceholder": "0",
 				"bucketSize": "Bucket Size (Optional)",
 				"bucketSizeNone": "No bucketing",
 				"bucketSizePlaceholder": "No bucketing",
@@ -1055,7 +1056,8 @@
 			"flatFee": "Flat Fee",
 			"package": "Package",
 			"volumeTiered": "Volume Tiered",
-			"slabTiered": "Slab Tiered"
+			"slabTiered": "Slab Tiered",
+			"percentageFee": "Percentage Fee"
 		},
 		"originalPrice": "Original Price",
 		"billingModel": "Billing Model",
@@ -1087,6 +1089,8 @@
 		"failedUpdateToast": "Failed to update price",
 		"toastScheduled": "{{name}} will be effective from {{date}}.",
 		"toastUpdated": "{{name}} has been updated successfully.",
-		"fallbackPriceName": "Price"
+		"fallbackPriceName": "Price",
+		"overridePercentageLabel": "Override percentage",
+		"enterNewPercentageOptional": "Enter new percentage (optional)"
 	}
 }

--- a/src/pricing/adapters.ts
+++ b/src/pricing/adapters.ts
@@ -9,6 +9,7 @@ import { Price, BILLING_PERIOD, INVOICE_CADENCE, PRICE_TYPE, CREDIT_GRANT_CADENC
 import { PlanType } from '@/constants/planTypes';
 import { billlingPeriodOptions } from '@/constants/constants';
 import type { Plan, PricingOption } from './types';
+import { isPercentagePrice } from '@/utils/common/percentage_price_helpers';
 
 export type PlanWithData = PlanResponse & { prices: PriceResponse[]; entitlements: EntitlementResponse[] };
 
@@ -16,7 +17,7 @@ export type PlanWithData = PlanResponse & { prices: PriceResponse[]; entitlement
 // so a real PriceResponse (or PlanWithData['prices'][number]) is assignable without any cast.
 type PriceLike = Pick<
 	PriceResponse,
-	'currency' | 'billing_period' | 'billing_model' | 'type' | 'amount' | 'tiers' | 'meter' | 'invoice_cadence'
+	'currency' | 'billing_period' | 'billing_model' | 'type' | 'amount' | 'tiers' | 'meter' | 'invoice_cadence' | 'metadata'
 >;
 
 export const parseAmount = (amount: string | undefined): number => {
@@ -200,6 +201,8 @@ export function adaptPlanToCard(plan: PlanWithData, grants: CreditGrant[]): Plan
 				amount: price.amount,
 				currency: price.currency,
 				billing_model: price.billing_model,
+				// The card has no access to price metadata, so resolve the percentage marker here.
+				is_percentage: isPercentagePrice(price),
 				// price.tiers is Tier[] | null; UsageCharge.tiers is non-nullable and Tier structurally
 				// matches its element (up_to widens to number | null), so assert the Tier[] shape here.
 				tiers: price.tiers as Tier[],
@@ -221,6 +224,7 @@ export function adaptPlanToCard(plan: PlanWithData, grants: CreditGrant[]): Plan
 			billingPeriod: displayPrice?.billing_period,
 			type: displayPrice?.type,
 			displayType,
+			is_percentage: displayPrice ? isPercentagePrice(displayPrice) : false,
 		},
 		usageCharges,
 		entitlements:

--- a/src/utils/common/index.ts
+++ b/src/utils/common/index.ts
@@ -16,8 +16,22 @@ export {
 	formatPriceDisplay,
 	getBillingModelLabel,
 	getTierModeLabel,
+	formatPercentageAmount,
 } from './price_helpers';
 export type { NormalizedPriceDisplay } from './price_helpers';
+export {
+	PERCENTAGE_BILLING_MODEL,
+	PERCENTAGE_METADATA_KEY,
+	PERCENTAGE_METADATA_VALUE,
+	shiftDecimalString,
+	percentageToDecimalAmount,
+	decimalAmountToPercentage,
+	isPercentageMetadata,
+	isPercentagePrice,
+	withPercentageMetadata,
+	withoutPercentageMetadata,
+} from './percentage_price_helpers';
+export type { PercentageBillingModel } from './percentage_price_helpers';
 export { default as formatCouponName } from './format_coupon_name';
 export type { ExtendedPriceOverride } from './price_override_helpers';
 export {

--- a/src/utils/common/percentage_price_helpers.test.ts
+++ b/src/utils/common/percentage_price_helpers.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+	PERCENTAGE_BILLING_MODEL,
+	decimalAmountToPercentage,
+	isPercentageMetadata,
+	isPercentagePrice,
+	percentageToDecimalAmount,
+	shiftDecimalString,
+	withPercentageMetadata,
+	withoutPercentageMetadata,
+} from './percentage_price_helpers';
+import { BILLING_MODEL } from '@/models/Price';
+
+describe('percentageToDecimalAmount', () => {
+	it('converts the percentages from the spec', () => {
+		expect(percentageToDecimalAmount('5')).toBe('0.05');
+		expect(percentageToDecimalAmount('10')).toBe('0.1');
+		expect(percentageToDecimalAmount('2.5')).toBe('0.025');
+	});
+
+	it('is exact where floating-point division is not', () => {
+		// 1.1 / 100 === 0.011000000000000001
+		expect(percentageToDecimalAmount('1.1')).toBe('0.011');
+		expect(percentageToDecimalAmount('0.07')).toBe('0.0007');
+	});
+
+	it('handles whole, zero and high percentages', () => {
+		expect(percentageToDecimalAmount('100')).toBe('1');
+		expect(percentageToDecimalAmount('0')).toBe('0');
+		expect(percentageToDecimalAmount('150')).toBe('1.5');
+	});
+
+	it('returns an empty string for empty input', () => {
+		expect(percentageToDecimalAmount('')).toBe('');
+	});
+});
+
+describe('decimalAmountToPercentage', () => {
+	it('converts the stored decimals from the spec back to percentages', () => {
+		expect(decimalAmountToPercentage('0.05')).toBe('5');
+		expect(decimalAmountToPercentage('0.10')).toBe('10');
+		expect(decimalAmountToPercentage('0.025')).toBe('2.5');
+	});
+
+	it('round-trips values entered in the form', () => {
+		for (const entered of ['5', '2.5', '1.1', '0.07', '99.99', '100']) {
+			expect(decimalAmountToPercentage(percentageToDecimalAmount(entered))).toBe(Number(entered).toString());
+		}
+	});
+
+	it('returns an empty string for empty input', () => {
+		expect(decimalAmountToPercentage('')).toBe('');
+	});
+});
+
+describe('shiftDecimalString', () => {
+	it('leaves non-numeric input untouched rather than producing a bogus number', () => {
+		expect(shiftDecimalString('abc', -2)).toBe('abc');
+		expect(shiftDecimalString('.', -2)).toBe('.');
+	});
+
+	it('preserves the sign, except on zero', () => {
+		expect(shiftDecimalString('-5', -2)).toBe('-0.05');
+		expect(shiftDecimalString('-0', -2)).toBe('0');
+	});
+});
+
+describe('isPercentageMetadata / isPercentagePrice', () => {
+	it('detects the marker', () => {
+		expect(isPercentageMetadata({ billing_model: 'percentage' })).toBe(true);
+		expect(isPercentageMetadata({ billing_model: 'flat_fee' })).toBe(false);
+		expect(isPercentageMetadata(null)).toBe(false);
+		expect(isPercentageMetadata(undefined)).toBe(false);
+	});
+
+	it('only treats a flat fee as a percentage', () => {
+		expect(isPercentagePrice({ billing_model: BILLING_MODEL.FLAT_FEE, metadata: { billing_model: 'percentage' } })).toBe(true);
+		expect(isPercentagePrice({ metadata: { billing_model: 'percentage' } })).toBe(true);
+	});
+
+	it('ignores a stale marker on a charge that has moved to another billing model', () => {
+		expect(isPercentagePrice({ billing_model: BILLING_MODEL.TIERED, metadata: { billing_model: 'percentage' } })).toBe(false);
+		expect(isPercentagePrice({ billing_model: BILLING_MODEL.PACKAGE, metadata: { billing_model: 'percentage' } })).toBe(false);
+	});
+});
+
+describe('withPercentageMetadata / withoutPercentageMetadata', () => {
+	it('adds the marker while keeping unrelated keys', () => {
+		expect(withPercentageMetadata({ source: 'import' })).toEqual({ source: 'import', billing_model: 'percentage' });
+		expect(withPercentageMetadata(undefined)).toEqual({ billing_model: 'percentage' });
+	});
+
+	it('strips the marker and drops metadata that becomes empty', () => {
+		expect(withoutPercentageMetadata({ billing_model: 'percentage' })).toBeUndefined();
+		expect(withoutPercentageMetadata({ billing_model: 'percentage', source: 'import' })).toEqual({ source: 'import' });
+		expect(withoutPercentageMetadata(undefined)).toBeUndefined();
+	});
+
+	it("leaves a caller's own billing_model value alone", () => {
+		expect(withoutPercentageMetadata({ billing_model: 'something_else' })).toEqual({ billing_model: 'something_else' });
+	});
+});
+
+describe('PERCENTAGE_BILLING_MODEL', () => {
+	it('does not collide with a real backend billing model', () => {
+		expect(Object.values(BILLING_MODEL)).not.toContain(PERCENTAGE_BILLING_MODEL as unknown as BILLING_MODEL);
+	});
+});

--- a/src/utils/common/percentage_price_helpers.ts
+++ b/src/utils/common/percentage_price_helpers.ts
@@ -1,0 +1,96 @@
+import { Metadata } from '@/models/base';
+import { BILLING_MODEL } from '@/models/Price';
+
+/**
+ * Frontend-only billing model. The backend has no percentage billing model - a percentage charge is
+ * persisted as a FLAT_FEE whose `amount` holds the decimal equivalent (5% -> "0.05"), tagged with
+ * `metadata.billing_model = "percentage"` so the UI can render it back as a percentage.
+ *
+ * Mirrors the existing 'SLAB_TIERED' convenience value, which is likewise a selector-only value that
+ * maps onto a real backend billing model.
+ */
+export const PERCENTAGE_BILLING_MODEL = 'PERCENTAGE' as const;
+
+export type PercentageBillingModel = typeof PERCENTAGE_BILLING_MODEL;
+
+/** Metadata key/value pair that marks a FLAT_FEE price as percentage-based. */
+export const PERCENTAGE_METADATA_KEY = 'billing_model';
+export const PERCENTAGE_METADATA_VALUE = 'percentage';
+
+/** How many decimal places separate a percentage from its decimal equivalent (5 <-> 0.05). */
+const PERCENT_DECIMAL_PLACES = 2;
+
+/**
+ * Shifts the decimal point of a numeric string by `places` (positive shifts right / multiplies by
+ * 10^places, negative shifts left / divides).
+ *
+ * Deliberately string-based rather than `Number(value) / 100`: floating point makes that conversion
+ * lossy for ordinary inputs (`1.1 / 100` is 0.011000000000000001), and the result here is persisted
+ * as the price amount, so the error would be permanent. Non-numeric input is returned untouched -
+ * the caller validates, this only converts.
+ */
+export const shiftDecimalString = (value: string, places: number): string => {
+	const trimmed = value.trim();
+	if (trimmed === '') return '';
+
+	const isNegative = trimmed.startsWith('-');
+	const unsigned = isNegative ? trimmed.slice(1) : trimmed;
+	if (!/^\d*\.?\d*$/.test(unsigned) || unsigned === '' || unsigned === '.') return value;
+
+	const [integerPart = '', fractionPart = ''] = unsigned.split('.');
+	const digits = `${integerPart}${fractionPart}`;
+
+	// Index within `digits` where the decimal point lands after the shift, padding with zeros on
+	// whichever side the point runs off.
+	let pointIndex = integerPart.length + places;
+	let padded = digits;
+	if (pointIndex < 0) {
+		padded = `${'0'.repeat(-pointIndex)}${padded}`;
+		pointIndex = 0;
+	} else if (pointIndex > padded.length) {
+		padded = `${padded}${'0'.repeat(pointIndex - padded.length)}`;
+	}
+
+	const newInteger = padded.slice(0, pointIndex).replace(/^0+(?=\d)/, '') || '0';
+	const newFraction = padded.slice(pointIndex).replace(/0+$/, '');
+	const result = newFraction ? `${newInteger}.${newFraction}` : newInteger;
+
+	return isNegative && Number(result) !== 0 ? `-${result}` : result;
+};
+
+/** User-entered percentage -> the decimal amount sent to the backend. `"2.5"` -> `"0.025"`. */
+export const percentageToDecimalAmount = (percentage: string): string => shiftDecimalString(percentage, -PERCENT_DECIMAL_PLACES);
+
+/** Stored decimal amount -> the percentage shown to the user. `"0.025"` -> `"2.5"`. */
+export const decimalAmountToPercentage = (amount: string): string => shiftDecimalString(amount, PERCENT_DECIMAL_PLACES);
+
+/** True when a price's metadata marks its flat-fee amount as percentage-based. */
+export const isPercentageMetadata = (metadata?: Metadata | null): boolean =>
+	metadata?.[PERCENTAGE_METADATA_KEY] === PERCENTAGE_METADATA_VALUE;
+
+/**
+ * True when this price should be read as a percentage: the percentage marker is present and the
+ * charge really is the FLAT_FEE it claims to be. A stale marker left on a price that was since
+ * switched to PACKAGE/TIERED must not turn its tiers into percentages.
+ */
+export const isPercentagePrice = (price: { billing_model?: BILLING_MODEL | string; metadata?: Metadata | null }): boolean =>
+	isPercentageMetadata(price.metadata) && (price.billing_model === undefined || price.billing_model === BILLING_MODEL.FLAT_FEE);
+
+/** Adds the percentage marker to existing metadata, leaving other keys intact. */
+export const withPercentageMetadata = (metadata?: Metadata | null): Metadata => ({
+	...(metadata ?? {}),
+	[PERCENTAGE_METADATA_KEY]: PERCENTAGE_METADATA_VALUE,
+});
+
+/**
+ * Removes the percentage marker, so switching an existing percentage charge to another billing model
+ * stops it from rendering as a percentage. Returns undefined when nothing else remains, to avoid
+ * sending an empty metadata object.
+ */
+export const withoutPercentageMetadata = (metadata?: Metadata | null): Metadata | undefined => {
+	if (!metadata) return undefined;
+	const { [PERCENTAGE_METADATA_KEY]: existing, ...rest } = metadata;
+	// Only strip our own marker - a `billing_model` key set to anything else belongs to the caller.
+	const next = existing === PERCENTAGE_METADATA_VALUE ? rest : metadata;
+	return Object.keys(next).length > 0 ? next : undefined;
+};

--- a/src/utils/common/price_helpers.test.ts
+++ b/src/utils/common/price_helpers.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { formatPriceDisplay, NormalizedPriceDisplay } from './price_helpers';
-import { BILLING_MODEL, TIER_MODE, PRICE_UNIT_TYPE } from '@/models/Price';
+import {
+	formatPriceDisplay,
+	normalizePriceDisplay,
+	getBillingModelLabel,
+	getPriceTableCharge,
+	NormalizedPriceDisplay,
+} from './price_helpers';
+import { PERCENTAGE_BILLING_MODEL } from './percentage_price_helpers';
+import { BILLING_MODEL, Price, PRICE_TYPE, TIER_MODE, PRICE_UNIT_TYPE } from '@/models/Price';
 
 const base: NormalizedPriceDisplay = {
 	amount: '0',
@@ -45,5 +52,52 @@ describe('formatPriceDisplay', () => {
 				tiers: [{ up_to: 100, unit_amount: '0.066666666666667', flat_amount: '0' }],
 			}),
 		).toBe('starts at $0.066667 per unit');
+	});
+});
+
+const percentagePrice = (amount: string, overrides: Partial<Price> = {}): Price =>
+	({
+		amount,
+		currency: 'USD',
+		billing_model: BILLING_MODEL.FLAT_FEE,
+		tier_mode: TIER_MODE.VOLUME,
+		price_unit_type: PRICE_UNIT_TYPE.FIAT,
+		tiers: null,
+		transform_quantity: null,
+		metadata: { billing_model: 'percentage' },
+		...overrides,
+	}) as unknown as Price;
+
+describe('percentage charges', () => {
+	it('renders the stored decimal as the percentage the user entered', () => {
+		expect(formatPriceDisplay(normalizePriceDisplay(percentagePrice('0.05')))).toBe('5%');
+		expect(formatPriceDisplay(normalizePriceDisplay(percentagePrice('0.10')))).toBe('10%');
+		expect(formatPriceDisplay(normalizePriceDisplay(percentagePrice('0.025')))).toBe('2.5%');
+	});
+
+	it('surfaces the percentage billing model, not the flat fee it is stored as', () => {
+		expect(normalizePriceDisplay(percentagePrice('0.05')).billingModel).toBe(PERCENTAGE_BILLING_MODEL);
+		expect(getBillingModelLabel(PERCENTAGE_BILLING_MODEL)).toBe('Percentage Fee');
+	});
+
+	it('renders an untagged flat fee as a currency amount', () => {
+		expect(formatPriceDisplay(normalizePriceDisplay(percentagePrice('0.05', { metadata: null })))).toBe('$0.05');
+	});
+
+	it('renders a fixed percentage charge as a percentage in the price table', () => {
+		expect(getPriceTableCharge(percentagePrice('0.025', { type: PRICE_TYPE.FIXED }))).toBe('2.5%');
+	});
+
+	it('renders a usage percentage charge without the per-unit suffix in the price table', () => {
+		expect(getPriceTableCharge(percentagePrice('0.05', { type: PRICE_TYPE.USAGE }))).toBe('5%');
+	});
+
+	it('ignores a stale marker once the charge is overridden onto another billing model', () => {
+		const normalized = normalizePriceDisplay(percentagePrice('0.05'), {
+			billing_model: BILLING_MODEL.PACKAGE,
+			transform_quantity: { divide_by: 10 },
+		} as never);
+		expect(normalized.billingModel).toBe(BILLING_MODEL.PACKAGE);
+		expect(formatPriceDisplay(normalized)).toBe('$0.05 / 10 units');
 	});
 });

--- a/src/utils/common/price_helpers.ts
+++ b/src/utils/common/price_helpers.ts
@@ -4,6 +4,7 @@ import { PriceUnit } from '@/models/PriceUnit';
 import { getCurrencySymbol } from './helper_functions';
 import { formatAmount } from '@/components/atoms/Input/Input';
 import { ExtendedPriceOverride } from './price_override_helpers';
+import { PERCENTAGE_BILLING_MODEL, PercentageBillingModel, decimalAmountToPercentage, isPercentagePrice } from './percentage_price_helpers';
 
 /**
  * Normalized price structure - single source of truth for price display
@@ -14,7 +15,7 @@ export interface NormalizedPriceDisplay {
 	amount: string; // The amount to display
 	symbol: string; // Currency/unit symbol to display
 	tiers: CreatePriceTier[] | null; // Pricing tiers (null if not tiered)
-	billingModel: BILLING_MODEL | 'SLAB_TIERED'; // Billing model
+	billingModel: BILLING_MODEL | 'SLAB_TIERED' | PercentageBillingModel; // Billing model
 	tierMode: TIER_MODE; // Tier mode (VOLUME or SLAB)
 	transformQuantity: TransformQuantity | null; // Transform quantity for package billing
 	priceUnitType: PRICE_UNIT_TYPE; // FIAT or CUSTOM
@@ -105,8 +106,15 @@ export const normalizePriceDisplay = (
 	}
 
 	// Step 4: Extract billing model and tier mode
-	const billingModel: BILLING_MODEL | 'SLAB_TIERED' = override?.billing_model || price.billing_model;
+	let billingModel: BILLING_MODEL | 'SLAB_TIERED' | PercentageBillingModel = override?.billing_model || price.billing_model;
 	let tierMode: TIER_MODE = override?.tier_mode || price.tier_mode;
+
+	// A percentage charge is stored as a FLAT_FEE tagged in metadata - surface it as its own billing
+	// model so display formats the amount as a percentage rather than a currency value. An override
+	// that moves the charge off FLAT_FEE drops back to the overridden model.
+	if (isPercentagePrice({ billing_model: billingModel, metadata: price.metadata })) {
+		billingModel = PERCENTAGE_BILLING_MODEL;
+	}
 
 	// Step 5: Handle SLAB_TIERED special case
 	// SLAB_TIERED is a frontend convenience representation for TIERED + SLAB mode
@@ -147,12 +155,23 @@ const capDisplayDecimals = (amount: string, maxDecimals: number = MAX_DISPLAY_DE
 	return Number.isFinite(parsed) ? parsed.toFixed(maxDecimals) : amount;
 };
 
+/**
+ * Renders a stored decimal amount as the percentage it stands for: "0.025" -> "2.5%".
+ * Single place every percentage-aware display goes through, so the symbol and the decimal cap stay
+ * consistent across charge tables, previews, tooltips and the pricing card.
+ */
+export const formatPercentageAmount = (amount: string): string =>
+	`${formatAmount(capDisplayDecimals(decimalAmountToPercentage(amount || '0')))}%`;
+
 export const formatPriceDisplay = (normalized: NormalizedPriceDisplay): string => {
 	const { amount, symbol, billingModel, transformQuantity, tiers } = normalized;
 
 	switch (billingModel) {
 		case BILLING_MODEL.FLAT_FEE:
 			return `${symbol}${formatAmount(capDisplayDecimals(amount))}`;
+
+		case PERCENTAGE_BILLING_MODEL:
+			return formatPercentageAmount(amount);
 
 		case BILLING_MODEL.PACKAGE: {
 			const divideBy = transformQuantity?.divide_by || 1;
@@ -173,10 +192,12 @@ export const formatPriceDisplay = (normalized: NormalizedPriceDisplay): string =
 /**
  * Get human-readable label for billing model
  */
-export const getBillingModelLabel = (model: BILLING_MODEL | 'SLAB_TIERED'): string => {
+export const getBillingModelLabel = (model: BILLING_MODEL | 'SLAB_TIERED' | PercentageBillingModel): string => {
 	switch (model) {
 		case BILLING_MODEL.FLAT_FEE:
 			return 'Flat Fee';
+		case PERCENTAGE_BILLING_MODEL:
+			return 'Percentage Fee';
 		case BILLING_MODEL.PACKAGE:
 			return 'Package';
 		case BILLING_MODEL.TIERED:
@@ -206,6 +227,12 @@ export const getPriceTableCharge = (price: Price & { pricing_unit?: PriceUnit },
 	const displaySymbol = getDisplaySymbol(price);
 	const displayAmount = getDisplayAmount(price);
 	const displayTiers = getDisplayTiers(price);
+
+	// Percentage charges are FLAT_FEE prices whose amount is the decimal equivalent - render the
+	// percentage rather than a currency amount, for both fixed and usage charges.
+	if (isPercentagePrice(price)) {
+		return formatPercentageAmount(displayAmount);
+	}
 
 	if (price.type === PRICE_TYPE.FIXED) {
 		return `${displaySymbol}${formatAmount(displayAmount)}`;

--- a/src/utils/subscription/internalPriceToSubscriptionLineItemRequest.ts
+++ b/src/utils/subscription/internalPriceToSubscriptionLineItemRequest.ts
@@ -116,6 +116,9 @@ export function internalPriceToSubscriptionLineItemRequest(
 			meter_id: internalPrice.meter_id,
 			filter_values: internalPrice.filter_values ?? undefined,
 		};
+		// Carries the percentage marker (metadata.billing_model = "percentage") that tells the UI to
+		// read this flat fee back as a percentage.
+		if (internalPrice.metadata) price.metadata = internalPrice.metadata;
 		if (internalPrice.amount != null) price.amount = internalPrice.amount;
 		if (internalPrice.tier_mode != null) price.tier_mode = internalPrice.tier_mode as TIER_MODE;
 		if (internalPrice.tiers?.length) price.tiers = internalPrice.tiers;
@@ -143,6 +146,8 @@ export function internalPriceToSubscriptionLineItemRequest(
 		min_quantity: internalPrice.min_quantity,
 		start_date: internalPrice.start_date,
 	};
+
+	if (internalPrice.metadata) price.metadata = internalPrice.metadata;
 
 	applyFixedChargePricingFields(price, internalPrice);
 
@@ -189,6 +194,7 @@ export function subscriptionLineItemToInternalPrice(
 		min_quantity: lineItem.quantity ?? subscriptionPrice.min_quantity ?? 1,
 		start_date: lineItem.start_date ?? subscriptionPrice.start_date,
 		price_unit_type: subscriptionPrice.price_unit_type ?? PRICE_UNIT_TYPE.FIAT,
+		metadata: subscriptionPrice.metadata ?? undefined,
 		internal_state: PriceInternalState.EDIT,
 	};
 


### PR DESCRIPTION
## Percentage Fee billing model

Adds a **Percentage Fee** option to the charge type selector on both the usage and fixed charge forms (plan charges, entity charges, and the subscription charge dialog).

The backend has no percentage billing model, so nothing changes server-side: the charge is persisted as a `FLAT_FEE` whose `amount` is the decimal equivalent of what the user typed, tagged with a metadata marker so the UI can read it back as a percentage.

```json
{ "billing_model": "FLAT_FEE", "amount": "0.025", "metadata": { "billing_model": "percentage" } }
```

| Entered | Stored | Displayed |
|---|---|---|
| `5` | `0.05` | `5%` |
| `10` | `0.1` | `10%` |
| `2.5` | `0.025` | `2.5%` |

### Notes for review

**Conversion is string-based, not `value / 100`.** Floating point makes that lossy for ordinary inputs — `1.1 / 100` is `0.011000000000000001` — and the result is what gets persisted as the price amount, so the error would be permanent. `shiftDecimalString` moves the decimal point on the digit string instead.

**One shared formatter.** A tagged flat fee renders as `2.5%` — no currency symbol, no per-unit/per-period suffix — everywhere a price rate is shown: charge tables, fixed/usage previews, price tooltips, the override summary, the update/override dialogs and the pricing card. Invoice and credit-note line items, wallet balances and commitment amounts keep their currency, since those are real computed money rather than the rate.

**Two correctness details.** A stale marker on a charge that has since moved to `PACKAGE`/`TIERED` is ignored, so tiers are never read as percentages; and switching a percentage charge to another billing model clears the marker rather than inheriting it.

**Bug fixed along the way.** `UpdatePriceDialog` and `PriceOverrideDialog` previously showed the stored decimal as a currency amount, and editing one wrote a raw amount back while leaving the marker in place — silently turning 2.5% into 250%. Both now edit in percent and convert on save.

## Dependency dedupe (second commit)

Radix pins its internal dependencies to exact versions, so `react-dialog`'s `1.1.19` and `react-select`/`popover`/`menu`/`tooltip`/`alert-dialog`'s `1.1.11` could not dedupe and npm installed **both**. Each copy carries its own module-level `DismissableLayerContext`, so a Select portaled out of a dialog registered in a *different layer stack* than the dialog — and Radix only wires its Escape handler to the highest layer within one stack. Both believed they were topmost and both handled the same keypress, so pressing Escape to dismiss a dropdown **closed the dialog underneath it and lost the form**.

An `overrides` entry pinning a single `1.1.19` restores one shared layer stack. The only lockfile change is the five duplicate copies disappearing.

This is very likely the root cause behind the existing outside-click workarounds in `src/lib/modal-scroll-lock.ts` too — same split-stack mechanism — but I left those in place rather than widening this PR.

## Verification

Driven in the running app against `api-dev`, with requests intercepted before reaching the backend so no data was written:

- Usage charge: entering `2.5` produced `{"type":"USAGE","billing_model":"FLAT_FEE","metadata":{"billing_model":"percentage"},"amount":"0.025"}`, and the row read back as `2.5%`.
- Fixed charge: entering `7.5` produced `{"type":"FIXED", ... "amount":"0.075"}`, row read back as `7.5%`.
- The Add Subscription charges table, which previously rendered a percentage charge as `$0.22 / month`, now shows `22%`.
- Escape behaviour before/after the dedupe: dropdown open + Escape used to close both; now the first Escape closes only the dropdown and a second closes the dialog. Selecting an option and clicking outside the dialog both still behave.

882 tests pass (27 new), `tsc` clean, `eslint src/` at its existing 436-warning baseline with 0 errors, `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
