### PR TITLE
fix(pricing): report is_percentage for usage-only plans

### DIFF
--- a/src/pricing/adapters.percentage.test.ts
+++ b/src/pricing/adapters.percentage.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { adaptPlanToCard, type PlanWithData } from './adapters';
+import { PlanType } from '@/constants/planTypes';
+
+// A percentage charge is stored as a FLAT_FEE whose amount holds the decimal equivalent
+// (5% -> "0.05"), tagged via metadata. See utils/common/percentage_price_helpers.
+const percentageMetadata = { billing_model: 'percentage' };
+
+const makePrice = (overrides: Record<string, unknown>) =>
+	({
+		id: 'price-1',
+		currency: 'usd',
+		billing_period: 'MONTHLY',
+		billing_model: 'FLAT_FEE',
+		type: 'FIXED',
+		amount: '0.05',
+		tiers: null,
+		meter: null,
+		invoice_cadence: 'ARREAR',
+		metadata: null,
+		...overrides,
+	}) as never;
+
+const makePlan = (prices: unknown[]): PlanWithData =>
+	({
+		id: 'plan-1',
+		name: 'Plan',
+		description: '',
+		prices,
+		entitlements: [],
+	}) as unknown as PlanWithData;
+
+// `usageCharges` is optional on the card props; the adapter always emits an array.
+const usageCharges = (card: ReturnType<typeof adaptPlanToCard>) => card.usageCharges ?? [];
+
+describe('adaptPlanToCard percentage headline price', () => {
+	it('reports a recurring percentage price as a percentage', () => {
+		const card = adaptPlanToCard(makePlan([makePrice({ type: 'FIXED', metadata: percentageMetadata })]), []);
+
+		expect(card.price.is_percentage).toBe(true);
+		expect(card.price.amount).toBe('0.05');
+	});
+
+	// Regression: `displayPrice` fell back to the metadata-less `usageCharges[0]` display object, so
+	// re-deriving the flag from it always produced false and the card rendered $0.05 instead of 5%.
+	it('reports a usage-only percentage plan as a percentage', () => {
+		const card = adaptPlanToCard(
+			makePlan([makePrice({ type: 'USAGE', metadata: percentageMetadata, meter: { name: 'Transactions' } })]),
+			[],
+		);
+
+		expect(card.price.displayType).toBe(PlanType.USAGE_ONLY);
+		expect(usageCharges(card)[0].is_percentage).toBe(true);
+		expect(card.price.is_percentage).toBe(true);
+	});
+
+	it('leaves a usage-only non-percentage plan as a plain amount', () => {
+		const card = adaptPlanToCard(makePlan([makePrice({ type: 'USAGE', amount: '0.5', meter: { name: 'Requests' } })]), []);
+
+		expect(usageCharges(card)[0].is_percentage).toBe(false);
+		expect(card.price.is_percentage).toBe(false);
+	});
+
+	// A stale marker on a price since switched away from FLAT_FEE must not turn tiers into percentages.
+	it('ignores a stale percentage marker on a tiered usage charge', () => {
+		const card = adaptPlanToCard(
+			makePlan([
+				makePrice({
+					type: 'USAGE',
+					billing_model: 'TIERED',
+					metadata: percentageMetadata,
+					tiers: [{ up_to: 100, unit_amount: '0.05', flat_amount: null }],
+					meter: { name: 'Requests' },
+				}),
+			]),
+			[],
+		);
+
+		expect(card.price.is_percentage).toBe(false);
+	});
+
+	// A recurring price wins the headline slot, so a percentage usage charge must not leak into it.
+	it('keeps the recurring headline price non-percentage when only the usage charge is a percentage', () => {
+		const card = adaptPlanToCard(
+			makePlan([
+				makePrice({ id: 'price-fixed', type: 'FIXED', amount: '20' }),
+				makePrice({ id: 'price-usage', type: 'USAGE', metadata: percentageMetadata, meter: { name: 'Transactions' } }),
+			]),
+			[],
+		);
+
+		expect(card.price.amount).toBe('20');
+		expect(card.price.is_percentage).toBe(false);
+		expect(usageCharges(card)[0].is_percentage).toBe(true);
+	});
+});

--- a/src/pricing/adapters.ts
+++ b/src/pricing/adapters.ts
@@ -224,7 +224,11 @@ export function adaptPlanToCard(plan: PlanWithData, grants: CreditGrant[]): Plan
 			billingPeriod: displayPrice?.billing_period,
 			type: displayPrice?.type,
 			displayType,
-			is_percentage: displayPrice ? isPercentagePrice(displayPrice) : false,
+			// `usageCharges` entries are plain display objects with no `metadata`, and
+			// `isPercentagePrice` keys off `metadata.billing_model`, so re-deriving the flag from a
+			// usage-charge `displayPrice` always yields false. Reuse the value already computed above
+			// from the real price (which does carry metadata) for the usage-only case.
+			is_percentage: recurringPrice ? isPercentagePrice(recurringPrice) : (usageCharges[0]?.is_percentage ?? false),
 		},
 		usageCharges,
 		entitlements:


### PR DESCRIPTION
From the #1390 release review.

## Bug

```ts
const displayPrice = recurringPrice || usageCharges[0];
...
is_percentage: displayPrice ? isPercentagePrice(displayPrice) : false,
```

`usageCharges[]` entries are plain objects built without a `metadata` field. `isPercentagePrice` short-circuits on `isPercentageMetadata(price.metadata)`, so for a plan with **no recurring price** the headline `is_percentage` was always `false` — even though the correct value had already been computed one line earlier into `usageCharges[0].is_percentage`.

`PricingCard.tsx:309` reads that flag, so a usage-only percentage plan rendered the raw stored decimal (`$0.05`) instead of `5%`.

## Fix

```ts
is_percentage: recurringPrice ? isPercentagePrice(recurringPrice) : (usageCharges[0]?.is_percentage ?? false),
```

## Verified the fallback is actually trustworthy

Worth stating, because the fix is only correct if `usageCharges[0].is_percentage` is itself sound. Inside the `.map()` the flag is computed from the **original `price`** — which does carry `metadata` — not from the literal being constructed:

```ts
.map((price) => ({
    ...
    is_percentage: isPercentagePrice(price),   // `price`, not the object being built
```

So it is correct, and no root-cause change was needed. Confirmed empirically: reverting the adapter makes only the usage-only-percentage assertion fail, while the `usageCharges[0].is_percentage` assertion passes on both sides.

`is_percentage` was the only field on the mapped object *re-derived* rather than copied verbatim — which is exactly why it was the only one that broke. The other fields are lossless copies.

## Tests

Five cases, including two guards beyond the obvious three: a stale `percentage` marker on a `TIERED` usage charge must stay `false` (exercises the `billing_model` half of `isPercentagePrice`), and a plan with both a fixed price and a percentage usage charge must keep a non-percentage headline — guarding against over-correcting the fix into leaking the usage flag upward.

`tsc` clean, eslint 0 errors, full suite **950 tests / 127 files** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
