### PR TITLE
fix(wallet-topup): make the Add Credits dialog readable in dark mode

### DIFF
--- a/src/components/molecules/WalletTopupCard/WalletTopupCard.tsx
+++ b/src/components/molecules/WalletTopupCard/WalletTopupCard.tsx
@@ -245,7 +245,7 @@ const TopupCard: FC<TopupCardProps> = ({ walletId, currency, conversion_rate = 1
 	};
 
 	return (
-		<DialogContent className='bg-white sm:max-w-[600px]'>
+		<DialogContent className='bg-surface sm:max-w-[600px]'>
 			<PaymentUrlSuccessDialog
 				isOpen={checkoutPopup.isOpen}
 				paymentUrl={checkoutPopup.paymentUrl}


### PR DESCRIPTION
> Same one-line fix as #1398 (which targets `develop`), branched from `main` so this PR carries only the fix — `develop` is 11 commits ahead of `main`, and a develop-based branch would have dragged all of them in.

## The bug

The **Add Credits** dialog (Wallet → Topup Wallet) is unreadable in dark mode. The dialog pinned its surface to `bg-white` while everything inside it uses theme tokens, so the text turned near-white on a white panel — the title, the **Credit Type** label, the Free/Purchased cards and every field label effectively disappeared.

Measured on the dialog in dark mode before the fix:

| | Value | |
|---|---|---|
| Title colour | `rgb(238, 239, 241)` | near-white |
| Dialog surface | `rgb(255, 255, 255)` | white |
| Contrast | **~1.04:1** | WCAG AA needs 4.5:1 |

### Before — dark mode

![Add Credits dialog in dark mode before the fix: labels and card text are invisible against a white panel](https://raw.githubusercontent.com/dskhairnar/flexprice-front/assets/topup-dark-mode/shots/before-dark.png)

## The fix

One line — `bg-white` becomes `bg-surface`, the token for an elevated panel, which is defined in **both** themes (`--fp-surface`: `#ffffff` light, `#181818` dark).

```diff
- <DialogContent className='bg-white sm:max-w-[600px]'>
+ <DialogContent className='bg-surface sm:max-w-[600px]'>
```

### After — dark mode

![Add Credits dialog in dark mode after the fix: all text legible on a dark panel](https://raw.githubusercontent.com/dskhairnar/flexprice-front/assets/topup-dark-mode/shots/after-dark.png)