### PR TITLE
polish(invoice): reapply-coupon moves below the line-items table behind a divider

### DIFF
--- a/src/pages/customer/invoices/EditInvoicePage.tsx
+++ b/src/pages/customer/invoices/EditInvoicePage.tsx
@@ -772,17 +772,16 @@ const EditInvoicePage: FC = () => {
 								<div className='px-2 py-1.5'>
 									<AddChargesButton onClick={handleAddLineItem} label={t('createInvoice.addLineItem')} />
 								</div>
-								{/* discount reapplication belongs with the line-item math, so it lives in this card */}
-								<div className={cn('border-t border-line px-4 py-4 transition-colors', applyDiscount && 'bg-muted/30')}>
-									<Checkbox
-										id='apply-discount'
-										checked={applyDiscount}
-										onCheckedChange={(checked) => setApplyDiscount(!!checked)}
-										label={t('invoices.edit.applyDiscount')}
-										description={t('invoices.edit.applyDiscountDescription')}
-									/>
-								</div>
 							</div>
+							{/* discount reapplication sits below the table, separated by its own rule */}
+							<Divider className='my-5' />
+							<Checkbox
+								id='apply-discount'
+								checked={applyDiscount}
+								onCheckedChange={(checked) => setApplyDiscount(!!checked)}
+								label={t('invoices.edit.applyDiscount')}
+								description={t('invoices.edit.applyDiscountDescription')}
+							/>
 						</div>
 					) : (
 						<div className='px-4 pb-4'>


### PR DESCRIPTION
## What

Moves the **Reapply coupon discounts** checkbox out of the line-items table card on the invoice edit page. The bordered container now ends after **+ Add Line Item**; below it, a horizontal divider separates the coupon option, which sits as its own element.

Same label, description, and `apply_discount` save behavior — purely a placement change.

## Testing

- Page suite 21/21, tsc clean
- Verified in the browser against api-dev (seeded env): checkbox renders outside the table's border, below its own rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Moved the discount reapplication control below the invoice line-item table.
  - Added a separate divider to visually distinguish the control from the table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->