### PR TITLE
fix(wallet-alerts): complete the escalation ordering copy and show the condition picker

### DIFF
--- a/src/components/molecules/WalletAlertDialog/WalletAlertDialog.tsx
+++ b/src/components/molecules/WalletAlertDialog/WalletAlertDialog.tsx
@@ -41,7 +41,8 @@ const WalletAlertDialog: React.FC<WalletAlertDialogProps> = ({ open, alertSettin
 		),
 		thresholdTypeAbsolute: t('wallet.alerts.thresholdTypeAbsolute'),
 		thresholdTypePercentage: t('wallet.alerts.thresholdTypePercentage'),
-		rowDescription: t('wallet.alerts.rowDescription'),
+		conditionBelow: t('wallet.alerts.conditionBelow'),
+		conditionAbove: t('wallet.alerts.conditionAbove'),
 		amountPlaceholder: t('wallet.alerts.amountPlaceholder'),
 		levels: {
 			[WalletAlertLevel.CRITICAL]: t('wallet.alerts.criticalTitle'),

--- a/src/components/molecules/WalletAlertThresholdSection/WalletAlertThresholdRow.tsx
+++ b/src/components/molecules/WalletAlertThresholdSection/WalletAlertThresholdRow.tsx
@@ -1,4 +1,5 @@
-import { Input } from '@/components/atoms';
+import { Input, Select } from '@/components/atoms';
+import type { WalletAlertCondition } from '@/utils/wallet/walletAlertUtils';
 
 /**
  * Negatives are accepted rather than blocked: post-paid wallets legitimately sit below zero, and
@@ -9,8 +10,15 @@ const THRESHOLD_FORMAT_OPTIONS = { allowNegative: true, allowDecimals: true, tho
 export interface WalletAlertThresholdRowProps {
 	/** Severity name, e.g. "Critical". */
 	title: string;
-	/** Fixed condition copy, e.g. "Balance below". */
-	description: string;
+	/** Currently selected comparison. Wallet balance alerts are always 'below'. */
+	condition: WalletAlertCondition;
+	conditionLabels: { below: string; above: string };
+	/**
+	 * Locks the condition picker. It stays visible so the comparison is explicit, but wallet
+	 * balance alerts only ever fire on a falling balance, so there is nothing to choose.
+	 */
+	conditionDisabled?: boolean;
+	onConditionChange?: (condition: WalletAlertCondition) => void;
 	/** Empty string means this severity has no threshold configured. */
 	value: string;
 	placeholder: string;
@@ -23,13 +31,16 @@ export interface WalletAlertThresholdRowProps {
 }
 
 /**
- * One severity as a single horizontal row: fixed-width severity column, condition copy, then the
- * value input. The severity and input columns are fixed so the three rows line up as one block.
- * There is no condition picker — wallet balance alerts always fire on a falling balance.
+ * One severity as a single horizontal row: fixed-width severity column, the comparison, then the
+ * value input. The severity, condition and input columns are fixed so the three rows line up as
+ * one block.
  */
 const WalletAlertThresholdRow = ({
 	title,
-	description,
+	condition,
+	conditionLabels,
+	conditionDisabled,
+	onConditionChange,
 	value,
 	placeholder,
 	symbol,
@@ -39,10 +50,22 @@ const WalletAlertThresholdRow = ({
 }: WalletAlertThresholdRowProps) => (
 	<div className='flex items-center gap-4 py-2'>
 		<span className='w-24 shrink-0 text-sm font-medium text-content'>{title}</span>
-		<span className='min-w-0 flex-1 truncate text-sm text-content-secondary'>{description}</span>
+		<div className='w-[150px] shrink-0'>
+			<Select
+				ariaLabel={`${title} condition`}
+				options={[
+					{ label: conditionLabels.below, value: 'below' },
+					{ label: conditionLabels.above, value: 'above' },
+				]}
+				value={condition}
+				onChange={(next) => onConditionChange?.(next as WalletAlertCondition)}
+				disabled={disabled || conditionDisabled}
+			/>
+		</div>
+		<div className='flex-1' />
 		<div className='w-[132px] shrink-0'>
 			<Input
-				aria-label={`${title} — ${description}`}
+				aria-label={`${title} threshold`}
 				placeholder={placeholder}
 				value={value}
 				onChange={onChange}

--- a/src/components/molecules/WalletAlertThresholdSection/WalletAlertThresholdSection.test.tsx
+++ b/src/components/molecules/WalletAlertThresholdSection/WalletAlertThresholdSection.test.tsx
@@ -10,7 +10,8 @@ const labels: WalletAlertThresholdSectionLabels = {
 	thresholdTypeTooltip: 'Absolute or percentage',
 	thresholdTypeAbsolute: 'Absolute',
 	thresholdTypePercentage: 'Percentage',
-	rowDescription: 'Balance below',
+	conditionBelow: 'Below',
+	conditionAbove: 'Above',
 	amountPlaceholder: '0.00',
 	levels: {
 		[WalletAlertLevel.CRITICAL]: 'Critical',
@@ -25,19 +26,18 @@ const Harness = ({ initial, currency }: { initial?: WalletAlertDraft; currency?:
 	return <WalletAlertThresholdSection draft={draft} labels={labels} currency={currency} onChange={setDraft} />;
 };
 
-const rowInput = (level: string) => screen.getByLabelText(`${level} — Balance below`) as HTMLInputElement;
+const rowInput = (level: string) => screen.getByLabelText(`${level} threshold`) as HTMLInputElement;
 
 describe('WalletAlertThresholdSection', () => {
-	it('renders one row per severity with the fixed falls-below copy and no condition picker', () => {
+	it('renders one row per severity with a condition picker locked to Below', () => {
 		render(<Harness />);
 
 		expect(screen.getByText('Critical')).toBeInTheDocument();
 		expect(screen.getByText('Warning')).toBeInTheDocument();
 		expect(screen.getByText('Info')).toBeInTheDocument();
-		expect(screen.getAllByText('Balance below')).toHaveLength(3);
-		// The Above/Below dropdown is gone — wallet alerts always fire on a falling balance.
-		expect(screen.queryByText('Above')).not.toBeInTheDocument();
-		expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+		// Every row shows the comparison as a picker, locked to Below.
+		expect(screen.getAllByText('Below')).toHaveLength(3);
+		screen.getAllByRole('combobox').forEach((c) => expect(c).toBeDisabled());
 	});
 
 	it('has no standalone Thresholds heading and keeps the type label beside its control', () => {

--- a/src/components/molecules/WalletAlertThresholdSection/WalletAlertThresholdSection.tsx
+++ b/src/components/molecules/WalletAlertThresholdSection/WalletAlertThresholdSection.tsx
@@ -1,5 +1,6 @@
 import { WalletAlertLevel, type WalletAlertDraft, type WalletAlertThresholdType } from '@/models/Wallet';
 import {
+	WALLET_ALERT_CONDITION,
 	getActiveWalletAlertLevels,
 	setWalletAlertDraftThresholdType,
 	setWalletAlertThresholdValue,
@@ -16,8 +17,9 @@ export interface WalletAlertThresholdSectionLabels {
 	thresholdTypeTooltip: React.ReactNode;
 	thresholdTypeAbsolute: string;
 	thresholdTypePercentage: string;
-	/** Fixed condition copy on every row, e.g. "Balance below". */
-	rowDescription: string;
+	/** Labels for the (locked) condition picker on every row. */
+	conditionBelow: string;
+	conditionAbove: string;
 	amountPlaceholder: string;
 	levels: Record<WalletAlertLevel, string>;
 }
@@ -65,7 +67,11 @@ const WalletAlertThresholdSection = ({ draft, labels, disabled, currency, onChan
 					<WalletAlertThresholdRow
 						key={level}
 						title={labels.levels[level]}
-						description={labels.rowDescription}
+						condition={WALLET_ALERT_CONDITION}
+						conditionLabels={{ below: labels.conditionBelow, above: labels.conditionAbove }}
+						// Wallet balance alerts only ever fire on a falling balance, so the picker is
+						// shown for clarity but never editable.
+						conditionDisabled
 						value={levels[level]?.threshold ?? ''}
 						placeholder={labels.amountPlaceholder}
 						symbol={symbol}

--- a/src/i18n/locales/ar/billing.json
+++ b/src/i18n/locales/ar/billing.json
@@ -824,7 +824,7 @@
 		"alerts": {
 			"amountPlaceholder": "0.00",
 			"conditionBelow": "أقل من",
-			"conditionAbove": "أعلى من",
+			"conditionAbove": "أكبر من",
 			"dialogTitle": "إعدادات تنبيه المحفظة",
 			"enableTitle": "تفعيل تنبيهات المحفظة",
 			"enableDescription": "احصل على إشعار عند انخفاض رصيد محفظتك عن العتبات المُعدّة.",
@@ -851,7 +851,6 @@
 				"infoMustBeLessThanWarning": "يجب أن تكون عتبة المعلومات أقل من عتبة التحذير",
 				"infoMustBeLessThanCritical": "يجب أن تكون عتبة المعلومات أقل من العتبة الحرجة"
 			},
-			"rowDescription": "الرصيد أقل من",
 			"thresholdTypeLabel": "نوع العتبة",
 			"thresholdTypeAbsolute": "مطلق",
 			"thresholdTypePercentage": "نسبة مئوية",

--- a/src/i18n/locales/ar/settings.json
+++ b/src/i18n/locales/ar/settings.json
@@ -402,14 +402,18 @@
 				"criticalRequiredForWarning": "عتبة حرجة مطلوبة عند تعيين عتبة تحذير",
 				"warningMustBeGreaterThanCritical": "يجب أن تكون عتبة التحذير أكبر من العتبة الحرجة",
 				"infoMustBeGreaterThanWarning": "يجب أن تكون عتبة المعلومات أكبر من عتبة التحذير",
-				"infoMustBeGreaterThanCritical": "يجب أن تكون عتبة المعلومات أكبر من العتبة الحرجة"
+				"infoMustBeGreaterThanCritical": "يجب أن تكون عتبة المعلومات أكبر من العتبة الحرجة",
+				"warningMustBeLessThanCritical": "يجب أن تكون عتبة التحذير أقل من العتبة الحرجة",
+				"infoMustBeLessThanWarning": "يجب أن تكون عتبة المعلومات أقل من عتبة التحذير",
+				"infoMustBeLessThanCritical": "يجب أن تكون عتبة المعلومات أقل من العتبة الحرجة"
 			},
-			"rowDescription": "الرصيد أقل من",
 			"thresholdTypeLabel": "نوع العتبة",
 			"thresholdTypeAbsolute": "مطلق",
 			"thresholdTypePercentage": "نسبة مئوية",
 			"thresholdTypeTooltipAbsolute": "مطلق: تُفعَّل التنبيهات عند انخفاض رصيد المحفظة عن مبلغ ثابت.",
-			"thresholdTypeTooltipPercentage": "نسبة مئوية: تُفعَّل التنبيهات على الرصيد الجاري، مقيسًا كنسبة مئوية من الأرصدة الممنوحة خلال فترة الفوترة الحالية. في حال عدم وجود اشتراك نشط، يُستخدم إجمالي الأرصدة الممنوحة طوال الوقت."
+			"thresholdTypeTooltipPercentage": "نسبة مئوية: تُفعَّل التنبيهات على الرصيد الجاري، مقيسًا كنسبة مئوية من الأرصدة الممنوحة خلال فترة الفوترة الحالية. في حال عدم وجود اشتراك نشط، يُستخدم إجمالي الأرصدة الممنوحة طوال الوقت.",
+			"conditionBelow": "أقل من",
+			"conditionAbove": "أكبر من"
 		}
 	},
 	"appearance": {

--- a/src/i18n/locales/en/billing.json
+++ b/src/i18n/locales/en/billing.json
@@ -980,7 +980,6 @@
 				"infoMustBeLessThanWarning": "The info threshold must be less than the warning threshold",
 				"infoMustBeLessThanCritical": "The info threshold must be less than the critical threshold"
 			},
-			"rowDescription": "Balance below",
 			"thresholdTypeLabel": "Threshold type",
 			"thresholdTypeAbsolute": "Absolute",
 			"thresholdTypePercentage": "Percentage",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -396,14 +396,18 @@
 				"criticalRequiredForWarning": "A critical threshold is required when a warning threshold is set",
 				"warningMustBeGreaterThanCritical": "The warning threshold must be greater than the critical threshold",
 				"infoMustBeGreaterThanWarning": "The info threshold must be greater than the warning threshold",
-				"infoMustBeGreaterThanCritical": "The info threshold must be greater than the critical threshold"
+				"infoMustBeGreaterThanCritical": "The info threshold must be greater than the critical threshold",
+				"warningMustBeLessThanCritical": "The warning threshold must be less than the critical threshold",
+				"infoMustBeLessThanWarning": "The info threshold must be less than the warning threshold",
+				"infoMustBeLessThanCritical": "The info threshold must be less than the critical threshold"
 			},
-			"rowDescription": "Balance below",
 			"thresholdTypeLabel": "Threshold type",
 			"thresholdTypeAbsolute": "Absolute",
 			"thresholdTypePercentage": "Percentage",
 			"thresholdTypeTooltipAbsolute": "Absolute: alerts trigger when the wallet balance falls below a fixed amount.",
-			"thresholdTypeTooltipPercentage": "Percentage: alerts trigger on the ongoing balance, measured as a percentage of the credits granted during the current billing period. If there is no active subscription, lifetime credits are used."
+			"thresholdTypeTooltipPercentage": "Percentage: alerts trigger on the ongoing balance, measured as a percentage of the credits granted during the current billing period. If there is no active subscription, lifetime credits are used.",
+			"conditionBelow": "Below",
+			"conditionAbove": "Above"
 		}
 	},
 	"appearance": {

--- a/src/pages/settings/alerts/WalletAlertSettings.tsx
+++ b/src/pages/settings/alerts/WalletAlertSettings.tsx
@@ -41,7 +41,8 @@ const WalletAlertSettingsSection = () => {
 		),
 		thresholdTypeAbsolute: t('alerts.walletAlerts.thresholdTypeAbsolute'),
 		thresholdTypePercentage: t('alerts.walletAlerts.thresholdTypePercentage'),
-		rowDescription: t('alerts.walletAlerts.rowDescription'),
+		conditionBelow: t('alerts.walletAlerts.conditionBelow'),
+		conditionAbove: t('alerts.walletAlerts.conditionAbove'),
 		amountPlaceholder: t('alerts.walletAlerts.amountPlaceholder'),
 		levels: {
 			[WalletAlertLevel.CRITICAL]: t('alerts.walletAlerts.levels.critical'),

--- a/src/utils/wallet/walletAlertValidationCopy.test.ts
+++ b/src/utils/wallet/walletAlertValidationCopy.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import arBilling from '@/i18n/locales/ar/billing.json';
+import arSettings from '@/i18n/locales/ar/settings.json';
+import enBilling from '@/i18n/locales/en/billing.json';
+import enSettings from '@/i18n/locales/en/settings.json';
+import { WalletAlertLevel } from '@/models/Wallet';
+import { getWalletAlertValidationErrorKey, type WalletAlertValidationErrorKey } from './walletAlertUtils';
+
+/**
+ * Every key the validator can return. Listed literally rather than derived from the type, so
+ * adding a member to WalletAlertValidationErrorKey without adding its copy fails this test —
+ * which is exactly how the escalation-ordering messages went missing from the settings
+ * namespace while remaining reachable from the tenant page.
+ */
+const ALL_ERROR_KEYS: WalletAlertValidationErrorKey[] = [
+	'atLeastOneThreshold',
+	'invalidCriticalThreshold',
+	'invalidWarningThreshold',
+	'invalidInfoThreshold',
+	'criticalThresholdOutOfRange',
+	'warningThresholdOutOfRange',
+	'infoThresholdOutOfRange',
+	'criticalRequiredForWarning',
+	'warningMustBeLessThanCritical',
+	'warningMustBeGreaterThanCritical',
+	'infoMustBeLessThanWarning',
+	'infoMustBeGreaterThanWarning',
+	'infoMustBeLessThanCritical',
+	'infoMustBeGreaterThanCritical',
+];
+
+const resolve = (root: unknown, path: string): unknown =>
+	path
+		.split('.')
+		.reduce<unknown>((acc, part) => (acc && typeof acc === 'object' ? (acc as Record<string, unknown>)[part] : undefined), root);
+
+// Both surfaces that render these errors, and every locale each ships.
+const NAMESPACES = [
+	{ name: 'billing (wallet dialog)', base: 'wallet.alerts.validation', bundles: { en: enBilling, ar: arBilling } },
+	{ name: 'settings (tenant defaults)', base: 'alerts.walletAlerts.validation', bundles: { en: enSettings, ar: arSettings } },
+];
+
+describe('wallet alert validation copy', () => {
+	for (const { name, base, bundles } of NAMESPACES) {
+		for (const [locale, bundle] of Object.entries(bundles)) {
+			it(`${name} has ${locale} copy for every validation error key`, () => {
+				const missing = ALL_ERROR_KEYS.filter((key) => typeof resolve(bundle, `${base}.${key}`) !== 'string');
+				expect(missing).toEqual([]);
+			});
+		}
+	}
+
+	it('the escalation ordering rules actually produce the keys that are now covered', () => {
+		const above = (threshold: string) => ({ threshold, condition: 'above' as const });
+		const below = (threshold: string) => ({ threshold, condition: 'below' as const });
+
+		// 'above' ladders descend: critical > warning > info.
+		expect(getWalletAlertValidationErrorKey({ alert_enabled: true, critical: above('10'), warning: above('12') }, 'above')).toBe(
+			'warningMustBeLessThanCritical',
+		);
+		expect(
+			getWalletAlertValidationErrorKey({ alert_enabled: true, critical: above('20'), warning: above('10'), info: above('15') }, 'above'),
+		).toBe('infoMustBeLessThanWarning');
+		expect(getWalletAlertValidationErrorKey({ alert_enabled: true, critical: above('20'), info: above('25') }, 'above')).toBe(
+			'infoMustBeLessThanCritical',
+		);
+
+		// 'below' ladders ascend: critical < warning < info.
+		expect(getWalletAlertValidationErrorKey({ alert_enabled: true, critical: below('20'), warning: below('10') })).toBe(
+			'warningMustBeGreaterThanCritical',
+		);
+		expect(getWalletAlertValidationErrorKey({ alert_enabled: true, critical: below('5'), warning: below('20'), info: below('10') })).toBe(
+			'infoMustBeGreaterThanWarning',
+		);
+		expect(getWalletAlertValidationErrorKey({ alert_enabled: true, critical: below('20'), info: below('10') })).toBe(
+			'infoMustBeGreaterThanCritical',
+		);
+	});
+
+	it('a correctly escalating ladder passes in both directions', () => {
+		expect(
+			getWalletAlertValidationErrorKey({
+				alert_enabled: true,
+				critical: { threshold: '10', condition: 'below' },
+				warning: { threshold: '25', condition: 'below' },
+				info: { threshold: '50', condition: 'below' },
+			}),
+		).toBeNull();
+		expect(
+			getWalletAlertValidationErrorKey(
+				{
+					alert_enabled: true,
+					critical: { threshold: '50', condition: 'above' },
+					warning: { threshold: '25', condition: 'above' },
+					info: { threshold: '10', condition: 'above' },
+				},
+				'above',
+			),
+		).toBeNull();
+	});
+
+	it('covers every level the validator inspects', () => {
+		expect(Object.values(WalletAlertLevel)).toEqual(['critical', 'warning', 'info']);
+	});
+});


### PR DESCRIPTION
Follows #1394. Two related gaps in the Critical → Warning → Info escalation ladder.

## 1. Missing escalation ordering copy

The ladder is validated in both directions — a `below` ladder must ascend (critical < warning < info), an `above` ladder must descend. Six error keys cover that, but only three of them had copy in the **settings** namespace:

| Error key | `billing` | `settings` |
|---|---|---|
| `warningMustBeGreaterThanCritical` | ✅ | ✅ |
| `infoMustBeGreaterThanWarning` | ✅ | ✅ |
| `infoMustBeGreaterThanCritical` | ✅ | ✅ |
| `warningMustBeLessThanCritical` | ✅ | **missing** |
| `infoMustBeLessThanWarning` | ✅ | **missing** |
| `infoMustBeLessThanCritical` | ✅ | **missing** |

A tenant default that violated a descending ladder therefore surfaced a raw i18n key in the toast instead of an explanation. Added in `en` and `ar`.

## 2. A test so this cannot recur silently

This is the third time copy for this feature has gone missing without anything failing — nothing type-checks a `t()` string, and the keys are built dynamically from the error-key union, so grep misses them too.

`walletAlertValidationCopy.test.ts` asserts that **every** member of `WalletAlertValidationErrorKey` resolves to a string in both namespaces and both locales, and that the ordering rules actually produce those keys.

Confirmed it fails for the right reason — deleting one message gives:

```
× settings (tenant defaults) has en copy for every validation error key
  → expected [ 'warningMustBeLessThanCritical' ] to deeply equal []
```

It names the missing key rather than just going red.

## 3. Condition picker restored

Each threshold row shows the comparison as a `Select` again rather than fixed text, locked to **Below**:

```
Critical      [ Below ▾ ]                        [ $ 10 ]
Warning       [ Below ▾ ]                        [ $ 25 ]
Info          [ Below ▾ ]                        [ $ 50 ]
```

Wallet balance alerts only ever fire on a falling balance, so it is visible for clarity but not editable — the same treatment spend alerts give their locked "Above". Restores `conditionBelow`/`conditionAbove` in the billing and settings namespaces and drops the now-unused `rowDescription`.

## Verification

`npm run build`, `eslint` (0 errors) and the full suite (**951 tests / 126 files**) pass.

Not verified in a browser: the e2e sandbox is currently closed ("Your sandbox is temporarily closed"), so the dialog will not load. Worth a look at both the wallet dialog and Settings → Alerts once it is back.

## Relationship to #1402

Independent, but both touch `src/i18n/locales/*/billing.json`. #1402 adds `spendAlerts.conditionBelow`; this adds `wallet.alerts.conditionBelow`/`conditionAbove`. Different keys, adjacent regions — whichever merges second may need a trivial conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
