### PR TITLE
fix(release-1390): revenue card crash, settings wipe, and percentage amount corruption

### DIFF
--- a/src/components/molecules/Dashboard/RevenueTrendCard.currency.test.tsx
+++ b/src/components/molecules/Dashboard/RevenueTrendCard.currency.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { formatDashboardRevenueAmount } from './RevenueTrendCard';
+
+/**
+ * A tenant can define a currency code that Intl rejects — getCustomCurrencyErrorKey only checks
+ * length, so `cr1` saves fine. This formatter runs inside the revenue card's render map, so an
+ * unguarded RangeError took the whole card down rather than degrading one cell.
+ */
+describe('formatDashboardRevenueAmount', () => {
+	it('formats a normal ISO currency', () => {
+		expect(formatDashboardRevenueAmount(1234, 'USD', 'N/A')).toContain('1,234');
+	});
+
+	it('returns the not-available label for zero', () => {
+		expect(formatDashboardRevenueAmount(0, 'USD', 'N/A')).toBe('N/A');
+	});
+
+	it('does not throw on a currency code Intl rejects', () => {
+		expect(() => formatDashboardRevenueAmount(1234, 'cr1', 'N/A')).not.toThrow();
+		// Fallback stays readable: symbol, space, grouped digits — not "cr11234".
+		expect(formatDashboardRevenueAmount(1234, 'cr1', 'N/A')).toBe('cr1 1,234');
+	});
+
+	it('does not throw on an empty or malformed code', () => {
+		expect(() => formatDashboardRevenueAmount(10, '', 'N/A')).not.toThrow();
+		expect(() => formatDashboardRevenueAmount(10, 'TOOLONG', 'N/A')).not.toThrow();
+	});
+
+	it('keeps a negative amount legible in the fallback', () => {
+		expect(formatDashboardRevenueAmount(-1234, 'cr1', 'N/A')).toBe('cr1 -1,234');
+	});
+});

--- a/src/components/molecules/Dashboard/RevenueTrendCard.tsx
+++ b/src/components/molecules/Dashboard/RevenueTrendCard.tsx
@@ -7,6 +7,8 @@ import { Info, AlertCircle } from 'lucide-react';
 import { currencyOptions } from '@/constants/constants';
 import { useTranslation } from 'react-i18next';
 import { getCustomCurrencySymbol } from '@/utils/common/custom_currency';
