### PR TITLE
fix(custom-currency): normalise config key casing at the parse boundary

### DIFF
--- a/src/types/dto/CustomCurrency.ts
+++ b/src/types/dto/CustomCurrency.ts
@@ -20,15 +20,27 @@ export interface CustomCurrencyConfig {
 // the pages that read it. An entry left without a symbol is dropped by the display map.
 const settingString = z.union([z.string(), z.number()]).transform(String).catch('');
 
+// Currency codes are case-insensitive everywhere they are used, but the stored setting is
+// free-form JSON, so a payload written by the API or an older client can carry "USD" where
+// this module expects "usd". Normalising the keys at the parse boundary lets everything
+// downstream - the draft, the display map and the validator - assume lowercase. Without it
+// `toCustomCurrencyDraft` lists the fiat codes lowercased and then misses the stored
+// uppercase key, blanking every factor and failing validation on a saved configuration.
+const toLowerCaseKeys = <T>(record: Record<string, T>): Record<string, T> =>
+	Object.entries(record).reduce<Record<string, T>>((normalised, [key, value]) => {
+		normalised[key.toLowerCase()] = value;
+		return normalised;
+	}, {});
+
 const customCurrencyDefinitionSchema = z.object({
 	name: settingString,
 	symbol: settingString,
-	fiat_conversion_factors: z.record(settingString).catch({}),
+	fiat_conversion_factors: z.record(settingString).catch({}).transform(toLowerCaseKeys),
 });
 
 const customCurrencyConfigSchema = z.object({
-	custom_currencies: z.record(customCurrencyDefinitionSchema).catch({}),
-	default_fiat_currency: settingString,
+	custom_currencies: z.record(customCurrencyDefinitionSchema).catch({}).transform(toLowerCaseKeys),
+	default_fiat_currency: settingString.transform((code) => code.toLowerCase()),
 });
 
 /** Reads an unknown settings payload into a config, tolerating a missing or partial value. */

--- a/src/utils/common/custom_currency.test.ts
+++ b/src/utils/common/custom_currency.test.ts
@@ -269,3 +269,56 @@ describe('currency options offered to the entities that accept a tenant currency
 		expect(custom[0].value.toLowerCase()).toBe('crd');
 	});
 });
+
+// The setting is free-form JSON, so a payload written elsewhere can spell the codes in any
+// case. The draft lists its fiat codes lowercased, so an uppercase stored key used to miss
+// on lookup, blank every factor, and disable Save on a configuration the backend accepted.
+describe('a payload stored with uppercase codes', () => {
+	const config = parseCustomCurrencyConfig({
+		custom_currencies: {
+			CRD: { name: 'Credits', symbol: 'CR', fiat_conversion_factors: { USD: '1.5', INR: '125' } },
+		},
+		default_fiat_currency: 'USD',
+	});
+
+	it('is normalised to lowercase at the parse boundary', () => {
+		expect(config).toEqual({
+			custom_currencies: {
+				crd: { name: 'Credits', symbol: 'CR', fiat_conversion_factors: { usd: '1.5', inr: '125' } },
+			},
+			default_fiat_currency: 'usd',
+		});
+	});
+
+	it('produces a draft with the factors populated', () => {
+		const draft = toCustomCurrencyDraft(config);
+		expect(draft.defaultFiatCurrency).toBe('usd');
+		expect(draft.fiatCurrencies).toEqual(['usd', 'inr']);
+		expect(draft.currencies[0]).toMatchObject({ code: 'crd', name: 'Credits', symbol: 'CR', factors: { usd: '1.5', inr: '125' } });
+	});
+
+	it('is not reported as invalid', () => {
+		expect(getCustomCurrencyErrorKey(toCustomCurrencyDraft(config))).toBeNull();
+	});
+
+	it('round-trips without renaming the currency', () => {
+		expect(serializeCustomCurrencyConfig(toCustomCurrencyDraft(config))).toEqual({
+			default_fiat_currency: 'usd',
+			custom_currencies: {
+				crd: { name: 'Credits', symbol: 'CR', fiat_conversion_factors: { usd: '1.5', inr: '125' } },
+			},
+		});
+	});
+
+	it('publishes the symbol under the lowercased code', () => {
+		expect(toCustomCurrencyDisplay(config)).toEqual({ crd: { symbol: 'CR', name: 'Credits' } });
+	});
+
+	it('still parses a mixed-case payload the same way as an already-lowercase one', () => {
+		const lower = parseCustomCurrencyConfig({
+			custom_currencies: { crd: { name: 'Credits', symbol: 'CR', fiat_conversion_factors: { usd: '1.5', inr: '125' } } },
+			default_fiat_currency: 'usd',
+		});
+		expect(config).toEqual(lower);
+	});
+});


### PR DESCRIPTION
From the #1390 release review.

## Bug

`parseCustomCurrencyConfig` used `z.record(settingString)`, which preserves key casing — a stored `"USD"` stayed `"USD"`. But `toCustomCurrencyDraft` builds its currency list from **lowercased** codes and looks up with the lowercase key:

```ts
const lower = fiat.toLowerCase();
...
factors[fiat] = String(definition?.fiat_conversion_factors?.[fiat] ?? '');   // 'usd' vs stored 'USD'
```

The lookup missed → empty factor → `getCustomCurrencyErrorKey` returned `'factorInvalid'` → the settings page showed a validation error and **disabled Save on a configuration the backend had accepted**.

Same family as the disabled-query bug in #1406: a config the user cannot edit or re-save.

## Fix

Normalise at the parse boundary so the rest of the module can assume lowercase — a `toLowerCaseKeys` helper plus three transforms on `fiat_conversion_factors`, `custom_currencies` and `default_fiat_currency`.

## Is lowercasing safe on the way out? Yes — checked every consumer

`serializeCustomCurrencyConfig` **already** lowercased unconditionally (`row.code.trim().toLowerCase()`, `draft.defaultFiatCurrency.toLowerCase()`). So a save has always sent lowercase regardless of what was stored — normalising at parse cannot rename anything a save would not already have renamed. It only makes the round trip idempotent instead of silently rewriting on first save.

Also confirmed: `toCustomCurrencyDisplay` keys by `code.toLowerCase()`; `useCurrencyOptions` and `customCurrencyConfigToOptions` uppercase only for the label; the settings input forces lowercase. Nothing reads the original casing.

The defensive `.toLowerCase()` calls inside `toCustomCurrencyDraft` were left in place, because `CustomCurrencyConfig` is a plain interface also constructed by hand (e.g. the fallback in `useCustomCurrencyConfig.ts`) and does not always come through the parser.

One behavioural note: a payload with both `"USD"` and `"usd"` now collapses, last one wins. That was already broken downstream and matches backend semantics.

## Tests

Six cases appended to the existing `custom_currency.test.ts`, including a parse → draft → serialize round trip. Verified non-vacuous: with the schema change stashed, 5 of the 6 fail.

`tsc` clean, eslint 0 errors, `custom_currency.test.ts` 32/32.

## Correction to the original report

CodeRabbit's example payload had the wrong shape — `fiat_conversion_factors` is not a top-level config key, it lives inside each currency definition. The tests use the real shape.

## Note

`EnvironmentApi.test.ts` is a pre-existing real-timer flake (fail/pass/pass on clean `develop`, shares no imports with this module). Seen in several parallel runs today; unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
