### PR TITLE
fix(price-override): key percentage formatting off the effective override model

### DIFF
--- a/src/components/molecules/PriceOverrideDialog/PriceOverrideDialog.test.tsx
+++ b/src/components/molecules/PriceOverrideDialog/PriceOverrideDialog.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { BILLING_MODEL, PRICE_TYPE, PRICE_UNIT_TYPE, type Price } from '@/models/Price';
+import type { ExtendedPriceOverride } from '@/utils/common/price_override_helpers';
+import PriceOverrideDialog from './PriceOverrideDialog';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@/hooks/useMeterForCommitment', () => ({ useMeterForCommitment: () => ({ meter: null }) }));
+vi.mock('@/hooks/useCommitmentTimeBucketPrices', () => ({
+	useCommitmentTimeBucketPrices: () => ({ bucketsWithPrices: [], isLoading: false }),
+}));
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+
+/** A percentage charge: a FLAT_FEE whose amount holds the decimal equivalent, tagged in metadata. */
+const percentagePrice = {
+	id: 'price_pct',
+	amount: '0.05',
+	currency: 'usd',
+	billing_model: BILLING_MODEL.FLAT_FEE,
+	type: PRICE_TYPE.USAGE,
+	price_unit_type: PRICE_UNIT_TYPE.FIAT,
+	metadata: { billing_model: 'percentage' },
+	description: 'Transaction fee',
+	tiers: [],
+} as unknown as Price;
+
+const renderDialog = (override: Omit<ExtendedPriceOverride, 'price_id'>) =>
+	render(
+		<PriceOverrideDialog
+			isOpen
+			onOpenChange={vi.fn()}
+			price={percentagePrice}
+			onPriceOverride={vi.fn()}
+			onResetOverride={vi.fn()}
+			overriddenPrices={{ price_pct: { price_id: 'price_pct', ...override } }}
+		/>,
+	);
+
+describe('PriceOverrideDialog percentage seeding', () => {
+	it('seeds a PACKAGE override with the stored amount as-is, not as a percentage', () => {
+		// The override moved the charge off FLAT_FEE, so "10" is a plain currency amount. Running it
+		// through decimalAmountToPercentage would seed the field with 1000 and persist that on save,
+		// because the save path (showAsPercentage) does not convert back for a PACKAGE override.
+		renderDialog({ amount: '10', billing_model: BILLING_MODEL.PACKAGE });
+
+		const amountInput = screen.getByPlaceholderText('priceDialogs.enterNewAmountOptional');
+		expect(amountInput).toHaveValue('10');
+		expect(amountInput).not.toHaveValue('1000');
+	});
+
+	it('seeds a FLAT_FEE override as a percentage', () => {
+		// The override kept the charge on the price's own FLAT_FEE, so "0.1" is still a stored
+		// percentage decimal and has to show as 10 next to a % suffix.
+		renderDialog({ amount: '0.1', billing_model: BILLING_MODEL.FLAT_FEE });
+
+		expect(screen.getByPlaceholderText('priceDialogs.enterNewPercentageOptional')).toHaveValue('10');
+	});
+
+	it('seeds an override that does not touch the billing model as a percentage', () => {
+		renderDialog({ amount: '0.025' });
+
+		expect(screen.getByPlaceholderText('priceDialogs.enterNewPercentageOptional')).toHaveValue('2.5');
+	});
+});

--- a/src/components/molecules/PriceOverrideDialog/PriceOverrideDialog.tsx
+++ b/src/components/molecules/PriceOverrideDialog/PriceOverrideDialog.tsx
@@ -10,7 +10,12 @@ import { BUCKET_SIZE_NONE, priceBucketSizeOptions } from '@/constants/constants'
 import { ExtendedPriceOverride } from '@/utils/common/price_override_helpers';
 import VolumeTieredPricingForm from '@/components/organisms/PlanForm/VolumeTieredPricingForm';
 import { PremiumFeatureIcon } from '../PremiumFeature/PremiumFeature';
-import { decimalAmountToPercentage, isPercentagePrice, percentageToDecimalAmount } from '@/utils/common/percentage_price_helpers';
+import {
+	decimalAmountToPercentage,
+	isPercentageOverride,
+	isPercentagePrice,
+	percentageToDecimalAmount,
+} from '@/utils/common/percentage_price_helpers';
 import { formatPercentageAmount } from '@/utils/common/price_helpers';
 import { useTranslation } from 'react-i18next';
 import type { LineItem } from '@/models/Subscription';
