### PR TITLE
fix(onboarding): validate the organization URL format, not just emptiness

### DIFF
--- a/src/i18n/locales/ar/common.json
+++ b/src/i18n/locales/ar/common.json
@@ -731,6 +731,7 @@
 		"orgUrlLabel": "رابط المنظمة",
 		"orgUrlPlaceholder": "https://example.com",
 		"orgUrlRequired": "رابط المنظمة مطلوب",
+		"orgUrlInvalid": "أدخل رابطًا صالحًا يبدأ بـ http:// أو https://",
 		"referralQuestion": "كيف عرفت عنا؟",
 		"referralPlaceholder": "من أين سمعت بنا؟",
 		"referralRequired": "يرجى اختيار كيف عرفت عنا",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -736,6 +736,7 @@
 		"orgUrlLabel": "Organization URL",
 		"orgUrlPlaceholder": "https://example.com",
 		"orgUrlRequired": "Organization URL is required",
+		"orgUrlInvalid": "Enter a valid URL starting with http:// or https://",
 		"referralQuestion": "How did you find us?",
 		"referralPlaceholder": "Where did you hear about us?",
 		"referralRequired": "Please select how you found us",

--- a/src/pages/onboarding/onboardingConstants.ts
+++ b/src/pages/onboarding/onboardingConstants.ts
@@ -22,6 +22,21 @@ export const findBannedOrgNameWord = (name: string): string | undefined => {
 	return BANNED_ORG_NAME_WORDS.find((word) => new RegExp(`\\b${word}\\b`, 'i').test(normalized));
 };
 
