### PR TITLE
fix(version-check): make the update toast readable in dark mode

### DIFF
--- a/src/hooks/useVersionCheck.test.tsx
+++ b/src/hooks/useVersionCheck.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import '@testing-library/jest-dom';
+import { Toaster } from 'react-hot-toast';
+import useVersionCheck from './useVersionCheck';
+
+vi.mock('@/config/config', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@/config/config')>();
+	// The hook is prod-gated; everything else keeps the real test config.
+	return { ...actual, config: { ...actual.config, app: { ...actual.config.app, isProd: true } } };
+});
+
+const Probe = () => {
+	useVersionCheck(60 * 60 * 1000);
+	return null;
+};
+
+describe('useVersionCheck', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		// Vite's compile-time define; not present under vitest.
+		vi.stubGlobal('__APP_VERSION__', 'v-current');
+		// jsdom has no matchMedia; react-hot-toast's Toaster queries prefers-reduced-motion.
+		vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }));
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({ versionId: 'v-next' }),
+			}),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('renders the update notice as a themed card on a transparent toast shell', async () => {
+		render(
+			<>
+				<Toaster />
+				<Probe />
+			</>,
+		);
+
+		// No i18n provider in this test, so t() returns the raw key.
+		const title = await screen.findByText('versionCheck.toastTitle');
+
+		// The card must paint its own themed surface…
+		const card = title.closest('.bg-surface');
+		expect(card).not.toBeNull();
+		expect(card).toHaveClass('border', 'border-line', 'rounded-lg');
+
+		// …because the library's default shell is hard-coded white and ignores dark
+		// mode; the shell around the card must be neutralized to transparent.
+		const shell = [...document.querySelectorAll<HTMLElement>('div')].find(
+			(el) => el.contains(card) && el.style.background === 'transparent',
+		);
+		expect(shell).toBeDefined();
+	});
+});

--- a/src/hooks/useVersionCheck.tsx
+++ b/src/hooks/useVersionCheck.tsx
@@ -37,7 +37,7 @@ export default function useVersionCheck(intervalMs = 5 * 60 * 1000) {
 					console.info(`[VersionCheck][${timestamp}] New version detected. Current: ${currentVersion}, Latest: ${latestVersion}`);
 					toast(
 						(toastCtx) => (
-							<div className='bg-surface border-line w-80'>
+							<div className='w-80 rounded-lg border border-line bg-surface p-4 shadow-lg'>
 								{/* Header */}
 								<div className='flex items-center justify-between mb-3'>
 									<div className='flex items-center gap-3'>
@@ -83,6 +83,9 @@ export default function useVersionCheck(intervalMs = 5 * 60 * 1000) {
 							duration: Infinity,
 							id: 'version-check-notification',
 							position: 'bottom-right',
+							// The default toast shell is hard-coded white, so it ignores dark mode;
+							// neutralize it and let the themed card above provide the surface.
+							style: { background: 'transparent', boxShadow: 'none', padding: 0, border: 'none' },
 						},
 					);
 				} else {


### PR DESCRIPTION
## Bug

The "New version available" notice (bottom-right, shown when `meta.json` reports a newer build) renders as a **white card in dark mode**, with the "Not now" button barely visible.

## Root cause

The toast's custom JSX already used theme tokens (`bg-surface`, `text-content`, …), but it renders inside react-hot-toast's default toast shell, whose background is **hard-coded white** — the themed content sat on a white pill that ignores the theme entirely.

## Fix

- The card paints its own complete surface: `rounded-lg border border-line bg-surface p-4 shadow-lg`
- This toast's shell is neutralized via its own options (`background: transparent`, no shadow/padding/border), so the themed card is the only visible surface — in both themes

Scoped to the version-check toast only; the shared `AppToaster` config is untouched.

## Testing

- New test renders the hook (prod-gated via config mock) with a real `<Toaster>`: asserts the notice renders as a themed `bg-surface` card inside a transparent shell (jsdom stubs for `__APP_VERSION__` / `matchMedia` included)
- Full suite 945/945, tsc + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)