### PR TITLE
fix(wallet-topup): make the Add Credits dialog readable in dark mode

### DIFF
--- a/src/components/molecules/WalletTopupCard/WalletTopupCard.tsx
+++ b/src/components/molecules/WalletTopupCard/WalletTopupCard.tsx
@@ -245,7 +245,7 @@ const TopupCard: FC<TopupCardProps> = ({ walletId, currency, conversion_rate = 1
 	};
 
 	return (
-		<DialogContent className='bg-white sm:max-w-[600px]'>
+		<DialogContent className='bg-surface sm:max-w-[600px]'>
 			<PaymentUrlSuccessDialog
 				isOpen={checkoutPopup.isOpen}
 				paymentUrl={checkoutPopup.paymentUrl}


### PR DESCRIPTION
## The bug

The **Add Credits** dialog (Wallet → Topup Wallet) is unreadable in dark mode. The dialog pinned its surface to `bg-white` while everything inside it uses theme tokens, so the text turned near-white on a white panel — the title, the **Credit Type** label, the Free/Purchased cards and every field label effectively disappeared.

Measured on the dialog in dark mode before the fix:

| | Value | |
|---|---|---|
| Title colour | `rgb(238, 239, 241)` | near-white |
| Dialog surface | `rgb(255, 255, 255)` | white |
| Contrast | **~1.04:1** | WCAG AA needs 4.5:1 |

### Before — dark mode

![Add Credits dialog in dark mode before the fix: labels and card text are invisible against a white panel](https://raw.githubusercontent.com/dskhairnar/flexprice-front/assets/topup-dark-mode/shots/before-dark.png)

## The fix

One line — `bg-white` becomes `bg-surface`, the token for an elevated panel, which is defined in **both** themes (`--fp-surface`: `#ffffff` light, `#181818` dark).

```diff
- <DialogContent className='bg-white sm:max-w-[600px]'>
+ <DialogContent className='bg-surface sm:max-w-[600px]'>
```

### After — dark mode

![Add Credits dialog in dark mode after the fix: all text legible on a dark panel](https://raw.githubusercontent.com/dskhairnar/flexprice-front/assets/topup-dark-mode/shots/after-dark.png)

### After — light mode (unchanged)

`bg-surface` resolves to `#ffffff` in light, exactly what `bg-white` produced, so light mode is unchanged.

![Add Credits dialog in light mode after the fix, an opaque white panel](https://raw.githubusercontent.com/dskhairnar/flexprice-front/assets/topup-dark-mode/shots/after-light.png)

## Why not just delete the class?

Removing it does not work, and this is worth knowing before someone tries it.

`DialogContent` defaults to `bg-background`, and **that token is malformed in light mode**. Tailwind maps it as `hsl(var(--background))`, but `:root` defines it as a hex:

```css
:root  { --background: #f8fafc;   }  /* hsl(#f8fafc) -> invalid -> transparent */
.dark  { --background: 0 0% 7.5%; }  /* valid */
```

So dropping `bg-white` fixes dark mode but leaves the light dialog transparent. I hit this while working on the fix — the intermediate state measured `rgba(0, 0, 0, 0)` in light, and the page behind it showed straight through:

![The Add Credits dialog with no background class, transparent in light mode, page content visible through it](https://raw.githubusercontent.com/dskhairnar/flexprice-front/assets/topup-dark-mode/shots/intermediate-light-transparent.png)

The `bg-white` was almost certainly a workaround for exactly this.

That token bug is **left alone in this PR**: fixing `--background` changes every `bg-background` surface in light mode from transparent to `#f8fafc`, which is a much wider blast radius and deserves its own change.

## Verification

Measured with the dialog open, both themes, against the same tokenized text:

| Theme | Dialog surface | Title colour |
|---|---|---|
| Light | `rgb(255, 255, 255)` | `rgb(10, 10, 10)` |
| Dark | `rgb(24, 24, 24)` | `rgb(238, 239, 241)` |

`npm run build`, `eslint` (clean on the changed file) and the full suite (**910 tests / 123 files**) all pass.

Screenshots were captured against a real authenticated session on the dev backend, not mocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the wallet top-up dialog background to use the standard surface color for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->