+import { ISO_FORMAT_PLACEHOLDER } from '@/constants/common';
+import { getCurrencySymbol } from '@/utils/common/helper_functions';
 
 interface RevenueMonth {
 	month: string;
@@ -14,16 +16,29 @@ interface RevenueMonth {
 	currency: string;
 }
 
-function formatDashboardRevenueAmount(revenue: number, currencyCode: string, notAvailableLabel: string): string {
+export function formatDashboardRevenueAmount(revenue: number, currencyCode: string, notAvailableLabel: string): string {
 	if (revenue === 0) return notAvailableLabel;
-	const parts = new Intl.NumberFormat(undefined, {
-		style: 'currency',
-		currency: currencyCode,
-		minimumFractionDigits: 0,
-		maximumFractionDigits: 0,
-	}).formatToParts(revenue);
-
+	// Intl only accepts a well-formed ISO code and throws on anything else, so a custom currency is
+	// formatted against a placeholder and its symbol swapped into the result — mirroring
+	// formatCurrency. Without this a tenant-defined code reaches Intl raw and the RangeError takes
+	// down the whole revenue card, since this runs inside the render map.
 	const customSymbol = getCustomCurrencySymbol(currencyCode);
+	const formatCode = customSymbol ? ISO_FORMAT_PLACEHOLDER : currencyCode;
+
+	let parts: Intl.NumberFormatPart[];
+	try {
+		parts = new Intl.NumberFormat(undefined, {
+			style: 'currency',
+			currency: formatCode,
+			minimumFractionDigits: 0,
+			maximumFractionDigits: 0,
+		}).formatToParts(revenue);
+	} catch {
+		// Space-separated and grouped, so the fallback still reads as an amount — `cr1 1,234`
+		// rather than `cr11234`, which runs the code into the digits and loses the separator.
+		return `${getCurrencySymbol(currencyCode)} ${revenue.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+	}
+
 	return parts.map((part) => (part.type === 'currency' && customSymbol ? customSymbol : part.value)).join('');
 }
 

--- a/src/components/molecules/UpdatePriceDialog/UpdatePriceDialog.tsx
+++ b/src/components/molecules/UpdatePriceDialog/UpdatePriceDialog.tsx
@@ -86,7 +86,10 @@ const UpdatePriceDialog: FC<UpdatePriceDialogProps> = ({ isOpen, onOpenChange, p
 			if (isCustomPriceUnit) {
 				// For CUSTOM prices, use price_unit_amount and price_unit_tiers
 				const initialAmount = price.price_unit_amount || price.price_unit_config?.amount || '';
-				setOverrideAmount(initialAmount);
+				// The save path converts a percentage back to its decimal form for CUSTOM prices too,
+				// so seeding the field with the raw stored value made every open/save cycle divide the
+				// amount again: 0.025 opened as "0.025%" and re-saved as 0.00025.
+				setOverrideAmount(isPercentage ? decimalAmountToPercentage(initialAmount) : initialAmount);
 
 				if (price.price_unit_tiers && price.price_unit_tiers.length > 0) {
 					setOverrideTiers(

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -8,7 +8,7 @@ import { getCustomCurrencySymbol } from '@/utils/common/custom_currency';
 // =============================================================================
 
 /** Any well-formed ISO code works as a scaffold: only its currency part is kept, and that part is replaced. */
-const ISO_FORMAT_PLACEHOLDER = 'USD';
+export const ISO_FORMAT_PLACEHOLDER = 'USD';
 
 export const formatCurrency = (amount: number | string, currency: string): string => {
 	const numAmount = typeof amount === 'string' ? parseFloat(amount) : amount;

--- a/src/pages/settings/billing/useCustomCurrencyConfiguration.ts
+++ b/src/pages/settings/billing/useCustomCurrencyConfiguration.ts
@@ -49,7 +49,10 @@ export function useCustomCurrencyConfiguration() {
 
 	return {
 		savedConfiguration,
-		isLoading: query.isLoading,
+		// A disabled query is not "loading" in TanStack v5 (isLoading is isPending && isFetching), so
+		// without the environment guard the section renders an empty draft as if it were the saved
+		// config — and saving that blank form wipes the tenant's configured currencies.
+		isLoading: !environmentId || query.isPending,
 		isError: query.isError,
 		updateConfiguration,
 	};

--- a/src/utils/common/percentage_amount_round_trip.test.ts
+++ b/src/utils/common/percentage_amount_round_trip.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { decimalAmountToPercentage, percentageToDecimalAmount } from './percentage_price_helpers';
+
+/**
+ * The invariant behind the UpdatePriceDialog CUSTOM-price fix.
+ *
+ * The dialog seeds its amount field with `decimalAmountToPercentage` and saves with
+ * `percentageToDecimalAmount`. The CUSTOM branch used to skip the seeding conversion while the
+ * save path still applied its half, so every open/save cycle divided the amount again — a stored
+ * 0.025 opened as "0.025%" and came back as 0.00025. Pinning the round trip here keeps the two
+ * halves symmetric; if either side is dropped again, this fails instead of silently corrupting
+ * a price.
+ */
+describe('percentage amount round trip', () => {
+	const storedAmounts = ['0.025', '0.05', '1', '0.0001', '100', '0'];
+
+	it.each(storedAmounts)('stored %s survives display -> save unchanged', (stored) => {
+		expect(percentageToDecimalAmount(decimalAmountToPercentage(stored))).toBe(stored);
+	});
+
+	it('renders a stored decimal as its percentage for display', () => {
+		expect(decimalAmountToPercentage('0.025')).toBe('2.5');
+		expect(decimalAmountToPercentage('0.05')).toBe('5');
+	});
+
+	it('stores a typed percentage back as its decimal', () => {
+		expect(percentageToDecimalAmount('2.5')).toBe('0.025');
+		expect(percentageToDecimalAmount('5')).toBe('0.05');
+	});
+
+	it('leaves an empty value alone in both directions', () => {
+		expect(decimalAmountToPercentage('')).toBe('');
+		expect(percentageToDecimalAmount('')).toBe('');
+	});
+
+	it('applying only one half is what corrupted the amount', () => {
+		// The pre-fix CUSTOM path: seeded raw, saved converted.
+		const stored = '0.025';
+		const seededRaw = stored;
+		expect(percentageToDecimalAmount(seededRaw)).toBe('0.00025');
+		expect(percentageToDecimalAmount(seededRaw)).not.toBe(stored);
+	});
+});


### PR DESCRIPTION
Three findings from the #1390 release review, chosen because they are the ones with real user-visible damage. All verified still present on `develop`, and independently reviewed before landing.

## 1. Revenue card crashes on a tenant-defined currency

`formatDashboardRevenueAmount` handed the raw code to `Intl.NumberFormat`, which throws `RangeError` on anything non-ISO. Custom-currency validation only checks length, so `cr1` saves fine. It runs inside the render map, so the throw took down the **whole revenue card**, not one cell.

Now mirrors `formatCurrency`. **Both halves are load-bearing** — I checked what Intl actually does:

```
"USD" → $1,234        "abc" → ABC 1,234      "XBT" → XBT 1,234
"cr1" → RangeError    ""    → RangeError     "TOOLONG" → RangeError
```

A well-formed non-ISO code like `abc` does **not** throw — it renders the code as its own symbol. So try/catch alone would still have shown `ABC 1,234` instead of the tenant's symbol; the placeholder substitution is what fixes that. The fallback is also spaced and grouped (`cr1 1,234`, not `cr11234`).

## 2. Saving custom currency settings could wipe them

The query is `enabled: !!environmentId`, and in TanStack Query v5 a **disabled query reports `isLoading === false`**. With no active environment the section rendered an empty draft as if it were saved config, and saving that blank form serialized to `{}` — erasing the tenant's configured currencies.

`isLoading: !environmentId || query.isPending` covers both the disabled case and the pending-but-paused (offline) case that plain `isLoading` also misses.

## 3. CUSTOM price percentages corrupted on every open/save

The `isCustomPriceUnit` branch seeded the amount raw while the non-custom branch applied `decimalAmountToPercentage`. The save path converts for CUSTOM too, so each cycle divided again — `0.025` opened as `0.025%` and came back as `0.00025`. Compounding, silent.

Corroborating detail: the dialog's own "Original price" header already rendered `2.5%` for the same price whose input field showed `0.025`. The two now agree.

## Tests

- `RevenueTrendCard.currency.test.tsx` — covers the crash, malformed and empty codes, and the fallback's formatting including negatives.
- `percentage_amount_round_trip.test.ts` — pins the invariant, including an explicit *"applying only one half is what corrupted the amount"* case, since that is exactly how it regressed.

`tsc` clean, build passes, eslint 0 errors, **960 tests / 128 files** pass.

## Reviewed, and one thing I got wrong

An adversarial review checked all three. It confirmed them correct — and disproved my own suspicion that the tiers block below fix 3 had the same asymmetry: tiers are seeded raw and saved raw, so they are symmetric. No change was needed there and I did not make one.

## Follow-ups it surfaced (not in this PR)

- **HIGH** — `UpdatePriceDialog.tsx:94`: tiers ignore `price_unit_config.price_unit_tiers`, so opening and saving a CUSTOM tiered price **overwrites its real tiers** with one bogus row. Same shape at `PriceOverrideDialog.tsx:153`.
- **HIGH** — `src/pages/settings/queryKeys.ts`: six sibling settings query keys are not environment-scoped, so after switching environments those sections show the previous environment's config and can save it into the new one — the same failure as fix 2, one layer up.
- **MEDIUM** — `hasChanges()` in `UpdatePriceDialog` is unconditionally true.
- **MEDIUM** — the amount field is not re-seeded when the billing model toggles (100× jump on switch).

## Note

`EnvironmentApi.test.ts` is a pre-existing real-timer flake — it failed once here and once for another agent, and fails/passes intermittently on clean `develop`. Unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