@@ -142,17 +147,22 @@ const PriceOverrideDialog: FC<Props> = ({
 		setIsOverridden(isCurrentlyOverridden);
 
 		if (isCurrentlyOverridden) {
+			// Seed the field from the EFFECTIVE billing model, not the price's. An override that moved the
+			// charge to PACKAGE/TIERED stores a plain currency amount, and `showAsPercentage` (which drives
+			// the save conversion) is false for it - converting on the way in would leave the two
+			// asymmetric and persist a 100x-inflated amount on the next save.
+			const overrideIsPercentage = isPercentageOverride({ billing_model: price.billing_model, metadata: price.metadata }, currentOverride);
 			// Initialize from override or original price based on price unit type
 			if (isCustomPriceUnit) {
 				setOverrideAmount(
 					toAmountFieldValue(
 						currentOverride.price_unit_amount || price.price_unit_amount || price.price_unit_config?.amount || '',
-						isPercentage,
+						overrideIsPercentage,
 					),
 				);
 				setOverrideTiers(currentOverride.price_unit_tiers || price.price_unit_tiers || []);
 			} else {
-				setOverrideAmount(toAmountFieldValue(currentOverride.amount || price.amount, isPercentage));
+				setOverrideAmount(toAmountFieldValue(currentOverride.amount || price.amount, overrideIsPercentage));
 				setOverrideTiers(currentOverride.tiers || price.tiers || []);
 			}
 			setOverrideQuantity(currentOverride.quantity);
@@ -241,6 +251,7 @@ const PriceOverrideDialog: FC<Props> = ({
 		price.price_unit_tiers,
 		price.price_unit_config,
 		price.bucket_size,
+		price.metadata,
 		showEffectiveFrom,
 		isCustomPriceUnit,
 		isPercentage,
@@ -415,17 +426,20 @@ const PriceOverrideDialog: FC<Props> = ({
 	const handleCancel = () => {
 		const currentOverride = overriddenPrices[price.id];
 		if (currentOverride) {
+			// Same effective-model rule as the initialization effect: only convert while the override
+			// leaves the charge on the price's own percentage FLAT_FEE.
+			const overrideIsPercentage = isPercentageOverride(price, currentOverride);
 			// Restore from override based on price unit type
 			if (isCustomPriceUnit) {
 				setOverrideAmount(
 					toAmountFieldValue(
 						currentOverride.price_unit_amount || price.price_unit_amount || price.price_unit_config?.amount || '',
-						isPercentage,
+						overrideIsPercentage,
 					),
 				);
 				setOverrideTiers(currentOverride.price_unit_tiers || price.price_unit_tiers || []);
 			} else {
-				setOverrideAmount(toAmountFieldValue(currentOverride.amount || price.amount, isPercentage));
+				setOverrideAmount(toAmountFieldValue(currentOverride.amount || price.amount, overrideIsPercentage));
 				setOverrideTiers(currentOverride.tiers || price.tiers || []);
 			}
 			setOverrideQuantity(currentOverride.quantity);

--- a/src/components/organisms/Subscription/PriceOverrideSummary.test.tsx
+++ b/src/components/organisms/Subscription/PriceOverrideSummary.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { BILLING_MODEL, PRICE_TYPE, PRICE_UNIT_TYPE, type Price } from '@/models/Price';
+import type { SubscriptionLineItemOverrideRequest } from '@/utils/common/price_override_helpers';
+import PriceOverrideSummary from './PriceOverrideSummary';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+/**
+ * A percentage charge is a FLAT_FEE whose amount holds the decimal equivalent (5% -> "0.05"),
+ * tagged in metadata. "0.05" must render as "5%", never as the currency amount it is stored as.
+ */
+const percentagePrice = {
+	id: 'price_pct',
+	amount: '0.05',
+	currency: 'usd',
+	billing_model: BILLING_MODEL.FLAT_FEE,
+	type: PRICE_TYPE.USAGE,
+	price_unit_type: PRICE_UNIT_TYPE.FIAT,
+	metadata: { billing_model: 'percentage' },
+	description: 'Transaction fee',
+} as unknown as Price;
+
+const renderSummary = (override: SubscriptionLineItemOverrideRequest) =>
+	render(<PriceOverrideSummary overrides={[override]} prices={[percentagePrice]} />);
+
+describe('PriceOverrideSummary percentage formatting', () => {
+	it('does not percentage-format an override that moves the charge off flat fee', () => {
+		// PACKAGE override: 10 is a plain currency amount, so it must read as $10 - not 1000%.
+		renderSummary({
+			price_id: 'price_pct',
+			amount: 10,
+			billing_model: BILLING_MODEL.PACKAGE,
+		});
+
+		const description = screen.getByText(/Amount:/);
+		expect(description).toHaveTextContent('Amount: 5% → $10');
+		expect(description).not.toHaveTextContent('1000%');
+	});
+
+	it('percentage-formats an override that keeps the charge on flat fee', () => {
+		// FLAT_FEE override: 0.1 is still the decimal equivalent of a percentage, so it reads as 10%.
+		renderSummary({
+			price_id: 'price_pct',
+			amount: 0.1,
+			billing_model: BILLING_MODEL.FLAT_FEE,
+		});
+
+		expect(screen.getByText(/Amount:/)).toHaveTextContent('Amount: 5% → 10%');
+	});
+
+	it('percentage-formats an override that does not touch the billing model at all', () => {
+		renderSummary({
+			price_id: 'price_pct',
+			amount: 0.025,
+		});
+
+		expect(screen.getByText(/Amount:/)).toHaveTextContent('Amount: 5% → 2.5%');
+	});
+
+	it('leaves a non-percentage price formatted as currency on both sides', () => {
+		const plainPrice = { ...percentagePrice, id: 'price_plain', amount: '12', metadata: {} } as unknown as Price;
+		render(
+			<PriceOverrideSummary
+				overrides={[{ price_id: 'price_plain', amount: 20, billing_model: BILLING_MODEL.PACKAGE }]}
+				prices={[plainPrice]}
+			/>,
+		);
+
+		expect(screen.getByText(/Amount:/)).toHaveTextContent('Amount: $12 → $20');
+	});
+});

--- a/src/components/organisms/Subscription/PriceOverrideSummary.tsx
+++ b/src/components/organisms/Subscription/PriceOverrideSummary.tsx
@@ -3,7 +3,7 @@ import { Price, PRICE_UNIT_TYPE } from '@/models/Price';
 import { SubscriptionLineItemOverrideRequest } from '@/utils/common/price_override_helpers';
 import { formatAmount } from '@/components/atoms/Input/Input';
 import { getCurrencySymbol } from '@/utils/common/helper_functions';
-import { isPercentagePrice } from '@/utils/common/percentage_price_helpers';
+import { isPercentageOverride, isPercentagePrice } from '@/utils/common/percentage_price_helpers';
 import { formatPercentageAmount } from '@/utils/common/price_helpers';
 import { Check } from 'lucide-react';
 import { Card } from '@/components/atoms';
@@ -38,21 +38,30 @@ const PriceOverrideSummary: FC<Props> = ({ overrides, prices, className }) => {
 		const descriptions: string[] = [];
 		const isCustomPriceUnit = price.price_unit_type === PRICE_UNIT_TYPE.CUSTOM;
 		const displaySymbol = getDisplaySymbol(price);
-		// A percentage charge stores the decimal equivalent - both sides of the arrow read as
-		// percentages, with no currency symbol.
-		const isPercentage = isPercentagePrice(price);
-		const formatMoney = (amount: string) => (isPercentage ? formatPercentageAmount(amount) : `${displaySymbol}${formatAmount(amount)}`);
+		// A percentage charge stores the decimal equivalent, so it reads as a percentage with no
+		// currency symbol. The two sides of the arrow are formatted independently: an override that
+		// switches the charge to PACKAGE/TIERED makes its amount a plain currency amount even though
+		// the price it replaces is still a percentage, and running that through the percentage
+		// conversion would show a stored `10` as `1000%`.
+		const baseIsPercentage = isPercentagePrice(price);
+		const overrideIsPercentage = isPercentageOverride(price, override);
+		const formatMoney = (amount: string, asPercentage: boolean) =>
+			asPercentage ? formatPercentageAmount(amount) : `${displaySymbol}${formatAmount(amount)}`;
 
 		// Handle amount/price_unit_amount based on price unit type
 		if (isCustomPriceUnit) {
 			// For CUSTOM prices, use price_unit_amount
 			if (override.price_unit_amount !== undefined) {
-				descriptions.push(`Amount: ${formatMoney(getDisplayAmount(price))} → ${formatMoney(override.price_unit_amount)}`);
+				descriptions.push(
+					`Amount: ${formatMoney(getDisplayAmount(price), baseIsPercentage)} → ${formatMoney(override.price_unit_amount, overrideIsPercentage)}`,
+				);
 			}
 		} else {
 			// For FIAT prices, use amount
 			if (override.amount !== undefined) {
-				descriptions.push(`Amount: ${formatMoney(price.amount)} → ${formatMoney(override.amount.toString())}`);
+				descriptions.push(
+					`Amount: ${formatMoney(price.amount, baseIsPercentage)} → ${formatMoney(override.amount.toString(), overrideIsPercentage)}`,
+				);
 			}
 		}
 

--- a/src/utils/common/index.ts
+++ b/src/utils/common/index.ts
@@ -28,6 +28,7 @@ export {
 	decimalAmountToPercentage,
 	isPercentageMetadata,
 	isPercentagePrice,
+	isPercentageOverride,
 	withPercentageMetadata,
 	withoutPercentageMetadata,
 } from './percentage_price_helpers';

--- a/src/utils/common/percentage_price_helpers.test.ts
+++ b/src/utils/common/percentage_price_helpers.test.ts
@@ -3,6 +3,7 @@ import {
 	PERCENTAGE_BILLING_MODEL,
 	decimalAmountToPercentage,
 	isPercentageMetadata,
+	isPercentageOverride,
 	isPercentagePrice,
 	percentageToDecimalAmount,
 	shiftDecimalString,
@@ -81,6 +82,35 @@ describe('isPercentageMetadata / isPercentagePrice', () => {
 	it('ignores a stale marker on a charge that has moved to another billing model', () => {
 		expect(isPercentagePrice({ billing_model: BILLING_MODEL.TIERED, metadata: { billing_model: 'percentage' } })).toBe(false);
 		expect(isPercentagePrice({ billing_model: BILLING_MODEL.PACKAGE, metadata: { billing_model: 'percentage' } })).toBe(false);
+	});
+});
+
+describe('isPercentageOverride', () => {
+	const percentageFlatFee = { billing_model: BILLING_MODEL.FLAT_FEE, metadata: { billing_model: 'percentage' } };
+
+	it('keeps a percentage charge percentage when the override leaves the billing model alone', () => {
+		expect(isPercentageOverride(percentageFlatFee, { billing_model: BILLING_MODEL.FLAT_FEE })).toBe(true);
+		expect(isPercentageOverride(percentageFlatFee, {})).toBe(true);
+		expect(isPercentageOverride(percentageFlatFee, undefined)).toBe(true);
+		expect(isPercentageOverride(percentageFlatFee, null)).toBe(true);
+	});
+
+	it('stops reading as a percentage once the override moves the charge off flat fee', () => {
+		// The override's amount is then a plain currency amount - converting it would turn 10 into 1000%.
+		expect(isPercentageOverride(percentageFlatFee, { billing_model: BILLING_MODEL.PACKAGE })).toBe(false);
+		expect(isPercentageOverride(percentageFlatFee, { billing_model: BILLING_MODEL.TIERED })).toBe(false);
+		expect(isPercentageOverride(percentageFlatFee, { billing_model: 'SLAB_TIERED' })).toBe(false);
+	});
+
+	it('never invents a percentage for a price that was never marked as one', () => {
+		const plainFlatFee = { billing_model: BILLING_MODEL.FLAT_FEE, metadata: { source: 'import' } };
+		expect(isPercentageOverride(plainFlatFee, { billing_model: BILLING_MODEL.FLAT_FEE })).toBe(false);
+		expect(isPercentageOverride(plainFlatFee, undefined)).toBe(false);
+	});
+
+	it('agrees with isPercentagePrice when there is no override', () => {
+		expect(isPercentageOverride(percentageFlatFee)).toBe(isPercentagePrice(percentageFlatFee));
+		expect(isPercentageOverride({ billing_model: BILLING_MODEL.PACKAGE, metadata: { billing_model: 'percentage' } })).toBe(false);
 	});
 });
 

--- a/src/utils/common/percentage_price_helpers.ts
+++ b/src/utils/common/percentage_price_helpers.ts
@@ -76,6 +76,21 @@ export const isPercentageMetadata = (metadata?: Metadata | null): boolean =>
 export const isPercentagePrice = (price: { billing_model?: BILLING_MODEL | string; metadata?: Metadata | null }): boolean =>
 	isPercentageMetadata(price.metadata) && (price.billing_model === undefined || price.billing_model === BILLING_MODEL.FLAT_FEE);
 
+/**
+ * True when the *effective* charge - a price plus whatever override sits on top of it - still reads
+ * as a percentage.
+ *
+ * The percentage marker lives in the price's metadata and an override cannot touch it, so the only
+ * thing an override can do is move the charge off FLAT_FEE. Once it does (PACKAGE / TIERED /
+ * SLAB_TIERED) the overridden amount is a plain currency amount and must not go through the
+ * percentage conversion, or a stored `10` reads as `1000%`. An override that leaves the billing
+ * model alone keeps the price's own answer.
+ */
+export const isPercentageOverride = (
+	price: { billing_model?: BILLING_MODEL | string; metadata?: Metadata | null },
+	override?: { billing_model?: BILLING_MODEL | string | null } | null,
+): boolean => isPercentagePrice({ metadata: price.metadata, billing_model: override?.billing_model || price.billing_model });
+
 /** Adds the percentage marker to existing metadata, leaving other keys intact. */
 export const withPercentageMetadata = (metadata?: Metadata | null): Metadata => ({
 	...(metadata ?? {}),


### PR DESCRIPTION
From the #1390 release review.

## Bug

Percentage formatting keyed off the **base price's** billing model instead of the **effective override's**, in two places. Both reproduced with failing tests before fixing.

**`PriceOverrideDialog`** — the two init paths that read an existing override passed the unguarded `isPercentage`:

```ts
setOverrideAmount(toAmountFieldValue(currentOverride.amount || price.amount, isPercentage));
```

Opening a percentage-marked FLAT_FEE price whose override is `PACKAGE`/`TIERED` ran `decimalAmountToPercentage` on a plain currency amount — a stored `10` seeded the field as `1000`, shown with a currency suffix. Saving persisted it.

**`PriceOverrideSummary`** — no guard at all, applied to both sides of the arrow, so the same `10` displayed as `1000%`.

## Fix

New exported `isPercentageOverride(price, override)` answers "is the *effective* charge still a percentage" by delegating to the existing FLAT_FEE rule with the effective billing model:

```ts
isPercentagePrice({ metadata: price.metadata, billing_model: override?.billing_model || price.billing_model })
```

Chosen over a simple `override.billing_model === price.billing_model` comparison so an override that explicitly sets FLAT_FEE on a price with an undefined `billing_model` still resolves correctly, and so `SLAB_TIERED` falls out as non-percentage for free.

The summary's `formatMoney` now takes an explicit `asPercentage`: the left side of the arrow uses `isPercentagePrice(price)`, the right side `isPercentageOverride(price, override)` — the base and the override can legitimately differ.

## Corrections to the original finding

- **Not "every initialization path" was broken.** Only the two that read an existing override. The four that seed from the base price (the no-override branch and `handleReset`) also set `overrideBillingModel = price.billing_model`, so `isPercentage` was already correct there — changing them would have *introduced* an asymmetry. Left alone.
- `PriceOverrideSummary.tsx` is not a sibling of the dialog; it lives under `src/components/organisms/Subscription/`.
- The `showAsPercentage` display guard was already correct and is untouched.

## Symmetry

The save path's `resolveStoredAmount` keys off `showAsPercentage = isPercentage && overrideBillingModel === price.billing_model`. After the effect runs, `overrideBillingModel = currentOverride.billing_model || price.billing_model`, so that flag and the new `overrideIsPercentage` derive from the same effective model and always agree. Nothing converted on the way in escapes conversion on the way out — the failure mode this whole class of bug keeps producing.

## Tests

11 new cases across three files: the helper (PACKAGE/TIERED/SLAB_TIERED → false; FLAT_FEE/empty/absent → true; never invents a percentage for an unmarked price), the dialog's seeded field value, and each side of the summary's arrow. The pre-fix files fail exactly the PACKAGE cases and pass the FLAT_FEE ones.

`tsc` clean, eslint 0 errors, prettier clean, full suite **956 tests / 128 files** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
