### PR TITLE
fix(a11y): stop hiding the focusable RedirectCell link from screen readers

### DIFF
--- a/src/components/molecules/Table/RedirectCell.test.tsx
+++ b/src/components/molecules/Table/RedirectCell.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router';
+import RedirectCell from './RedirectCell';
+
+const renderCell = (ui: React.ReactNode) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('RedirectCell', () => {
+	// The link carried aria-hidden='true' while staying keyboard-focusable, which is
+	// the axe `aria-hidden-focus` failure: the tab stop survives but the element is
+	// stripped from the accessibility tree, so a screen-reader user lands on an
+	// unlabeled stop and the cell's text vanishes from the tree entirely.
+	it('does not hide the focusable link from the accessibility tree', () => {
+		renderCell(<RedirectCell redirectUrl='/customers/cus_1'>Acme Corp</RedirectCell>);
+
+		const link = screen.getByRole('link');
+		expect(link).not.toHaveAttribute('aria-hidden');
+	});
+
+	it("exposes the cell's text as the link's accessible name", () => {
+		renderCell(<RedirectCell redirectUrl='/customers/cus_1'>Acme Corp</RedirectCell>);
+
+		// getByRole matches on accessible name, so this only passes if the children
+		// are actually reachable in the accessibility tree.
+		expect(screen.getByRole('link', { name: 'Acme Corp' })).toHaveAttribute('href', '/customers/cus_1');
+	});
+
+	// The trailing ExternalLink is purely decorative - it duplicates what the link
+	// already conveys, so it must not leak into the accessible name.
+	it('hides the decorative external-link icon', () => {
+		const { container } = renderCell(<RedirectCell redirectUrl='/plans/plan_1'>Starter</RedirectCell>);
+
+		const icon = container.querySelector('svg');
+		expect(icon).toHaveAttribute('aria-hidden', 'true');
+		expect(screen.getByRole('link').textContent).toBe('Starter');
+	});
+
+	it('renders children without a link when redirection is disabled', () => {
+		renderCell(
+			<RedirectCell redirectUrl='/plans/plan_1' allowRedirect={false}>
+				Starter
+			</RedirectCell>,
+		);
+
+		expect(screen.queryByRole('link')).not.toBeInTheDocument();
+		expect(screen.getByText('Starter')).toBeInTheDocument();
+	});
+});

--- a/src/components/molecules/Table/RedirectCell.tsx
+++ b/src/components/molecules/Table/RedirectCell.tsx
@@ -20,10 +20,9 @@ const RedirectCell: FC<Props> = ({ redirectUrl, children, allowRedirect = true, 
 			<Link
 				target={target}
 				to={redirectUrl}
-				aria-hidden='true'
 				className='flex items-center gap-2 max-w-fit group underline decoration-dashed decoration-[1px] decoration-content-muted/50 underline-offset-4'>
 				{children}
-				<ExternalLink className='w-4 h-4 opacity-0 group-hover:opacity-40 transition-opacity duration-200' />
+				<ExternalLink aria-hidden='true' className='w-4 h-4 opacity-0 group-hover:opacity-40 transition-opacity duration-200' />
 			</Link>
 		</div>
 	);


### PR DESCRIPTION
From the #1390 release review.

## Bug

`RedirectCell` put `aria-hidden` on the focusable link itself:

```tsx
<Link target={target} to={redirectUrl} aria-hidden='true' className='...'>
```

`aria-hidden` on a keyboard-focusable element is a WCAG failure (axe `aria-hidden-focus`): the link stays in the tab order but is removed from the accessibility tree, so a screen-reader user lands on an **unlabeled focus stop**. Where the cell's text lives only inside the link — the customer name at `EditInvoicePage.tsx:501`, for instance — that content vanished from the a11y tree entirely.

## Fix

Removed `aria-hidden` from the `Link`; added it to the decorative `ExternalLink` icon, which had none.

## Provenance

`git log -S` pins the attribute to `07f321c70`, a styling refactor that introduced the decorative icon in the same hunk. It was never deliberate duplicate-suppression — the attribute was simply put on the wrong element.

## Blast radius — checked, not assumed

`RedirectCell` has **28 call sites across 26 files**. None relied on the `aria-hidden`. The structurally riskiest were inspected directly — `EditInvoicePage`, `CustomerUsageTable` (3 sites, one with a chip + name, one inside a tooltip), `Events/ProcessedEventsSection` (3 sites inside a `<dl>`), `FeatureDetails`, `CustomerInvoiceDetail`, `GroupOverviewTab`. In every case the text is rendered only as `RedirectCell`'s children and never duplicated in an adjacent node, so exposing the link reintroduces no double announcement. `<dt>` labels sit outside the cell.

## Tests

New `RedirectCell.test.tsx` (4 tests) asserting the link is not aria-hidden and its accessible name is the cell text. Verified non-vacuous: re-adding the attribute fails 3 of the 4.

`tsc` clean, eslint 0 errors, full suite **949 tests / 127 files** pass.

## Residual gap worth a separate pass

When a call site passes falsy children the link now has *no* accessible name (the icon is hidden, nothing remains) — e.g. `FeatureDetails.tsx:89` renders `row.plan?.name` and `PlanEntitlementsTab.tsx:100` renders `row?.feature?.name`, both without a fallback. That is still strictly better than before (an unnamed focus stop that was *also* hidden), and it converts `aria-hidden-focus` into `link-name` only in the already-degraded empty-data case. Deliberately not papered over with a synthetic name, since that would mask the real defect: the missing data fallback at those call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