+/**
+ * True when `value` parses as an absolute URL served over http(s).
+ * The org URL input is `type='url' required`, but the onboarding form has no
+ * `<form>` element, so native constraint validation never runs and we must
+ * check the format ourselves before persisting it.
+ */
+export const isValidHttpUrl = (value: string): boolean => {
+	try {
+		const { protocol } = new URL(value.trim());
+		return protocol === 'http:' || protocol === 'https:';
+	} catch {
+		return false;
+	}
+};
+
 export type OnboardingFormErrors = {
 	orgName?: string;
 	orgUrl?: string;

--- a/src/pages/onboarding/useOnboardingTenant.test.ts
+++ b/src/pages/onboarding/useOnboardingTenant.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockMutate = vi.fn();
+
+vi.mock('react-router', () => ({
+	useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+	useQuery: () => ({ data: undefined, isLoading: false }),
+	useMutation: () => ({ mutate: mockMutate, isPending: false }),
+}));
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('react-hot-toast', () => ({
+	default: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useUser', () => ({
+	default: () => ({ user: { id: 'u1', email: 'a@b.com', tenant: { id: 't1' } }, loading: false }),
+}));
+
+vi.mock('@/core/routes/Routes', () => ({ RouteNames: { homeDashboard: '/' } }));
+vi.mock('@/api/TenantApi', () => ({ default: { getTenantById: vi.fn(), updateTenant: vi.fn() } }));
+vi.mock('@/api/OnboardingApi', () => ({ default: { recordOnboardingData: vi.fn() } }));
+vi.mock('@/core/services/tanstack/ReactQueryProvider', () => ({ refetchQueries: vi.fn() }));
+
+// Imported after the mocks above so the module picks them up.
+import useOnboardingTenant from './useOnboardingTenant';
+
+/** Runs validate() through the only caller that exposes it: handleContinue(). */
+const validateWith = (orgUrl: string) => {
+	const { result } = renderHook(() => useOnboardingTenant());
+	act(() => {
+		result.current.setOrgName('Acme Corp');
+		result.current.setOrgUrl(orgUrl);
+		result.current.setReferralSource('LinkedIn');
+	});
+	act(() => {
+		result.current.handleContinue();
+	});
+	return result;
+};
+
+describe('useOnboardingTenant validate()', () => {
+	beforeEach(() => {
+		mockMutate.mockReset();
+	});
+
+	it('flags an empty organization URL as required', () => {
+		const result = validateWith('   ');
+		expect(result.current.errors.orgUrl).toBe('tenantSetup.orgUrlRequired');
+		expect(mockMutate).not.toHaveBeenCalled();
+	});
+
+	it('rejects a value that is not a URL', () => {
+		const result = validateWith('not-a-url');
+		expect(result.current.errors.orgUrl).toBe('tenantSetup.orgUrlInvalid');
+		expect(mockMutate).not.toHaveBeenCalled();
+	});
+
+	it('rejects a URL that is not served over http(s)', () => {
+		const result = validateWith('ftp://x.com');
+		expect(result.current.errors.orgUrl).toBe('tenantSetup.orgUrlInvalid');
+		expect(mockMutate).not.toHaveBeenCalled();
+	});
+
+	it('accepts a well-formed https URL', () => {
+		const result = validateWith('https://acme.com');
+		expect(result.current.errors.orgUrl).toBeUndefined();
+		expect(result.current.errors).toEqual({});
+		expect(mockMutate).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/pages/onboarding/useOnboardingTenant.ts
+++ b/src/pages/onboarding/useOnboardingTenant.ts
@@ -9,7 +9,7 @@ import OnboardingApi from '@/api/OnboardingApi';
 import { TenantMetadataKey } from '@/models';
 import useUser from '@/hooks/useUser';
 import { refetchQueries } from '@/core/services/tanstack/ReactQueryProvider';
-import { findBannedOrgNameWord, type OnboardingFormErrors } from './onboardingConstants';
+import { findBannedOrgNameWord, isValidHttpUrl, type OnboardingFormErrors } from './onboardingConstants';
 
 const useOnboardingTenant = () => {
 	const navigate = useNavigate();
@@ -83,7 +83,12 @@ const useOnboardingTenant = () => {
 			}
 		}
 
-		if (!orgUrl.trim()) next.orgUrl = t('tenantSetup.orgUrlRequired');
+		const trimmedOrgUrl = orgUrl.trim();
+		if (!trimmedOrgUrl) {
+			next.orgUrl = t('tenantSetup.orgUrlRequired');
+		} else if (!isValidHttpUrl(trimmedOrgUrl)) {
+			next.orgUrl = t('tenantSetup.orgUrlInvalid');
+		}
 
 		if (!referralSource) next.referralSource = t('tenantSetup.referralRequired');
 


### PR DESCRIPTION
From the #1390 release review.

## Bug

`validate()` in `useOnboardingTenant.ts` only checked emptiness:

```ts
if (!orgUrl.trim()) next.orgUrl = t('tenantSetup.orgUrlRequired');
```

`OnboardingOrgUrlStep` does set `type='url' required`, but `OnboardingTenant.tsx` has **no `<form>`** — submission goes through `<Button onClick={handleContinue}>`, so native constraint validation never runs. `not-a-url` was persisted to `metadata.onboarding_organization_url` and sent to `OnboardingApi.recordOnboardingData`.

## Fix

New `isValidHttpUrl()` helper in `onboardingConstants.ts` (mirroring the existing `findBannedOrgNameWord` precedent, and independently testable): parses with `new URL()` and requires `http:`/`https:`. `validate()` calls it and sets a new `tenantSetup.orgUrlInvalid` message.

i18n added to both locales that have `orgUrlRequired`:
- en — `Enter a valid URL starting with http:// or https://`
- ar — `أدخل رابطًا صالحًا يبدأ بـ http:// أو https://`

## Tests

`validate()` is a closure inside the hook, so the test drives it through its only caller (`handleContinue` via `renderHook` + `act`) rather than changing the hook's public API to export it. Covers empty, `not-a-url`, `ftp://x.com`, and a valid URL.

Verified non-vacuous: reverting just the `validate()` change fails exactly the two new format cases while empty and valid still pass.

`tsc` clean, eslint 0 errors, full suite **949 tests / 127 files** pass.

## Scope note

`new URL()` accepts `https://foo` (no TLD) and `http://localhost`. This catches malformed and wrong-protocol input but is not a strict hostname validator — tightening further is a product decision, not a bug fix.

## Gotcha for anyone testing this hook

It needs `vi.mock('@/core/routes/Routes', …)`: the hook imports `RouteNames` from `Routes.tsx`, which calls `createBrowserRouter` at module scope and blows up under a mocked `react-router`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
